### PR TITLE
feat(backglass): enhance data fetching and socket handling for leader…

### DIFF
--- a/apps/backglass/src/hooks/useBackglassData.ts
+++ b/apps/backglass/src/hooks/useBackglassData.ts
@@ -25,13 +25,16 @@ export function useBackglassData() {
   const [stats, setStats] = useState<GlobalStats>(EMPTY_STATS)
   const [connected, setConnected] = useState(false)
   const [mapId, setMapId] = useState<string>(FORCED_MAP_ID ?? DEFAULT_MAP_ID)
+  // Ref sur la map courante : les closures du useEffect([], []) lisent
+  // toujours la valeur à jour sans se recréer.
+  const mapIdRef = useRef<string>(FORCED_MAP_ID ?? DEFAULT_MAP_ID)
 
   useEffect(() => {
     // Kiosk : une réponse d'erreur (JSON {error}, 5xx HTML, déconnexion)
     // ne doit JAMAIS remplacer un état valide. On valide statut + forme,
     // sinon on garde les données précédentes (ou EMPTY_STATS).
     const fetchLeaderboard = () =>
-      fetch('/api/leaderboard')
+      fetch(`/api/leaderboard?mapId=${mapIdRef.current}`)
         .then((res) => {
           if (!res.ok) throw new Error(`leaderboard ${res.status}`)
           return res.json()
@@ -43,7 +46,7 @@ export function useBackglassData() {
         .catch(() => {})
 
     const fetchStats = () =>
-      fetch('/api/stats')
+      fetch(`/api/stats?mapId=${mapIdRef.current}`)
         .then((res) => {
           if (!res.ok) throw new Error(`stats ${res.status}`)
           return res.json()
@@ -64,10 +67,11 @@ export function useBackglassData() {
 
     socket.on('connect', () => setConnected(true))
     socket.on('disconnect', () => setConnected(false))
-    // Même garde que le fetch : un refresh socket malformé ne remplace
-    // pas un classement valide (entries doit toujours rester un tableau).
-    socket.on('leaderboard:refresh', (data) => {
-      if (Array.isArray(data)) setEntries(data)
+    // leaderboard:refresh arrive après un game:over sur n'importe quelle map.
+    // On re-fetch depuis l'API avec le mapId courant pour ne montrer que les
+    // scores de la map active (le payload de l'event est ignoré).
+    socket.on('leaderboard:refresh', () => {
+      fetchLeaderboard()
     })
     // les agrégats ont changé : on re-fetch /api/stats
     socket.on('game:over', () => {
@@ -76,7 +80,14 @@ export function useBackglassData() {
     // Synchro map active (émis à la connexion + à chaque changement).
     // Ignoré si NEXT_PUBLIC_MAP_ID est forcé (prod Fliphetic mono-map).
     socket.on('map:selected', ({ mapId: id }) => {
-      if (!FORCED_MAP_ID) setMapId(id)
+      if (!FORCED_MAP_ID) {
+        mapIdRef.current = id
+        setMapId(id)
+        // Re-fetch immédiat avec la nouvelle map : le board et les stats
+        // doivent basculer dès le changement, sans attendre le prochain poll.
+        fetchLeaderboard()
+        fetchStats()
+      }
     })
 
     // Les claims arrivent async (téléphone, après la partie, depuis n'importe

--- a/apps/server/src/interface/index.ts
+++ b/apps/server/src/interface/index.ts
@@ -109,7 +109,7 @@ io.on('connection', (socket) => {
     try {
       const registered = await registerScore(data);
       socket.emit('game:registered', registered); // au seul émetteur → QR
-      io.emit('leaderboard:refresh', await worldTopTen()); // backglass (board mondial)
+      io.emit('leaderboard:refresh', await worldTopTen(data.mapId)); // backglass (board de la map jouée)
     } catch (err) {
       // le jeu continue — la persistence ne doit JAMAIS bloquer le relay
       console.error('[server] game:over persist failed:', err);

--- a/packages/maps/zelda/manifest.ts
+++ b/packages/maps/zelda/manifest.ts
@@ -110,6 +110,13 @@ export const manifest: MapManifest = {
     'ocarina',
     'sheikah',
   ],
+  // Wording de l'écran game-over (QR code de claim). Textes thématisés Zelda.
+  // qrLogo absent : pas de PNG disponible dans les assets (ajouter plus tard).
+  outro: {
+    title: 'LA LÉGENDE EST TERMINÉE',
+    scanLabel: 'Scanne pour graver ton nom au Temple du Temps',
+    replayLabel: 'START — Rejouer',
+  },
   // ─── Rendu Three.js — spécifique Zelda ────────────────────────────────────
   // Esthétique Hyrule : marbre noir profond, or et gemmes vifs.
   // envIntensityMetallic élevé → les matériaux métalliques (triforce, couronnes


### PR DESCRIPTION
…board and stats

- Updated the useBackglassData hook to utilize a ref for the current map ID, ensuring accurate data fetching for leaderboard and stats based on the active map.
- Modified socket event handling to re-fetch leaderboard and stats immediately upon map selection and game over events, improving real-time data accuracy.
- Adjusted server-side leaderboard refresh to include the map ID, ensuring the leaderboard reflects scores specific to the currently played map.