### PR TITLE
Chore/cleanup readme compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,53 +1,123 @@
-# Pinball Monorepo
+# Pinball Hetic
 
-Bienvenue dans le monorepo du projet Pinball. Ce projet utilise une **Clean Architecture** pour assurer sa scalabilité et sa maintenabilité.
+Borne de flipper virtuelle pédagogique — trois écrans Web synchronisés
+(playfield 3D, DMD, backglass) pilotés par un boîtier de boutons ESP32.
 
-## Structure du Projet
+Stack : Next.js · Three.js · Rapier3D · Socket.io · Bun · Docker.
 
-- `packages/game-engine` : Moteur de jeu (Three.js + Cannon.js)
-- `packages/server` : Backend (Node.js + Express + Socket.io + Prisma)
-- `packages/app` : Frontend (Next.js)
-- `packages/config-lint` : Configurations partagées (TS, ESLint, Prettier)
+Packagé pour [Fliphetic](https://pandormedia.github.io/fliphetic/).
 
-## Architecture Logicielle (Clean Architecture)
+## Quick start
 
-Chaque package suit cette structure :
-- `domain` : Entités et modèles métier purs.
-- `use-cases` : Logique métier.
-- `infrastructure` : Implémentations concrètes (DB, moteur physique, rendu).
-- `interface` : Adaptateurs pour l’UI ou les contrôleurs.
-
-## Outils de Productivité
-
-- **Task** (`Taskfile.yml`) : Unifié les commandes communes.
-- **Docker Compose** : Démarre l'infrastructure locale (DB, Server, App).
-- **GitHub Actions** : Pipeline CI automatisée pour lint et build.
-
-## Démarrage Rapide
-
-### Utilisation de Task (Recommandé)
 ```bash
-task install
-task db:up
-task dev
+bun install
+task docker:dev:up
 ```
 
-### Installation Classique
-```bash
-npm install
+| Écran | URL |
+| --- | --- |
+| playfield | http://localhost:3333 |
+| dmd | http://localhost:3335 |
+| backglass | http://localhost:3336 |
+| server | http://localhost:3334 |
+
+Arrêt : `task docker:dev:down`.
+
+## Structure
+
+Monorepo Bun workspaces.
+
+```
+apps/
+  playfield/      Écran jeu 3D (Next.js + Three.js + Rapier)
+  dmd/            Écran score temps réel (Next.js)
+  backglass/      Écran leaderboard (Next.js)
+  server/         Backend Express + Socket.io + Prisma
+  input-bridge/   Pont USB-Serial ESP32 ↔ Socket.io (Bun)
+
+packages/
+  game-engine/    Moteur physique + géométrie (no React)
+  shared-types/   Types Socket.io partagés
+  config/         ESLint, Prettier, tsconfig
 ```
 
-### Développement
+## Variables d'environnement
+
+### `playfield`
+
+| Variable | Défaut | Rôle |
+| --- | --- | --- |
+| `NEXT_PUBLIC_KEYBOARD_MODE` | `direct` | Mode clavier (voir tableau ci-dessous). |
+| `NEXT_PUBLIC_SOCKET_URL` | (vide) | URL Socket.io directe (dev). Vide → polling same-origin via rewrite Next.js (prod Fliphetic). |
+| `SERVER_INTERNAL_URL` | `http://server:3001` | Cible des rewrites `/api/*` et `/socket.io/*`. |
+
+**Modes clavier** (`NEXT_PUBLIC_KEYBOARD_MODE`) :
+
+| Mode | Comportement | Cas d'usage |
+| --- | --- | --- |
+| `direct` | Le clavier applique directement le callback métier. Latence ~0. | Dev quotidien, jeu au clavier. |
+| `simulate-esp32` | Le clavier émet `dev:simulate-button` au server → routé vers input-bridge mock → parser → `input:button` broadcast à tous. | Valider la chaîne réseau sans hardware ESP32. |
+| `disabled` | Clavier de jeu ignoré (sauf `H` debug). | Tester uniquement le vrai ESP32 quand il sera branché. |
+
+Variable build-time Next.js : redémarrer le conteneur après changement
+(`docker compose up --force-recreate playfield`).
+
+**Touches** : `←`/`Q` flipper gauche, `→`/`D` flipper droit, `Espace`
+charge/release plunger, `H` toggle debug colliders.
+
+### `dmd` et `backglass`
+
+| Variable | Défaut | Rôle |
+| --- | --- | --- |
+| `NEXT_PUBLIC_SOCKET_URL` | (vide) | Idem playfield. |
+
+### `server`
+
+| Variable | Défaut | Rôle |
+| --- | --- | --- |
+| `PORT` | `3001` | Port d'écoute HTTP + WebSocket. |
+| `DATABASE_URL` | — | Connexion Postgres. |
+| `NODE_ENV` | — | `development` désactive le cache global Prisma. |
+
+### `input-bridge`
+
+| Variable | Défaut | Rôle |
+| --- | --- | --- |
+| `INPUT_BRIDGE_MODE` | `mock` | `mock` (binding virtuel) ou `serial` (ESP32 réel). |
+| `SERIAL_PATH` | `/dev/MOCK_ESP32` | Chemin du périphérique en mode `serial`. |
+| `SERIAL_BAUD` | `115200` | Baudrate runtime. |
+| `SERVER_URL` | `http://server:3001` | URL Socket.io interne au réseau Docker. |
+
+## Scripts
+
 ```bash
-npm run dev
+bun run dev     # tous les workspaces
+bun run build
+bun run lint
 ```
 
-### Build
-```bash
-npm run build
-```
+Raccourcis Docker dans `Taskfile.yml` (`task docker:dev:up`,
+`docker:prod:up`, `clean`, …).
 
-### Lint
-```bash
-npm run lint
-```
+## Documentation
+
+| Sujet | Fichier |
+| --- | --- |
+| Architecture, règles SRP, conventions | [`CLAUDE.md`](./CLAUDE.md) |
+| Modes clavier, env vars playfield | [`apps/playfield/README.md`](./apps/playfield/README.md) |
+| Protocole série, modes mock/serial | [`apps/input-bridge/README.md`](./apps/input-bridge/README.md) |
+| Manifeste Fliphetic | [`fliphetic.toml`](./fliphetic.toml) |
+
+## Hardware
+
+Le firmware ESP32 n'est pas dans ce dépôt. En attendant, l'input-bridge
+tourne en mode `mock` et le clavier émule les boutons (mode
+`simulate-esp32` valide la chaîne réseau complète).
+
+## CI
+
+GitHub Actions : `install → lint → build` sur push/PR vers `dev`.
+
+## Auteurs
+
+Anthony, Hugo, Florian, Imxran — Web3 HETIC.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,11 @@ services:
     build:
       context: .
       dockerfile: apps/playfield/Dockerfile
+    # Tant que le firmware ESP32 n'existe pas, le clavier doit dispatcher
+    # via le réseau (clavier → server → input-bridge mock → broadcast).
+    # Passer à `disabled` une fois l'ESP32 réel branché.
+    environment:
+      NEXT_PUBLIC_KEYBOARD_MODE: "simulate-esp32"
     ports:
       - "0:3000"
     depends_on:
@@ -85,6 +90,9 @@ services:
       dockerfile: apps/input-bridge/Dockerfile
     restart: unless-stopped
     environment:
+      # Mode mock tant que le firmware ESP32 n'existe pas. Passer à `serial`
+      # uniquement après avoir décommenté `devices:` et fourni un chemin
+      # réel /dev/serial/by-id/usb-... (cf. instructions ci-dessous).
       INPUT_BRIDGE_MODE: mock
       SERIAL_PATH: /dev/MOCK_ESP32
       SERIAL_BAUD: "115200"


### PR DESCRIPTION
This pull request updates the project documentation and Docker configuration to clarify the setup and development workflow, especially regarding the ESP32 hardware integration. The changes provide clearer instructions, environment variable documentation, and improve the developer experience by setting sensible defaults for running the project in a mock environment until the real hardware is available.

Key documentation improvements:

* The `README.md` has been rewritten for clarity, detailing the project stack, quick start commands, workspace structure, environment variables for each app, keyboard modes, and links to further documentation. It also explains the current reliance on mock input in the absence of ESP32 firmware and clarifies the development workflow.

Docker configuration enhancements:

* The `docker-compose.yml` file now sets `NEXT_PUBLIC_KEYBOARD_MODE` to `"simulate-esp32"` for the `playfield` service, ensuring keyboard input is routed through the network and mock bridge during development.
* The `input-bridge` service is explicitly configured to run in `mock` mode by default, with comments explaining when and how to switch to `serial` mode once the real ESP32 hardware is available.