### PR TITLE
Update GLB models and enhance PinballPlayfield functionality

### DIFF
--- a/apps/playfield/src/components/pinball/PinballPlayfield.tsx
+++ b/apps/playfield/src/components/pinball/PinballPlayfield.tsx
@@ -52,6 +52,7 @@ import {
   type BallDiagnosticsSnapshot,
   findObjectByNormalizedName,
   removePinballmapUnusedMeshes,
+  hidePinballmapDecorNodes,
   prepareGltfMaterialsForDisplay,
   configureGltfRenderer,
   createGltfLoader,
@@ -259,7 +260,6 @@ function boundingBoxPlayfieldSurface(playfieldRoot: THREE.Object3D): THREE.Box3 
       n.includes("separator") ||
       n.includes("sling") ||
       n.includes("target") ||
-      n.includes("spinner") ||
       n.includes("guide") ||
       n.includes("rail") ||
       n.includes("rocket") ||
@@ -647,6 +647,7 @@ export default function PinballPlayfield({ cabinetMode = false }: PinballPlayfie
         collectDisposables(playfieldRoot);
         modelRoot.add(playfieldRoot);
         removePinballmapUnusedMeshes(playfieldRoot);
+        hidePinballmapDecorNodes(playfieldRoot);
         prepareGltfMaterialsForDisplay(playfieldRoot);
 
         bumperVisuals = new BumperVisuals();

--- a/packages/game-engine/src/infrastructure/GltfNodeNames.ts
+++ b/packages/game-engine/src/infrastructure/GltfNodeNames.ts
@@ -122,13 +122,12 @@ export function isPinballmapNonPhysicalFloorMesh(mesh: THREE.Mesh): boolean {
 }
 
 /**
- * Nœuds GLB présents dans le modèle mais qui doivent rester invisibles en jeu
- * (plaque, switch sensors…).
- * Pas de collision non plus — ces nœuds sont déjà dans EXCLUDED_NODES de
- * PlayfieldTrimeshBuilder.
+ * Switch sensors du GLB (zones de capteurs non-gameplay visuels).
+ * Source unique partagée par les 3 pipelines : trimesh (HIDDEN_NODES),
+ * colliders (EXCLUDED_NODES) et rendu (VISUALLY_HIDDEN_NODES). Variantes avec
+ * espace conservées par parité avec l'ancien code.
  */
-const VISUALLY_HIDDEN_NODES = new Set([
-  'plate',
+export const SWITCH_SENSOR_NODES = new Set([
   'switch_slingshot', 'switch slingshot',
   'switch_left_pop_bumper_zone',  'switch left pop bumper zone',
   'switch_center_pop_bumper_zone','switch center pop bumper zone',
@@ -137,6 +136,14 @@ const VISUALLY_HIDDEN_NODES = new Set([
   'switch_rocket',  'switch rocket',
   'switch_out',     'switch out',
 ]);
+
+/**
+ * Nœuds GLB présents dans le modèle mais qui doivent rester invisibles en jeu
+ * (plaque, switch sensors…).
+ * Pas de collision non plus — ces nœuds sont déjà dans EXCLUDED_NODES de
+ * PlayfieldTrimeshBuilder.
+ */
+const VISUALLY_HIDDEN_NODES = new Set(['plate', ...SWITCH_SENSOR_NODES]);
 
 /** Cache les maillages décoratifs / non-gameplay du GLB (plaque, switches). */
 export function hidePinballmapDecorNodes(root: THREE.Object3D): void {

--- a/packages/game-engine/src/infrastructure/GltfNodeNames.ts
+++ b/packages/game-engine/src/infrastructure/GltfNodeNames.ts
@@ -121,6 +121,35 @@ export function isPinballmapNonPhysicalFloorMesh(mesh: THREE.Mesh): boolean {
   );
 }
 
+/**
+ * Nœuds GLB présents dans le modèle mais qui doivent rester invisibles en jeu
+ * (plaque, switch sensors…).
+ * Pas de collision non plus — ces nœuds sont déjà dans EXCLUDED_NODES de
+ * PlayfieldTrimeshBuilder.
+ */
+const VISUALLY_HIDDEN_NODES = new Set([
+  'plate',
+  'switch_slingshot', 'switch slingshot',
+  'switch_left_pop_bumper_zone',  'switch left pop bumper zone',
+  'switch_center_pop_bumper_zone','switch center pop bumper zone',
+  'switch_right_pop_bumper_zone', 'switch right pop bumper zone',
+  'switch_plunger', 'switch plunger',
+  'switch_rocket',  'switch rocket',
+  'switch_out',     'switch out',
+]);
+
+/** Cache les maillages décoratifs / non-gameplay du GLB (plaque, switches). */
+export function hidePinballmapDecorNodes(root: THREE.Object3D): void {
+  root.traverse((obj) => {
+    if (!(obj instanceof THREE.Mesh)) return;
+    const n = normalizeGltfName(obj.name);
+    const c = canonicalGltfName(obj.name);
+    if (VISUALLY_HIDDEN_NODES.has(n) || VISUALLY_HIDDEN_NODES.has(c)) {
+      obj.visible = false;
+    }
+  });
+}
+
 export function removePinballmapUnusedMeshes(root: THREE.Object3D): void {
   const toRemove: THREE.Object3D[] = [];
   root.traverse((obj) => {

--- a/packages/game-engine/src/infrastructure/PlayfieldTrimeshBuilder.ts
+++ b/packages/game-engine/src/infrastructure/PlayfieldTrimeshBuilder.ts
@@ -12,6 +12,7 @@ import {
   normalizeGltfName,
   playfieldUsesCollOnlyCollision,
   isPinballmapNonPhysicalFloorMesh,
+  SWITCH_SENSOR_NODES,
 } from './GltfNodeNames';
 import { surfaceYAtZ } from '../domain/PlayfieldGeometry';
 
@@ -72,23 +73,14 @@ const STANDALONE_WALL_MESHES = new Set([
   'fix-start', // guide de lancement : lisse la paroi du couloir au démarrage
 ]);
 
-const HIDDEN_NODES = new Set([
-  'switch_left_pop_bumper_zone', 'switch left pop bumper zone',
-  'switch_center_pop_bumper_zone', 'switch center pop bumper zone',
-  'switch_plunger', 'switch plunger',
-  'switch_right_pop_bumper_zone', 'switch right pop bumper zone',
-  'switch_rocket', 'switch rocket',
-  'switch_slingshot', 'switch slingshot',
-  'switch_out', 'switch out',
-]);
+// Switch sensors : source unique dans GltfNodeNames (partagée avec le rendu).
+const HIDDEN_NODES = new Set(SWITCH_SENSOR_NODES);
 
 const EXCLUDED_NODES = new Set([
   'ball', 'box', 'glass', 'feet', 'score_board', 'coin_slot',
   'exit_cover', 'plate', 'start_button',
   'drop_target_left_1', 'drop_target_left_2',
   'drop_target_right_1', 'drop_target_right_2', 'drop_target_right_3',
-  'switch_out', 'switch_center_pop_bumper_zone', 'switch_left_pop_bumper_zone',
-  'switch_right_pop_bumper_zone', 'switch_plunger', 'switch_rocket', 'switch_slingshot',
   'launcher',
   ...HIDDEN_NODES,
 ]);

--- a/packages/game-engine/src/infrastructure/PlayfieldTrimeshBuilder.ts
+++ b/packages/game-engine/src/infrastructure/PlayfieldTrimeshBuilder.ts
@@ -79,13 +79,12 @@ const HIDDEN_NODES = new Set([
   'switch_right_pop_bumper_zone', 'switch right pop bumper zone',
   'switch_rocket', 'switch rocket',
   'switch_slingshot', 'switch slingshot',
-  'spinner',
   'switch_out', 'switch out',
 ]);
 
 const EXCLUDED_NODES = new Set([
   'ball', 'box', 'glass', 'feet', 'score_board', 'coin_slot',
-  'exit_cover', 'plate', 'start_button', 'spinner',
+  'exit_cover', 'plate', 'start_button',
   'drop_target_left_1', 'drop_target_left_2',
   'drop_target_right_1', 'drop_target_right_2', 'drop_target_right_3',
   'switch_out', 'switch_center_pop_bumper_zone', 'switch_left_pop_bumper_zone',


### PR DESCRIPTION
- Replaced the existing Strangerthings.glb model with an updated version.
- Added a new Strangerthings1.glb model to the playfield assets.
- Introduced hidePinballmapDecorNodes function to hide visually non-gameplay nodes in the GLB model, improving rendering performance and gameplay clarity.
- Removed spinner from the list of hidden nodes in PlayfieldTrimeshBuilder for better collision handling.