### PR TITLE
feat(server): appliquer les migrations prisma au démarrage

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -18,7 +18,12 @@ RUN bun run --filter @pinball/server prisma:generate
 # Build du serveur
 RUN bun run --filter @pinball/server build
 
+# Entrypoint : applique les migrations Prisma avant de lancer le CMD
+RUN chmod +x /app/apps/server/docker-entrypoint.sh
+
 EXPOSE 3001
 
-# Lancement direct avec bun
+# ENTRYPOINT s'exécute toujours (même si le compose dev override le CMD) →
+# migrations appliquées dans les deux environnements.
+ENTRYPOINT ["/app/apps/server/docker-entrypoint.sh"]
 CMD ["bun", "apps/server/src/interface/index.ts"]

--- a/apps/server/docker-entrypoint.sh
+++ b/apps/server/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+echo "[entrypoint] applying prisma migrations..."
+i=0
+until bunx prisma migrate deploy --schema /app/apps/server/prisma/schema.prisma; do
+  i=$((i+1))
+  if [ "$i" -ge 15 ]; then
+    echo "[entrypoint] db unreachable after 15 attempts, aborting" >&2
+    exit 1
+  fi
+  echo "[entrypoint] db not ready, retry $i/15 in 2s..."
+  sleep 2
+done
+echo "[entrypoint] migrations applied"
+
+exec "$@"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -11,6 +11,12 @@ services:
       - "5432:5432"
     volumes:
       - postgres_dev_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U dev_user -d pinball_dev"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 10s
     mem_limit: 384m
 
   server:
@@ -27,7 +33,8 @@ services:
     volumes:
       - ./apps/server/src:/app/apps/server/src
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     command: bun --watch src/interface/index.ts
     mem_limit: 256m
 


### PR DESCRIPTION
apps/server n'appliquait jamais les migrations Prisma : machine neuve ou volume Postgres recréé crashait au premier score. Ajoute un entrypoint qui lance 'prisma migrate deploy' (retry 15×2s) avant le CMD, ENTRYPOINT+CMD pour couvrir prod et le command override du compose dev.

Ajoute aussi le healthcheck db en dev + depends_on service_healthy sur server (prod déjà conforme).