### PR TITLE
refactor(playfield): simplify bottom out detection logic

### DIFF
--- a/apps/playfield/src/components/pinball/PinballPlayfield.tsx
+++ b/apps/playfield/src/components/pinball/PinballPlayfield.tsx
@@ -16,7 +16,6 @@ import {
   DetectBottomOut,
   getBallRadius,
   BALL_MAX_SPEED,
-  bottomOutLaneSepX,
   INITIAL_LIVES,
   PLUNGER_CHARGE_MS,
   plungerChargeProgress,
@@ -758,7 +757,7 @@ function PinballPlayfieldInner({ cabinetMode = false, resolvedMap }: PinballPlay
     let debugCollidersOn = false;
 
     const stuckDetector = new StuckBallDetector();
-    const bottomOutDetector = new DetectBottomOut(bottomOutLaneSepX(mapLayout.spawns.ball.x));
+    const bottomOutDetector = new DetectBottomOut();
     const diag = new BallDiagnostics(mapLayout);
     let lastDebugPush = 0;
 

--- a/packages/game-engine/src/domain/PlayfieldGeometry.ts
+++ b/packages/game-engine/src/domain/PlayfieldGeometry.ts
@@ -55,7 +55,7 @@ export function bottomOutLaneSepX(spawnX: number): number {
   return spawnX - getBallRadius() * 2;
 }
 
-export function isInBottomOutZone(x: number, z: number, laneSepX: number): boolean {
+export function isInBottomOutZone(x: number, z: number, laneSepX: number = WALL_RIGHT_X): boolean {
   return z >= BOTTOM_OUT_Z && x <= laneSepX;
 }
 

--- a/packages/game-engine/src/infrastructure/PlayfieldColliderFactory.ts
+++ b/packages/game-engine/src/infrastructure/PlayfieldColliderFactory.ts
@@ -6,7 +6,7 @@ import {
   SLINGSHOT_RIGHT_CENTER,
 } from '../domain/Ball';
 import type { MapLayout } from '../domain/MapLayout';
-import { surfaceYAtZ, bottomOutLaneSepX, BOTTOM_OUT_Z } from '../domain/PlayfieldGeometry';
+import { surfaceYAtZ, BOTTOM_OUT_Z } from '../domain/PlayfieldGeometry';
 import { computeLauncherLaneZBounds } from './LauncherLaneBounds';
 import { hasPinballmapRoot } from './GltfNodeNames';
 
@@ -474,15 +474,16 @@ export class PlayfieldColliderFactory {
     layout: MapLayout,
     colliderMap: Map<number, string>,
   ): void {
-    const leftX = layout.geometry.bounds.leftX;
-    const laneSepX = bottomOutLaneSepX(layout.spawns.ball.x);
-    const centerX = (leftX + laneSepX) / 2;
-    const halfX = (laneSepX - leftX) / 2;
+    const leftX  = layout.geometry.bounds.leftX;
+    const rightX = layout.geometry.bounds.rightX; // pleine largeur (0.265)
+    const centerX = (leftX + rightX) / 2;
+    const halfX   = (rightX - leftX) / 2;
+    const sensorZ = BOTTOM_OUT_Z + 0.03; // décalé vers le bas sans toucher BOTTOM_OUT_Z
     const body = world.createRigidBody(
-      RAPIER.RigidBodyDesc.fixed().setTranslation(centerX, surfaceYAtZ(BOTTOM_OUT_Z), BOTTOM_OUT_Z),
+      RAPIER.RigidBodyDesc.fixed().setTranslation(centerX, surfaceYAtZ(sensorZ), sensorZ),
     );
     const col = world.createCollider(
-      RAPIER.ColliderDesc.cuboid(halfX, 0.03, 0.01)
+      RAPIER.ColliderDesc.cuboid(halfX, 0.03, 0.06)
         .setSensor(true)
         .setActiveEvents(RAPIER.ActiveEvents.COLLISION_EVENTS),
       body,

--- a/packages/game-engine/src/use-cases/DetectBottomOut.ts
+++ b/packages/game-engine/src/use-cases/DetectBottomOut.ts
@@ -1,10 +1,10 @@
 import { isInBottomOutZone } from '../domain/PlayfieldGeometry';
 
 export class DetectBottomOut {
-  // laneSepX dérivé du spawn de la map (bottomOutLaneSepX(layout.spawns.ball.x)).
-  constructor(private readonly laneSepX: number) {}
-
+  // Couvre toute la largeur du plateau (jusqu'à WALL_RIGHT_X = 0.265).
+  // Sans limite côté couloir plongeur : la balle doit drainer même si elle
+  // dérive vers x > laneSepX avant d'atteindre z = BOTTOM_OUT_Z.
   check(pos: { x: number; z: number }): boolean {
-    return isInBottomOutZone(pos.x, pos.z, this.laneSepX);
+    return isInBottomOutZone(pos.x, pos.z); // default rightX = WALL_RIGHT_X
   }
 }


### PR DESCRIPTION
- Removed the dependency on laneSepX in the DetectBottomOut class, allowing it to cover the full width of the playfield.
- Updated isInBottomOutZone to use a default lane separation value, enhancing flexibility in bottom out zone detection.
- Adjusted collider dimensions and positions to improve gameplay mechanics and ensure accurate collision detection.