### PR TITLE
fix(bosses/layout): update target positions and portal dimensions for…

### DIFF
--- a/packages/maps/zelda/bosses.ts
+++ b/packages/maps/zelda/bosses.ts
@@ -14,7 +14,7 @@ export const bossDefinitions: BossDefinition[] = [
   {
     id: 'ganondorf',
     colliderRole: 'ganondorf_target',
-    target: { x: 0, y: 1.012, z: -0.02 },
+    target: { x: -0.0249, y: 1.01222, z: -0.0740 },
     targetHits: 5,
     scoreTargetHit: 250,
     reveal: {
@@ -78,7 +78,7 @@ export const bossDefinitions: BossDefinition[] = [
   {
     id: 'darklink',
     colliderRole: 'darklink_target',
-    target: { x: 0, y: 1.012, z: -0.067 },
+    target: { x: -0.0249, y: 1.01222, z: -0.0740 },
     targetHits: 10,
     scoreTargetHit: 300,
     reveal: {

--- a/packages/maps/zelda/layout.ts
+++ b/packages/maps/zelda/layout.ts
@@ -17,9 +17,10 @@ import {
 // Zelda si les positions de meshes changent.
 export const layout: MapLayout = {
   bumpers: [
-    { x: -0.020586, y: 1.0482, z: -0.1967 },
-    { x: -0.097406, y: 1.0621, z: -0.30509 },
-    { x: 0.059483, y: 1.0621, z: -0.30509 },
+    // Positions exactes extraites du node GLB zelda.glb (via dump-glb-meshes)
+    { x: -0.02561, y: 1.02870, z: -0.19060 }, // bumper_3 (centre bas)
+    { x: -0.09967, y: 1.04850, z: -0.32417 }, // bumper_2 (gauche haut)
+    { x: 0.05183,  y: 1.04850, z: -0.32417 }, // bumper_1 (droite haut)
   ],
   dropTargets: [
     { id: 'drop_left_1', x: -0.209, y: 1.022, z: -0.019, side: 'left' },
@@ -36,7 +37,7 @@ export const layout: MapLayout = {
     ],
     rocket: { x: 0.193, y: 1.021, z: -0.13 },
     bossReveal: { x: -0.0195, y: 1.0575, z: -0.269 },
-    portal: { x: -0.000751, y: 1.015191, z: -0.064818 },
+    portal: { x: -0.0249, y: 1.01379, z: -0.0740 },
   },
   spawns: {
     ball: { x: 0.2355, y: 1.01, z: 0.161 },

--- a/packages/maps/zelda/systems/ZeldaPortal.ts
+++ b/packages/maps/zelda/systems/ZeldaPortal.ts
@@ -4,10 +4,10 @@ import type { MapLayout } from '@pinball/game-engine';
 import { easeOut } from '@pinball/game-engine';
 
 // ── Dimensions ─────────────────────────────────────────────────────────────
-const PORTAL_SENSOR_RADIUS = 0.042;
-const PORTAL_OUTER_R       = 0.056;
-const PORTAL_INNER_R       = 0.040;
-const PORTAL_TUBE_R        = 0.0042;
+const PORTAL_SENSOR_RADIUS = 0.014;
+const PORTAL_OUTER_R       = 0.01867;
+const PORTAL_INNER_R       = 0.01333;
+const PORTAL_TUBE_R        = 0.0014;
 const OPEN_DURATION        = 1.1;
 const PARTICLE_COUNT       = 28;
 
@@ -70,7 +70,7 @@ export class ZeldaPortal {
 
     // Visuel Three.js — masqué au départ. Sensor PAS encore créé.
     this.portalGroup = this.buildVisual();
-    this.portalGroup.position.set(pos.x, pos.y + 0.006, pos.z);
+    this.portalGroup.position.set(pos.x, pos.y + 0.020, pos.z);
     this.portalGroup.rotation.x = 96 * Math.PI / 180;  // à plat sur le plateau
     this.portalGroup.visible = false;
     config.root.add(this.portalGroup);


### PR DESCRIPTION
… Zelda map

- Adjusted target positions for Ganondorf and Dark Link to improve gameplay accuracy.
- Updated bumper positions in the layout for better alignment with the GLB model.
- Modified portal dimensions to enhance visual consistency and interaction within the Zelda map.