### PR TITLE
fix(input-bridge): runtime Node au lieu de Bun (fix crash SIGILL borne)

### DIFF
--- a/apps/input-bridge/Dockerfile
+++ b/apps/input-bridge/Dockerfile
@@ -1,13 +1,17 @@
-FROM oven/bun:1.2-alpine AS base
-
+# Étape build : Bun résout les workspaces et bundle le service en un seul JS.
+FROM oven/bun:1.2-alpine AS build
 WORKDIR /app
-
-# Plus de binding natif : la lecture série passe par node:fs + busybox `stty`
-# (présent dans l'image alpine). Aucun toolchain de compilation requis.
-
-# Copie tout le monorepo pour que les workspaces Bun résolvent correctement
 COPY . .
-
 RUN bun install
+# --target=node : le bundle tourne sous Node (voir runtime ci-dessous).
+RUN bun build apps/input-bridge/src/index.ts --target=node --outfile /tmp/bridge.js
 
-CMD ["bun", "run", "--filter", "@pinball/input-bridge", "start"]
+# Étape runtime : Node, PAS Bun. Bun 1.2 ne supporte pas uv_default_loop appelé
+# par les addons natifs de `ws` (bufferutil/utf-8-validate) → SIGILL crash-loop
+# sur la borne. Node supporte libuv nativement. Lecture série via node:fs +
+# busybox `stty` (présent dans node:alpine). Bundle self-contained, pas de
+# node_modules : les requires natifs optionnels de ws retombent sur le JS pur.
+FROM node:20-alpine
+WORKDIR /app
+COPY --from=build /tmp/bridge.js ./bridge.js
+CMD ["node", "bridge.js"]


### PR DESCRIPTION
## Problème
Même après suppression de @serialport, input-bridge crash-loop sur la borne en mode serial :
```
Bun encountered a crash when running a NAPI module that tried to call uv_default_loop
panic: unsupported uv function: uv_default_loop → SIGILL
```
Le natif restant = `bufferutil`/`utf-8-validate`, addons optionnels de `ws` (via socket.io-client). Prebuilds musl présents sur la borne Linux (absents sur mac → pourquoi le mock passe en local). Bun 1.2 ne supporte pas `uv_default_loop`.

## Fix
Bundle avec Bun (`bun build --target=node`) puis exécution sur **node:20-alpine**. Node supporte libuv → plus de crash NAPI. Bundle self-contained (216 KB), pas de node_modules → les requires natifs optionnels de ws retombent sur le JS pur. `stty` dispo via busybox de node:alpine.

Validé localement : bundle exécuté sous Node v26, démarre clean en mock.

## Après merge
Reload + rebuild `--no-cache input-bridge` sur la borne (Fliphetic ne rebuild pas les images existantes au reload).