### PR TITLE
Add support for non-collision meshes in Pinballmap

### DIFF
--- a/packages/game-engine/src/infrastructure/GltfNodeNames.ts
+++ b/packages/game-engine/src/infrastructure/GltfNodeNames.ts
@@ -112,6 +112,28 @@ export function isPinballmapNonPhysicalFloorMesh(mesh: THREE.Mesh): boolean {
   );
 }
 
+/**
+ * Meshes purement décoratifs sous la hiérarchie Pinballmap : visibles,
+ * mais SANS collision — la balle passe à travers.
+ *
+ * Ajouter ici tout mesh GLB qui crée un collider parasite (rig, armature,
+ * ornement 3D) sans jamais devoir bloquer la balle.
+ *
+ * Noms normalisés (lowercase, espaces → underscores, parenthèses conservées).
+ */
+export const PINBALLMAP_NO_COLLISION_MESHES = new Set([
+  'demogorgon_portal_rig_(1)',
+]);
+
+export function isPinballmapNoCollisionMesh(mesh: THREE.Mesh): boolean {
+  const n = normalizeGltfName(mesh.name);
+  const c = canonicalGltfName(mesh.name);
+  return (
+    PINBALLMAP_NO_COLLISION_MESHES.has(n) ||
+    PINBALLMAP_NO_COLLISION_MESHES.has(c)
+  );
+}
+
 export function removePinballmapUnusedMeshes(root: THREE.Object3D): void {
   const toRemove: THREE.Object3D[] = [];
   root.traverse((obj) => {

--- a/packages/game-engine/src/infrastructure/PlayfieldTrimeshBuilder.ts
+++ b/packages/game-engine/src/infrastructure/PlayfieldTrimeshBuilder.ts
@@ -12,6 +12,7 @@ import {
   normalizeGltfName,
   playfieldUsesCollOnlyCollision,
   isPinballmapNonPhysicalFloorMesh,
+  isPinballmapNoCollisionMesh,
 } from './GltfNodeNames';
 import { surfaceYAtZ } from '../domain/PlayfieldGeometry';
 
@@ -260,6 +261,8 @@ export class PlayfieldTrimeshBuilder {
       // balle glisse sans accrocher les arêtes du trimesh. Mesh_1…4 (cadre bois,
       // structure haute) gardent leur collision.
       if (isPinballmapNonPhysicalFloorMesh(child)) return;
+      // Meshes décoratifs : visibles mais sans collision (balle passe à travers).
+      if (isPinballmapNoCollisionMesh(child)) return;
 
       if (isPinballmapRailMesh(child)) {
         PlayfieldTrimeshBuilder.createRailColliders(


### PR DESCRIPTION
- Introduced a new set of decorative meshes that are visible but do not interact with the ball, allowing it to pass through.
- Implemented a function to check if a mesh is part of this non-collision set, enhancing the physics handling in the PlayfieldTrimeshBuilder.
- Updated the PlayfieldTrimeshBuilder to utilize the new non-collision mesh check for improved gameplay experience.