### PR TITLE
feat(physics): zones flipper dérivées des bbox mesh au chargement

### DIFF
--- a/apps/playfield/src/components/pinball/PinballPlayfield.tsx
+++ b/apps/playfield/src/components/pinball/PinballPlayfield.tsx
@@ -32,12 +32,6 @@ import {
   SWING_SMOOTH,
   FLIPPER_RESTITUTION,
   FLIPPER_FRICTION,
-  FLIPPER_Z_MIN,
-  FLIPPER_Z_MAX,
-  FLIPPER_LEFT_X_MIN,
-  FLIPPER_LEFT_X_MAX,
-  FLIPPER_RIGHT_X_MIN,
-  FLIPPER_RIGHT_X_MAX,
   FLIPPER_MIN_LAUNCH_VZ,
   FLIPPER_MIN_LAUNCH_ANGVEL,
   computeSurfaceSnap,
@@ -47,6 +41,8 @@ import {
   resolvePlayfieldFlippers,
   attachFlipperAtHinge,
   applyFlipperSwing,
+  computeFlipperZones,
+  type FlipperZones,
   type FlipperPivot,
   CollisionEventProcessor,
   StuckBallDetector,
@@ -709,6 +705,7 @@ export default function PinballPlayfield({ cabinetMode = false }: PinballPlayfie
     let rightFlipperPivot: FlipperPivot | null = null;
     let leftFlipperObj: THREE.Object3D | null = null;
     let rightFlipperObj: THREE.Object3D | null = null;
+    let flipperZones: FlipperZones | null = null;
     let leftSwing = 0, rightSwing = 0;
     let prevLeftSwing = 0, prevRightSwing = 0;
     let leftTarget = 0, rightTarget = 0;
@@ -984,6 +981,11 @@ export default function PinballPlayfield({ cabinetMode = false }: PinballPlayfie
           rightFlipperPivot = attachFlipperAtHinge(rightFlipper, "right", pinballmap);
           rightFlipperObj = rightFlipper;
           rightFlashMats = collectFlashMats(rightFlipper);
+        }
+
+        // Zones de garantie de lancement dérivées des bbox mesh (pose de repos).
+        if (leftFlipperObj && rightFlipperObj) {
+          flipperZones = computeFlipperZones(leftFlipperObj, rightFlipperObj, BALL_RADIUS);
         }
 
         // ── Physics ──────────────────────────────────────────────────────────
@@ -1713,17 +1715,19 @@ export default function PinballPlayfield({ cabinetMode = false }: PinballPlayfie
         // physique fait déjà mieux.
         // Seuil normalisé en vitesse angulaire (rad/s) : 0.004 * 60 = 0.24 rad/s,
         // indépendant du fps (évite que le seuil ne se déclenche jamais à 120+ Hz).
-        if (ballPhysicsInst && gameStateRef.current === 'playing') {
+        if (ballPhysicsInst && gameStateRef.current === 'playing' && flipperZones) {
           const bp = ballPhysicsInst.body.translation();
           const bv = ballPhysicsInst.body.linvel();
-          const inZ = bp.z > FLIPPER_Z_MIN && bp.z < FLIPPER_Z_MAX;
+          const { left: lz, right: rz } = flipperZones;
           const angVelL = (leftSwing  - prevLeftSwing) / dt;
           const angVelR = (rightSwing - prevRightSwing) / dt;
-          if (inZ && angVelL > FLIPPER_MIN_LAUNCH_ANGVEL && bp.x > FLIPPER_LEFT_X_MIN  && bp.x < FLIPPER_LEFT_X_MAX  && bv.z > FLIPPER_MIN_LAUNCH_VZ) {
+          const inLeft  = bp.z > lz.zMin && bp.z < lz.zMax && bp.x > lz.xMin && bp.x < lz.xMax;
+          const inRight = bp.z > rz.zMin && bp.z < rz.zMax && bp.x > rz.xMin && bp.x < rz.xMax;
+          if (inLeft && angVelL > FLIPPER_MIN_LAUNCH_ANGVEL && bv.z > FLIPPER_MIN_LAUNCH_VZ) {
             ballPhysicsInst.body.setLinvel({ x: bv.x, y: bv.y, z: FLIPPER_MIN_LAUNCH_VZ }, true);
             leftFlash = FLASH_DURATION; // hit-flash à la frappe
           }
-          if (inZ && angVelR > FLIPPER_MIN_LAUNCH_ANGVEL && bp.x > FLIPPER_RIGHT_X_MIN && bp.x < FLIPPER_RIGHT_X_MAX && bv.z > FLIPPER_MIN_LAUNCH_VZ) {
+          if (inRight && angVelR > FLIPPER_MIN_LAUNCH_ANGVEL && bv.z > FLIPPER_MIN_LAUNCH_VZ) {
             ballPhysicsInst.body.setLinvel({ x: bv.x, y: bv.y, z: FLIPPER_MIN_LAUNCH_VZ }, true);
             rightFlash = FLASH_DURATION;
           }

--- a/packages/game-engine/src/domain/FlipperConstants.ts
+++ b/packages/game-engine/src/domain/FlipperConstants.ts
@@ -15,13 +15,10 @@ export const FLIPPER_RIGHT_PIVOT_X =  -0.02;
 export const FLIPPER_PIVOT_Y       =  0.00;
 export const FLIPPER_PIVOT_Z       =  -0.018;
 
-// Zone flipper (PlayfieldGeometry + BallDiagnostics)
+// Zone flipper Z (PlayfieldGeometry + BallDiagnostics). Les bornes X sont
+// désormais dérivées des bbox mesh au chargement (cf. FlipperZones.ts).
 export const FLIPPER_Z_MIN = 0.20;
 export const FLIPPER_Z_MAX = 0.33;
-export const FLIPPER_LEFT_X_MIN  = -0.085;
-export const FLIPPER_LEFT_X_MAX  =  0.015;
-export const FLIPPER_RIGHT_X_MIN = -0.015;
-export const FLIPPER_RIGHT_X_MAX =  0.055;
 
 // ── Physique contact ──────────────────────────────────────────────────────────
 export const FLIPPER_POWER       = 0.138;   // conservé pour compatibilité (inutilisé)

--- a/packages/game-engine/src/index.ts
+++ b/packages/game-engine/src/index.ts
@@ -28,6 +28,7 @@ export * from './infrastructure/PlayfieldTrimeshBuilder';
 export * from './infrastructure/PlayfieldColliderFactory';
 export * from './infrastructure/LauncherLaneBounds';
 export * from './infrastructure/FlipperSplitter';
+export * from './infrastructure/FlipperZones';
 export * from './infrastructure/CollisionEventProcessor';
 export * from './infrastructure/BossFightManager';
 export * from './infrastructure/BossTargetPulse';

--- a/packages/game-engine/src/infrastructure/FlipperZones.ts
+++ b/packages/game-engine/src/infrastructure/FlipperZones.ts
@@ -1,0 +1,33 @@
+import * as THREE from 'three';
+
+export type FlipperZone = { xMin: number; xMax: number; zMin: number; zMax: number };
+export type FlipperZones = { left: FlipperZone; right: FlipperZone };
+
+/**
+ * Dérive les zones de garantie de lancement depuis la bbox réelle des meshes
+ * flippers (pose de repos, AVANT le démarrage de la simulation). Évite les
+ * coordonnées X figées mesurées sur un ancien GLB.
+ *
+ * `margin` étend la bbox sur X/Z : la balle touche dès que son centre est à un
+ * rayon du bord (margin = BALL_RADIUS).
+ */
+export function computeFlipperZones(
+  left: THREE.Object3D,
+  right: THREE.Object3D,
+  margin: number,
+): FlipperZones {
+  const zoneOf = (obj: THREE.Object3D): FlipperZone => {
+    obj.updateMatrixWorld(true);
+    const { min, max } = new THREE.Box3().setFromObject(obj);
+    return {
+      xMin: min.x - margin,
+      xMax: max.x + margin,
+      zMin: min.z - margin,
+      zMax: max.z + margin,
+    };
+  };
+
+  const zones = { left: zoneOf(left), right: zoneOf(right) };
+  console.info('[FlipperZones]', zones);
+  return zones;
+}


### PR DESCRIPTION
Remplace les bornes X de zone flipper figées (mesurées sur un ancien GLB) par des zones calculées au chargement depuis les bbox des meshes flippers résolus. Supprime le boost fantôme entre les flippers et garantit le lancement jusqu'à la pointe.

Nouveau FlipperZones.computeFlipperZones ; constantes FLIPPER_*_X_* retirées (FLIPPER_Z_MIN/MAX gardées pour PlayfieldGeometry + BallDiagnostics).