### PR TITLE
feat(playfield): rim light optionnel par map + exposure ST 1.12

### DIFF
--- a/apps/playfield/src/components/pinball/PinballPlayfield.tsx
+++ b/apps/playfield/src/components/pinball/PinballPlayfield.tsx
@@ -532,9 +532,9 @@ function PinballPlayfieldInner({ cabinetMode = false, resolvedMap }: PinballPlay
     const rendering = mapManifest.rendering;
     configureGltfRenderer(renderer, rendering);
 
-    // Environment map — uniquement pour les maps qui en ont besoin (rendering.useEnvironment).
-    // ST original : pas d'envmap → matériaux sans reflets ambiants (état git d'origine).
-    // Zelda : envmap active → or et gemmes très réfléchissants (effet Vectary).
+    // Environment map — par map (rendering.useEnvironment). ST : off → métal
+    // éclairé par les directionnels + rim (pas de reflets ambiants). Zelda :
+    // on → or/gemmes très réfléchissants (effet Vectary).
     if (rendering?.useEnvironment) {
       const pmrem = new THREE.PMREMGenerator(renderer);
       pmrem.compileEquirectangularShader();
@@ -579,6 +579,15 @@ function PinballPlayfieldInner({ cabinetMode = false, resolvedMap }: PinballPlay
       dirLight2.position.set(rl.dir2.x, rl.dir2.y, rl.dir2.z);
       dirLight2.castShadow = false;
       scene.add(dirLight2);
+    }
+
+    // Contre-jour optionnel (rl.rim) fond de table → liseré métal vers la
+    // caméra. Coût quasi nul. Absent dans la config → pas de rim.
+    if (rl?.rim) {
+      const rimLight = new THREE.DirectionalLight(rl.rim.color, rl.rim.intensity);
+      rimLight.position.set(rl.rim.x, rl.rim.y, rl.rim.z);
+      rimLight.castShadow = false;
+      scene.add(rimLight);
     }
 
     const fillLight = new THREE.DirectionalLight(

--- a/packages/maps/strangerthings/manifest.ts
+++ b/packages/maps/strangerthings/manifest.ts
@@ -129,7 +129,7 @@ export const manifest: MapManifest = {
   // réanime (elle écrase les intensités via les refs lumières).
   rendering: {
     useEnvironment: false,
-    toneMappingExposure: 1.38,
+    toneMappingExposure: 1.12,
     colorDarken: 0.9,
     environmentBlur: 0.04,
     envIntensityMetallic: 1.0,
@@ -140,9 +140,11 @@ export const manifest: MapManifest = {
       hemi:    { sky: 0xffffff, ground: 0x111111, intensity: 0 },
       // Double soleil latéral opposé (réglé à l'œil) : pas de highlight
       // spéculaire dans l'axe caméra, sol débouché des deux côtés.
-      dir:     { color: 0xffffff, intensity: 2.54, x: 1.08,  y: 1.5, z: 0.27 },
-      dir2:    { color: 0xffffff, intensity: 5.05, x: -1.21, y: 1.5, z: 0.55 },
-      fill:    { color: 0xffffff, intensity: 0,    x: 0,     y: 1,   z: -1   },
+      dir:     { color: 0xffffff, intensity: 2.54, x: 1.08,  y: 1.5,  z: 0.27 },
+      dir2:    { color: 0xffffff, intensity: 5.05, x: -1.21, y: 1.5,  z: 0.55 },
+      // Contre-jour : liseré métal vers la caméra (réglé à l'œil).
+      rim:     { color: 0xffffff, intensity: 1.1,  x: 0,     y: 1.3,  z: -1.2 },
+      fill:    { color: 0xffffff, intensity: 0,    x: 0,     y: 1,    z: -1   },
     },
   },
   meshAliases: {

--- a/packages/shared-types/src/map-contract.ts
+++ b/packages/shared-types/src/map-contract.ts
@@ -74,6 +74,9 @@ export interface MapRenderingConfig {
      *  éclairage qui débouche l'ombre du `dir` sans le fill (réservé à
      *  UpsideDownAtmosphere). Absent → un seul soleil. */
     dir2?: MapDirLightConfig;
+    /** Contre-jour optionnel (fond de table, vers la caméra) → liseré sur les
+     *  bords métal. Absent → pas de rim. */
+    rim?: MapDirLightConfig;
     /** Fill léger — débouche les zones d'ombre sans écraser le contraste. */
     fill: MapDirLightConfig;
   };


### PR DESCRIPTION
- Ajoute lights.rim?: MapDirLightConfig (contre-jour → liseré métal vers caméra), gaté côté PinballPlayfield. Absent → pas de rim.
- ST : rim (1.1) + toneMappingExposure 1.38→1.12. useEnvironment reste false (métal éclairé par les directionnels + rim, pas de reflets env).
- Zelda inchangée (pas de rim, son env intact).