### PR TITLE
refacto(useGameState): extraire fonctions pures dans gameStateUtils (…

### DIFF
--- a/apps/playfield/src/hooks/gameStateUtils.ts
+++ b/apps/playfield/src/hooks/gameStateUtils.ts
@@ -1,0 +1,52 @@
+/**
+ * gameStateUtils.ts — Fonctions pures et constantes du game state.
+ *
+ * Extraites de useGameState.ts (SRP) : ces utilitaires ne dépendent d'aucun
+ * state React, aucun ref, aucun hook. Ils peuvent être testés indépendamment
+ * de React, sans monter de composant.
+ */
+
+export const COMBO_DECAY_MS = 2000;
+export const MULTIPLIER_THRESHOLDS = [5, 10, 20, 40] as const;
+
+export const MILESTONES = [5_000, 15_000, 30_000];
+export const MILESTONE_REPEAT_EVERY = 25_000; // au-delà de 50k
+
+/**
+ * Renvoie le multiplicateur de score correspondant au combo courant.
+ * Combo 0–4 → ×1, 5–9 → ×2, 10–19 → ×3, 20–39 → ×4, 40+ → ×5.
+ */
+export function computeMultiplier(combo: number): number {
+  if (combo < MULTIPLIER_THRESHOLDS[0]) return 1;
+  if (combo < MULTIPLIER_THRESHOLDS[1]) return 2;
+  if (combo < MULTIPLIER_THRESHOLDS[2]) return 3;
+  if (combo < MULTIPLIER_THRESHOLDS[3]) return 4;
+  return 5;
+}
+
+/**
+ * Plus haut seuil de {5k,15k,30k,50k,75k,100k,…} franchi entre prev et next.
+ * Marque TOUS les seuils franchis dans `passed` (sinon les seuils intermédiaires
+ * non retournés re-déclencheraient au prochain event) et renvoie le plus haut.
+ */
+export function nextMilestone(prev: number, next: number, passed: Set<number>): number | null {
+  let crossed: number | null = null;
+  const mark = (m: number) => {
+    if (m > prev && m <= next && !passed.has(m)) {
+      passed.add(m);
+      if (crossed === null || m > crossed) crossed = m;
+    }
+  };
+  for (const m of MILESTONES) mark(m);
+  // Répétition tous les 25k au-delà de 50k.
+  for (let m = 50_000; m <= next; m += MILESTONE_REPEAT_EVERY) mark(m);
+  return crossed;
+}
+
+/**
+ * Génère un nom de joueur aléatoire de la forme PLAYER0000–PLAYER9999.
+ */
+export function generatePlayerName(): string {
+  const n = Math.floor(Math.random() * 10000).toString().padStart(4, "0");
+  return `PLAYER${n}`;
+}

--- a/apps/playfield/src/hooks/gameStateUtils.ts
+++ b/apps/playfield/src/hooks/gameStateUtils.ts
@@ -1,19 +1,19 @@
 /**
- * gameStateUtils.ts — Fonctions pures et constantes du game state.
+ * gameStateUtils.ts — Pure functions and constants for game state logic.
  *
- * Extraites de useGameState.ts (SRP) : ces utilitaires ne dépendent d'aucun
- * state React, aucun ref, aucun hook. Ils peuvent être testés indépendamment
- * de React, sans monter de composant.
+ * Extracted from useGameState.ts (SRP): these utilities depend on no React
+ * state, refs, or hooks. They can be tested independently without mounting
+ * any component.
  */
 
 export const COMBO_DECAY_MS = 2000;
 export const MULTIPLIER_THRESHOLDS = [5, 10, 20, 40] as const;
 
 export const MILESTONES = [5_000, 15_000, 30_000];
-export const MILESTONE_REPEAT_EVERY = 25_000; // au-delà de 50k
+export const MILESTONE_REPEAT_EVERY = 25_000; // beyond 50k
 
 /**
- * Renvoie le multiplicateur de score correspondant au combo courant.
+ * Returns the score multiplier for the current combo count.
  * Combo 0–4 → ×1, 5–9 → ×2, 10–19 → ×3, 20–39 → ×4, 40+ → ×5.
  */
 export function computeMultiplier(combo: number): number {
@@ -25,9 +25,9 @@ export function computeMultiplier(combo: number): number {
 }
 
 /**
- * Plus haut seuil de {5k,15k,30k,50k,75k,100k,…} franchi entre prev et next.
- * Marque TOUS les seuils franchis dans `passed` (sinon les seuils intermédiaires
- * non retournés re-déclencheraient au prochain event) et renvoie le plus haut.
+ * Returns the highest milestone in {5k, 15k, 30k, 50k, 75k, 100k, …} crossed
+ * between prev and next. All crossed milestones are recorded in `passed` to
+ * prevent intermediate ones from re-triggering on the next event.
  */
 export function nextMilestone(prev: number, next: number, passed: Set<number>): number | null {
   let crossed: number | null = null;
@@ -38,13 +38,13 @@ export function nextMilestone(prev: number, next: number, passed: Set<number>): 
     }
   };
   for (const m of MILESTONES) mark(m);
-  // Répétition tous les 25k au-delà de 50k.
+  // Repeat every 25k beyond 50k.
   for (let m = 50_000; m <= next; m += MILESTONE_REPEAT_EVERY) mark(m);
   return crossed;
 }
 
 /**
- * Génère un nom de joueur aléatoire de la forme PLAYER0000–PLAYER9999.
+ * Generates a random player name in the form PLAYER0000–PLAYER9999.
  */
 export function generatePlayerName(): string {
   const n = Math.floor(Math.random() * 10000).toString().padStart(4, "0");

--- a/apps/playfield/src/hooks/useGameState.ts
+++ b/apps/playfield/src/hooks/useGameState.ts
@@ -54,7 +54,7 @@ export interface ScoringCallbacks {
   onIdleReset?: () => void;
   onAtmosphereChange?: (alternateWorldActive: boolean) => void;
   onMilestone?: (threshold: number) => void;
-  onBossArmed?: (bossId: BossId) => void; // palier franchi → le nid s'éveille (1×/partie)
+  onBossArmed?: (bossId: BossId) => void; // score threshold crossed → boss awakens (once per game)
   onFeverEnd?: () => void;
 }
 
@@ -70,13 +70,13 @@ const initialBossHud = (bosses: BossDefinition[]): BossHudState =>
   Object.fromEntries(bosses.map((b) => [b.id, initialBossHudEntry()])) as BossHudState;
 
 export interface GameStateOptions {
-  /** Ancre écran des pop de score portail (depuis layout.sensors.portal). */
+  /** Screen anchor for portal score pops (from layout.sensors.portal). */
   portalAnchor?: { x: number; z: number };
-  /** Ancres écran des pop de score bumper (depuis layout.bumpers). */
+  /** Screen anchors for bumper score pops (from layout.bumpers). */
   bumperAnchors?: { x: number; z: number }[];
-  /** Délai avant le hint d'atmosphère (depuis layout.atmosphere.hintMs). */
+  /** Delay before the atmosphere hint disappears (from layout.atmosphere.hintMs). */
   atmosphereHintMs?: number;
-  /** Définitions de boss de la map active (layout.bosses). */
+  /** Boss definitions for the active map (layout.bosses). */
   bosses?: BossDefinition[];
 }
 
@@ -86,9 +86,9 @@ export function useGameState(callbacks?: ScoringCallbacks, opts?: GameStateOptio
   const atmosphereHintMs = opts?.atmosphereHintMs ?? 45_000;
   const bosses = opts?.bosses ?? [];
   const bossIds = bosses.map((b) => b.id);
-  // `callbacks` est un objet littéral recréé à chaque render → on le lit via
-  // un ref pour ne PAS remettre l'interval 250ms (decay combo + expiration
-  // fever) à zéro à chaque render (sinon il pourrait ne jamais se déclencher).
+  // `callbacks` is a literal object recreated on every render → read via a ref
+  // to avoid resetting the 250ms interval (combo decay + fever expiration)
+  // on every render, which could prevent it from ever firing.
   const callbacksRef = useRef(callbacks);
   callbacksRef.current = callbacks;
 
@@ -118,8 +118,8 @@ export function useGameState(callbacks?: ScoringCallbacks, opts?: GameStateOptio
   const lastEventTimeRef = useRef(0);
   const playerRef = useRef(player);
   const victoryTimersRef = useRef<Partial<Record<BossId, number>>>({});
-  // Timer du flash d'assist (générique : le boss propriétaire est déduit de
-  // sa def via `assist`). Un seul assist actif à la fois.
+  // Assist flash timer (generic: the owning boss is derived from its def via `assist`).
+  // Only one assist can be active at a time.
   const assistTimerRef = useRef<number | null>(null);
   const scorePopIdRef = useRef(0);
   const scorePopTimersRef = useRef<Map<number, number>>(new Map());
@@ -144,7 +144,7 @@ export function useGameState(callbacks?: ScoringCallbacks, opts?: GameStateOptio
         setCombo(0);
         setMultiplier(1);
       }
-      // Expiration du fever
+      // Fever expiration
       if (feverUntilRef.current && performance.now() > feverUntilRef.current) {
         feverUntilRef.current = 0;
         setFever(false);
@@ -194,7 +194,7 @@ export function useGameState(callbacks?: ScoringCallbacks, opts?: GameStateOptio
       window.clearTimeout(timer);
       delete victoryTimersRef.current[id];
     }
-    // Annule le flash d'assist si CE boss en possède un (plus de nom en dur).
+    // Cancel the assist flash if this boss owns one (no hardcoded name).
     const def = getBossById(bosses, id);
     if (def?.assist && assistTimerRef.current !== null) {
       window.clearTimeout(assistTimerRef.current);
@@ -211,9 +211,9 @@ export function useGameState(callbacks?: ScoringCallbacks, opts?: GameStateOptio
 
   const clearAlternateWorldSession = useCallback(() => {
     clearAlternateWorldHint();
-    // Boss liés au monde alternatif (reveal gaté requiresAlternateWorld) : reset
-    // HUD + ré-armement, sans nom en dur. Ils se ré-annoncent à la prochaine
-    // entrée dans le monde alternatif.
+    // Bosses tied to the alternate world (reveal gated by requiresAlternateWorld):
+    // reset HUD + re-arm without hardcoded names. They re-announce on the next
+    // alternate world entry.
     for (const def of bosses) {
       if (!def.reveal.requiresAlternateWorld) continue;
       clearBossHud(def.id);
@@ -255,8 +255,8 @@ export function useGameState(callbacks?: ScoringCallbacks, opts?: GameStateOptio
       const stats: GameStats = {
         maxCombo: maxComboRef.current,
         maxMultiplier: maxMultiplierRef.current,
-        // Counters remplis par PinballPlayfield depuis le mapState (alimenté par
-        // le module de map). useGameState ne compte plus rien de ST.
+        // Counters are filled by PinballPlayfield from mapState (fed by the map module).
+        // useGameState no longer tracks any map-specific counters.
         counters: {},
         durationS: gameStartRef.current
           ? Math.round((performance.now() - gameStartRef.current) / 1000)
@@ -313,8 +313,8 @@ export function useGameState(callbacks?: ScoringCallbacks, opts?: GameStateOptio
           maxMultiplierRef.current,
           multiplierRef.current,
         );
-        // En fever le multiplier effectif est forcé à 5 (combo continue
-        // de compter en arrière-plan).
+        // During fever the effective multiplier is forced to 5 (combo keeps
+        // counting in the background).
         const mult = isFeverActive() ? 5 : multiplierRef.current;
         const finalPoints = event.scoreIncrement * mult;
         const prevScore = scoreRef.current;
@@ -330,13 +330,13 @@ export function useGameState(callbacks?: ScoringCallbacks, opts?: GameStateOptio
           newMultiplier: multiplierRef.current,
         });
 
-        // Paliers de score (nextMilestone marque déjà tous les seuils franchis)
+        // Score milestones (nextMilestone already records all crossed thresholds)
         const crossed = nextMilestone(prevScore, scoreRef.current, milestonesPassedRef.current);
         if (crossed) callbacks?.onMilestone?.(crossed);
 
-        // Éveil du nid : palier de boss franchi → onBossArmed une fois par partie.
-        // Le set garde l'unicité ; le gate monde alternatif/baseline est porté par
-        // bossThresholdMet (générique pour tout boss, gate monde alternatif inclus).
+        // Boss awakening: threshold crossed → onBossArmed fires once per game.
+        // The set ensures uniqueness; the alternate-world/baseline gate is handled
+        // by bossThresholdMet (generic for all bosses, including world gate).
         for (const id of bossIds) {
           if (bossArmedFiredRef.current.has(id)) continue;
           const def = getBossById(bosses, id); if (!def) continue;
@@ -379,7 +379,7 @@ export function useGameState(callbacks?: ScoringCallbacks, opts?: GameStateOptio
           tone: "target",
         });
         const victory = event.hitCount >= def.targetHits;
-        // Compteur "boss vaincus" : tenu par le module de map (mapState).
+        // "Bosses defeated" counter: tracked by the map module (mapState).
         setBossHud((prev) => ({
           ...prev,
           [event.bossId]: {
@@ -421,7 +421,7 @@ export function useGameState(callbacks?: ScoringCallbacks, opts?: GameStateOptio
         }));
       }
       if (event.type === "ASSIST") {
-        // Boss propriétaire de l'assist déduit de sa def (assist.id), pas en dur.
+        // Owning boss is derived from its def (assist.id), not hardcoded.
         const assistBoss = bosses.find((b) => b.assist?.id === event.assistId);
         if (assistBoss) {
           const bossId = assistBoss.id;
@@ -452,15 +452,14 @@ export function useGameState(callbacks?: ScoringCallbacks, opts?: GameStateOptio
           clearAllBossHud();
         }
       }
-      // DROP_TARGET_COMPLETE (compteur de collecte + cinématiques) : géré par
-      // le module de map.
+      // DROP_TARGET_COMPLETE (collection counter + cinematics): handled by the map module.
       if (event.type === "BALL_LAUNCHED") {
         if (gameStartRef.current === 0) gameStartRef.current = now;
         if (gameStateRef.current === "idle") callbacks?.onGameStart?.();
         updateGameState("playing");
       }
       if (event.type === "PORTAL_ENTER") {
-        // Compteur "portals" : tenu par le module de map (mapState).
+        // "Portals" counter: tracked by the map module (mapState).
         const point = jitterScreenPoint(
           playfieldToScreenPercent(portalAnchor.x, portalAnchor.z),
           3,

--- a/apps/playfield/src/hooks/useGameState.ts
+++ b/apps/playfield/src/hooks/useGameState.ts
@@ -13,6 +13,12 @@ import {
   onMusicGameOver,
 } from "../audio/pinballAudio";
 import { playfieldToScreenPercent, jitterScreenPoint } from "../utils/playfieldScreen";
+import {
+  computeMultiplier,
+  nextMilestone,
+  generatePlayerName,
+  COMBO_DECAY_MS,
+} from "./gameStateUtils";
 
 export type GameState = "idle" | "playing" | "game_over";
 
@@ -52,41 +58,6 @@ export interface ScoringCallbacks {
   onFeverEnd?: () => void;
 }
 
-const COMBO_DECAY_MS = 2000;
-const MULTIPLIER_THRESHOLDS = [5, 10, 20, 40] as const;
-
-const MILESTONES = [5_000, 15_000, 30_000];
-const MILESTONE_REPEAT_EVERY = 25_000; // au-delà de 50k
-
-// Plus haut seuil de {5k,15k,30k,50k,75k,100k,…} franchi entre prev et next.
-// Marque TOUS les seuils franchis dans `passed` (sinon les seuils intermédiaires
-// non retournés re-déclencheraient au prochain event) et renvoie le plus haut.
-function nextMilestone(prev: number, next: number, passed: Set<number>): number | null {
-  let crossed: number | null = null;
-  const mark = (m: number) => {
-    if (m > prev && m <= next && !passed.has(m)) {
-      passed.add(m);
-      if (crossed === null || m > crossed) crossed = m;
-    }
-  };
-  for (const m of MILESTONES) mark(m);
-  // Répétition tous les 25k au-delà de 50k.
-  for (let m = 50_000; m <= next; m += MILESTONE_REPEAT_EVERY) mark(m);
-  return crossed;
-}
-
-function computeMultiplier(combo: number): number {
-  if (combo < MULTIPLIER_THRESHOLDS[0]) return 1;
-  if (combo < MULTIPLIER_THRESHOLDS[1]) return 2;
-  if (combo < MULTIPLIER_THRESHOLDS[2]) return 3;
-  if (combo < MULTIPLIER_THRESHOLDS[3]) return 4;
-  return 5;
-}
-
-function generatePlayerName(): string {
-  const n = Math.floor(Math.random() * 10000).toString().padStart(4, "0");
-  return `PLAYER${n}`;
-}
 
 const initialBossHudEntry = (): BossHudEntry => ({
   active: false,

--- a/apps/server/src/interface/index.ts
+++ b/apps/server/src/interface/index.ts
@@ -17,8 +17,6 @@ const PORT = process.env.PORT || 3001;
 
 const INPUT_BRIDGE_ROOM = 'input-bridge';
 
-// Map active côté server : mise à jour via 'map:select' (playfield → sélecteur).
-// Communiqué à chaque nouveau connecté + broadcasté à tous quand ça change.
 let currentMapId: string = DEFAULT_MAP_ID;
 
 app.get('/', (req, res) => {
@@ -54,8 +52,6 @@ io.on('connection', (socket) => {
     console.log('[server] input-bridge joined room');
   }
 
-  // Informer le nouveau connecté de la map courante (DMD/backglass synchro au
-  // démarrage, même si aucun `map:select` n'a encore été émis).
   socket.emit('map:selected', { mapId: currentMapId });
 
   socket.on('map:select', ({ mapId }) => {
@@ -80,9 +76,6 @@ io.on('connection', (socket) => {
     io.emit('input:sensor', data);
   });
 
-  // Mode dev `simulate-esp32` : route ciblé vers l'input-bridge. C'est
-  // l'input-bridge qui injectera le texte sur son port mock, son parser
-  // relira, et émettra `input:button` au server → broadcast à tous.
   socket.on('dev:simulate-button', (data) => {
     console.log('[server] dev:simulate-button', data.id, data.action, '→ input-bridge');
     io.to(INPUT_BRIDGE_ROOM).emit('dev:simulate-button', data);
@@ -100,18 +93,16 @@ io.on('connection', (socket) => {
 
   socket.on('game:over', async (data) => {
     console.log('[server] game:over', data.player, 'final=', data.finalScore);
-    io.emit('game:over', data); // relay inchangé (DMD, backglass)
-    // Game over déclenché depuis /debug : relay seul, pas de persistence.
+    io.emit('game:over', data);
     if (data.debug === true) {
-      console.log('[server] game:over [debug skip] — pas de persistence');
+      console.log('[server] game:over [debug skip]');
       return;
     }
     try {
       const registered = await registerScore(data);
-      socket.emit('game:registered', registered); // au seul émetteur → QR
-      io.emit('leaderboard:refresh', await worldTopTen(data.mapId)); // backglass (board de la map jouée)
+      socket.emit('game:registered', registered);
+      io.emit('leaderboard:refresh', await worldTopTen(data.mapId));
     } catch (err) {
-      // le jeu continue — la persistence ne doit JAMAIS bloquer le relay
       console.error('[server] game:over persist failed:', err);
     }
   });


### PR DESCRIPTION
…SRP)

- Créer gameStateUtils.ts : computeMultiplier, nextMilestone, generatePlayerName + constantes associées (COMBO_DECAY_MS, MULTIPLIER_THRESHOLDS, MILESTONES, MILESTONE_REPEAT_EVERY)
- useGameState.ts : remplacer les définitions locales par imports depuis gameStateUtils
- Ces fonctions pures ne dépendent d'aucun state/ref/hook React → testables sans composant monté