### PR TITLE
fix(compose): GLOBAL_API_URL/BORNE_TOKEN optionnels (fix load borne)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,11 +21,14 @@ services:
       dockerfile: apps/server/Dockerfile
     environment:
       DATABASE_URL: "postgresql://user:password@db:5432/pinball?schema=public"
-      # API globale (scores mondiaux + claim QR). Injectés depuis .env racine
-      # (gitignoré). Absents → outro/QR + classement mondial dégradent en
-      # local-only (pas de crash, tout est catché côté serveur).
-      GLOBAL_API_URL: "${GLOBAL_API_URL}"
-      BORNE_TOKEN: "${BORNE_TOKEN}" # token brk_ par borne, jamais en dur
+      # API globale (scores mondiaux + claim QR). Sur la borne Fliphetic ces
+      # valeurs viennent des env vars par-app du dashboard (Operations), PAS du
+      # .env racine (gitignoré, absent de la borne). Le `:-` fournit un défaut
+      # vide : sans lui, compose émet un warning que l'override Fliphetic capture
+      # dans le YAML généré → load en échec. Absents → outro/QR + classement
+      # mondial dégradent en local-only (pas de crash, catché côté serveur).
+      GLOBAL_API_URL: "${GLOBAL_API_URL:-}"
+      BORNE_TOKEN: "${BORNE_TOKEN:-}" # token brk_ par borne, jamais en dur
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## Problème
Load borne échoue au `docker compose up` :
```
validating .env-overrides/pinball-hetic.yml: services additional properties 'time=...warning msg=...BORNE_TOKEN...', '...GLOBAL_API_URL...' not allowed
--- FAILED: docker compose up failed (rc=1)
```

## Cause
`server` lit `${GLOBAL_API_URL}` / `${BORNE_TOKEN}` depuis le `.env` racine (gitignoré, **absent de la borne**). Non définis → compose émet un warning → le générateur d'override Fliphetic capture ce stderr dans le YAML généré → YAML invalide → load KO.

## Fix
Défaut vide `${VAR:-}` → plus de warning → override valide. Les vraies valeurs se définissent via les **env vars par-app du dashboard** (Operations), mécanisme Fliphetic pour secrets/valeurs par-borne.

ESP32 flash OK déjà confirmé. Ce fix débloque le `compose up`.