### PR TITLE
fix(playfield): bailout init après chaque await (race StrictMode — bi…

### DIFF
--- a/apps/playfield/src/components/pinball/PinballPlayfield.tsx
+++ b/apps/playfield/src/components/pinball/PinballPlayfield.tsx
@@ -881,6 +881,7 @@ function PinballPlayfieldInner({ cabinetMode = false }: PinballPlayfieldProps) {
     const init = async () => {
       try {
         const gltf = await loadPlayfieldGlb();
+        if (cancelled) return; // StrictMode : démontage du 1er mount en vol
         const playfieldRoot = gltf.scene;
         playfieldRootRef = playfieldRoot;
         collectDisposables(playfieldRoot);
@@ -945,6 +946,7 @@ function PinballPlayfieldInner({ cabinetMode = false }: PinballPlayfieldProps) {
 
         // ── Physics ──────────────────────────────────────────────────────────
         physicsWorld = await PhysicsWorld.create();
+        if (cancelled) return; // bail avant colliders/bille — World nettoyé au cleanup
         const world = physicsWorld.world;
         // colliderMap créé ici (avant le ctx) pour être injecté dans le module.
         const colliderMap = new Map<number, string>();
@@ -1039,6 +1041,7 @@ function PinballPlayfieldInner({ cabinetMode = false }: PinballPlayfieldProps) {
         // Préchargement asynchrone du module (ex. reveals boss) — bloque le
         // chargement comme avant.
         await mapModule?.preload?.();
+        if (cancelled) return; // bail avant la création de la bille/colliders
 
         shooterLaneGate = new ShooterLaneGate();
         shooterLaneGate.bind(world, mapLayout.shooterLane);


### PR DESCRIPTION
…lle manquante au chargement)

init() async avait 4 await (GLB, PhysicsWorld.create, mapModule.preload) mais un seul `if (cancelled) return` tardif (L1535). En dev, React StrictMode double-monte : le cleanup du 1er mount disposait scène/renderer/module pendant que l'init() en vol continuait entre ses await, en course avec le 2e mount sur les ressources partagées (WASM Rapier, cache GLTF) → bille parfois non ajoutée/non visible (refresh multiples nécessaires).

Ajout d'un `if (cancelled) return` juste après chaque await (GLB, PhysicsWorld.create, mapModule.preload). Le bail intervient avant la création bille/colliders (L1070+). Pas de fuite WASM nouvelle : le cleanup ne libère jamais le World (comportement existant), et StrictMode le double-crée de toute façon.