### PR TITLE
fix(pinball): remove debug "Reset ball" button and related keyboard h…

### DIFF
--- a/apps/playfield/src/components/pinball/GameOverlay.tsx
+++ b/apps/playfield/src/components/pinball/GameOverlay.tsx
@@ -140,6 +140,9 @@ export default function GameOverlay({
   qrLogo,
 }: GameOverlayProps) {
   void cabinetMode;
+  // Le bouton "Reset balle" (debug) a été retiré de l'affichage ; le
+  // raccourci R reste actif indépendamment (cf. PinballPlayfield.tsx).
+  void onResetBall;
   const layout = overlayLayout(portraitFill);
 
   const showHud = bootPhase === "in_game";
@@ -156,9 +159,6 @@ export default function GameOverlay({
   const title = outro?.title ?? "FIN DE PARTIE";
   const scanLabel = outro?.scanLabel ?? "Scanne pour t'inscrire au classement";
   const replayLabel = outro?.replayLabel ?? "START — Rejouer";
-
-  const showResetBall =
-    bootPhase === "in_game" && gameState !== "game_over" && plungerCharge === null;
 
   const showAlternateWorldBanner =
     bootPhase === "in_game" && gameState === "playing" && alternateWorldActive;
@@ -184,25 +184,14 @@ export default function GameOverlay({
                 </span>
               ))}
             </div>
-            {showResetBall && onResetBall && (
-              <button
-                type="button"
-                onClick={onResetBall}
-                className="pointer-events-auto mt-2 rounded border border-red-500/35 bg-black/60 px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.18em] text-red-300/90 backdrop-blur-sm transition hover:border-red-400/50 hover:bg-black/80 hover:text-red-200 active:scale-[0.98]"
-              >
-                Reset balle — R (−1 vie)
-              </button>
-            )}
+            {/*
+              Le bouton "Reset balle" et la légende clavier sont des aides de
+              debug : elles ne doivent pas apparaître sur la borne (démo du
+              vrai flipper). Les raccourcis restent actifs (R reset, ESPACE
+              lance) — cf. onKeyDown/onKeyUp dans PinballPlayfield.tsx, qui
+              n'ont aucune dépendance sur cet affichage.
+            */}
           </div>
-          {layout.keyboardHints && (
-            <div className={layout.keyboardHints}>
-              <div>Q / ← — Flipper gauche</div>
-              <div>D / → — Flipper droit</div>
-              <div>ESPACE — Charger / lancer</div>
-              <div>R — Reset balle (−1 vie)</div>
-              <div>H — Debug colliders</div>
-            </div>
-          )}
         </header>
       )}
 
@@ -432,26 +421,19 @@ export default function GameOverlay({
         />
       )}
 
-      {showPowerBar && (
-        <div className={`pointer-events-none absolute inset-x-0 ${layout.powerHint} z-10 flex justify-center px-4`}>
-          <p className="animate-pulse font-mono text-[11px] uppercase tracking-[0.22em] text-amber-200/80">
-            Relâcher ESPACE pour lancer
-          </p>
-        </div>
-      )}
-
-      {showLaunchHint && (
+      {/*
+        Les aides "Relâcher ESPACE pour lancer" / "Maintenir ESPACE — relâcher
+        pour lancer" ont été retirées de l'affichage (debug, pas pour la
+        démo du vrai flipper). Le lancement au clavier (ESPACE) reste actif
+        indépendamment — cf. onKeyDown/onKeyUp dans PinballPlayfield.tsx.
+        On garde le décompte de vies restantes, qui est une info de jeu et
+        pas un raccourci clavier.
+      */}
+      {showLaunchHint && lives < initialLives && (
         <div className={`pointer-events-none absolute inset-x-0 ${layout.bottomHint} z-10 flex flex-col items-center gap-2 px-4`}>
-          {lives < initialLives && (
-            <p className="font-mono text-[10px] uppercase tracking-[0.24em] text-zinc-500">
-              Bille perdue — {lives} vie{lives > 1 ? "s" : ""} restante{lives > 1 ? "s" : ""}
-            </p>
-          )}
-          <div className="rounded-full border border-zinc-700/60 bg-black/55 px-5 py-2 font-mono backdrop-blur-sm">
-            <p className="text-[11px] uppercase tracking-[0.22em] text-zinc-300">
-              Maintenir <span className="text-amber-300/90">ESPACE</span> — relâcher pour lancer
-            </p>
-          </div>
+          <p className="font-mono text-[10px] uppercase tracking-[0.24em] text-zinc-500">
+            Bille perdue — {lives} vie{lives > 1 ? "s" : ""} restante{lives > 1 ? "s" : ""}
+          </p>
         </div>
       )}
     </>

--- a/bun.lock
+++ b/bun.lock
@@ -210,6 +210,9 @@
       },
     },
   },
+  "overrides": {
+    "@dimforge/rapier3d-compat": "0.14.0",
+  },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.5.0", "", {}, "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q=="],
 
@@ -1116,8 +1119,6 @@
     "@types/serve-static/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
     "@types/superagent/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
-
-    "@types/three/@dimforge/rapier3d-compat": ["@dimforge/rapier3d-compat@0.12.0", "", {}, "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow=="],
 
     "@types/ws/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 

--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
     "prettier": "^3.5.3",
     "supertest": "^7.2.2",
     "typescript": "^5.9.3"
+  },
+  "overrides": {
+    "@dimforge/rapier3d-compat": "0.14.0"
   }
 }

--- a/packages/game-engine/src/infrastructure/BossActorAnimator.test.ts
+++ b/packages/game-engine/src/infrastructure/BossActorAnimator.test.ts
@@ -165,6 +165,65 @@ describe('BossActorAnimator update', () => {
   });
 });
 
+// ── Régression : la pose de victoire ne doit pas contaminer le combat suivant ──
+// `victoryAction` tourne en LoopOnce + clampWhenFinished : une fois finie, elle
+// se fige sur sa dernière frame au lieu de s'arrêter — son poids reste dans le
+// blend. Avant le fix, hide()/playIdle() ne l'arrêtaient jamais explicitement,
+// donc le 2e combat démarrait avec la pose de victoire gelée mélangée à l'idle
+// (Ganondorf bloqué dans une pose bizarre au lieu de repartir en idle propre).
+function makeRotZClip(name: string, endValue: number): THREE.AnimationClip {
+  const track = new THREE.NumberKeyframeTrack('.rotation[z]', [0, 1], [0, endValue]);
+  return new THREE.AnimationClip(name, 1, [track]);
+}
+
+function step(mixer: THREE.AnimationMixer, seconds: number, dt = 1 / 60): void {
+  let t = 0;
+  while (t < seconds) {
+    mixer.update(dt);
+    t += dt;
+  }
+}
+
+function setupVictoryLeakRig() {
+  const root = new THREE.Object3D();
+  const mixer = new THREE.AnimationMixer(root);
+  const idleAction = mixer.clipAction(makeRotZClip('idle', 0.1));
+  idleAction.setLoop(THREE.LoopRepeat, Infinity);
+  const victoryAction = mixer.clipAction(makeRotZClip('victory', 2.0));
+  victoryAction.setLoop(THREE.LoopOnce, 1);
+  victoryAction.clampWhenFinished = true;
+
+  const animator = new BossActorAnimator(GLOW);
+  animator.setActions({ mixer, idleAction, hitAction: null, victoryAction });
+
+  return { root, mixer, idleAction, victoryAction, animator };
+}
+
+describe('BossActorAnimator — victory pose does not leak into the next fight', () => {
+  it('playIdle() after a finished victory produces a clean idle pose, not a blend', () => {
+    const { root, mixer, animator } = setupVictoryLeakRig();
+
+    animator.playIdle();
+    step(mixer, 0.5);
+
+    animator.playVictory();
+    step(mixer, 3); // well past the 1s victory clip → finished & clamped
+
+    // End of fight / game reset.
+    animator.hide(root);
+    // Next game: boss revealed again → show() → playIdle().
+    animator.playIdle();
+    step(mixer, 0.2); // let the 0.12s idle fade-in complete
+    step(mixer, 0.25); // sample a clean quarter-second into the idle ramp
+
+    // A contaminated blend (pre-fix behaviour) lands around rotZ ≈ 1.0+
+    // (averaging idle's ~0.05 with victory's frozen 2.0). A clean idle pose
+    // stays within the idle clip's own range [0, 0.1].
+    expect(root.rotation.z).toBeGreaterThanOrEqual(0);
+    expect(root.rotation.z).toBeLessThan(0.1);
+  });
+});
+
 describe('BossActorAnimator reset', () => {
   it('reset(false) keeps the light disposable later but clears state', () => {
     const a = new BossActorAnimator(GLOW);

--- a/packages/game-engine/src/infrastructure/BossActorAnimator.ts
+++ b/packages/game-engine/src/infrastructure/BossActorAnimator.ts
@@ -110,6 +110,14 @@ export class BossActorAnimator {
     }
     this.animState = 'idle';
     this.hitFlash = 0;
+    // hit/victory tournent en LoopOnce + clampWhenFinished : une fois finies,
+    // elles restent "actives" gelées sur leur dernière frame (poids toujours
+    // dans le blend) au lieu de se couper. Sans ce stop() explicite, la pose
+    // de victoire (boss "mort") continuait de peser au combat suivant — d'où
+    // le boss figé dans une pose bizarre au lieu de repartir en idle propre
+    // (cf. bug Ganondorf coincé après une 1re victoire).
+    this.hitAction?.stop();
+    this.victoryAction?.stop();
     if (this.glowLight) {
       this.glowLight.intensity = 0;
       this.glowLight.removeFromParent();
@@ -142,6 +150,12 @@ export class BossActorAnimator {
   playIdle(): void {
     if (!this.idleAction) return;
     this.animState = 'idle';
+    // Défense en profondeur : garantit qu'aucune pose one-shot gelée (hit ou
+    // victoire d'une partie précédente) ne reste dans le blend quand on
+    // revient à idle, quel que soit le chemin d'appel (show() après hide(),
+    // reveal direct, etc.).
+    this.hitAction?.stop();
+    this.victoryAction?.stop();
     this.idleAction.reset();
     this.idleAction.setLoop(THREE.LoopRepeat, Infinity);
     this.idleAction.fadeIn(0.12).play();

--- a/packages/game-engine/src/infrastructure/PlungerPhysics.ts
+++ b/packages/game-engine/src/infrastructure/PlungerPhysics.ts
@@ -1,13 +1,37 @@
 import RAPIER from '@dimforge/rapier3d-compat';
 
+/**
+ * Rapier renamed `RigidBodyDesc.newKinematicPositionBased()` to
+ * `.kinematicPositionBased()`. Depending on which exact
+ * `@dimforge/rapier3d-compat` build actually gets resolved (version drift
+ * between a fresh install and a cached one — e.g. a nested/older copy pulled
+ * in transitively), only one of the two names may exist at runtime even
+ * though both are declared in the current package's types. Feature-detect
+ * instead of hard-crashing with "kinematicPositionBased is not a function".
+ */
+function kinematicPositionBasedDesc(): RAPIER.RigidBodyDesc {
+  const Desc = RAPIER.RigidBodyDesc;
+  if (typeof Desc.kinematicPositionBased === 'function') {
+    return Desc.kinematicPositionBased();
+  }
+  if (typeof Desc.newKinematicPositionBased === 'function') {
+    return Desc.newKinematicPositionBased();
+  }
+  throw new Error(
+    '[PlungerPhysics] No kinematic position-based constructor found on ' +
+      'RAPIER.RigidBodyDesc (expected kinematicPositionBased() or the ' +
+      'deprecated newKinematicPositionBased()). Check the installed ' +
+      '@dimforge/rapier3d-compat version.',
+  );
+}
+
 export class PlungerPhysics {
   static createBody(
     world: RAPIER.World,
     position: { x: number; y: number; z: number },
   ): RAPIER.RigidBody {
     const body = world.createRigidBody(
-      RAPIER.RigidBodyDesc.kinematicPositionBased()
-        .setTranslation(position.x, position.y, position.z),
+      kinematicPositionBasedDesc().setTranslation(position.x, position.y, position.z),
     );
     world.createCollider(
       RAPIER.ColliderDesc.cuboid(0.015, 0.015, 0.02)

--- a/packages/game-engine/src/use-cases/DetectStuckBall.test.ts
+++ b/packages/game-engine/src/use-cases/DetectStuckBall.test.ts
@@ -72,14 +72,35 @@ describe('StuckBallDetector', () => {
     expect(detector.update(0.01, center, 1.01)!.type).toBe('nudge');
   });
 
-  test('a moving ball resets timer and nudge count', () => {
+  test('a ball that actually drifts away resets timer and nudge count', () => {
     detector.update(0.01, center, 1.01); // nudge 1
     detector.update(0.01, center, 1.01); // nudge 2 (count = 2)
-    detector.update(0.5, center, 0.1); // balle bouge → reset
+    // Vitesse élevée ET position qui s'éloigne réellement de l'ancre → la
+    // balle s'est vraiment dégagée, pas juste un rebond sur place.
+    detector.update(0.5, { x: 0.5, z: 0.5 }, 0.1);
     // count repart de 0 : il faut 3 nouveaux nudges avant force_drain.
     expect(detector.update(0.01, center, 1.01)!.type).toBe('nudge'); // 1
     expect(detector.update(0.01, center, 1.01)!.type).toBe('nudge'); // 2
     expect(detector.update(0.01, center, 1.01)!.type).toBe('force_drain');
+  });
+
+  test('a velocity spike WITHOUT real positional drift does not reset (stuck-in-pocket case)', () => {
+    // Reproduit le bug : une balle coincée dans une poche peut rebondir
+    // contre les parois (pic de vitesse instantané) sans jamais s'éloigner
+    // réellement de l'endroit où elle est bloquée. Le minuteur doit continuer
+    // à s'accumuler dans ce cas, sinon la balle ne se dégage jamais.
+    detector.update(0.01, center, 0.5); // timer = 0.5, ancre posée en (0,0)
+    detector.update(0.5, { x: 0.005, z: 0 }, 0.1); // rebond, mais dans STUCK_RADIUS → timer = 0.6
+    // timer = 0.6 + 0.5 = 1.1 > 1.0 → le dégagement se déclenche malgré le
+    // pic de vitesse intermédiaire.
+    expect(detector.update(0.01, center, 0.5)!.type).toBe('nudge');
+  });
+
+  test('nudge strength escalates on repeated failed attempts', () => {
+    const first = detector.update(0.01, center, 1.01);
+    expect(first).toEqual({ type: 'nudge', impulse: { x: 0.08, y: 0.02, z: 0.12 } });
+    const second = detector.update(0.01, center, 1.01);
+    expect(second).toEqual({ type: 'nudge', impulse: { x: 0.14, y: 0.05, z: 0.2 } });
   });
 
   test('reset() clears timer and nudge count', () => {

--- a/packages/game-engine/src/use-cases/DetectStuckBall.ts
+++ b/packages/game-engine/src/use-cases/DetectStuckBall.ts
@@ -3,37 +3,84 @@ export interface StuckBallResult {
   impulse?: { x: number; y: number; z: number };
 }
 
+interface BallPositionXZ {
+  x: number;
+  z?: number;
+}
+
+const SLOW_SPEED_THRESHOLD = 0.02;
+const STUCK_TIMEOUT_S = 1.0;
+const MAX_NUDGES_BEFORE_DRAIN = 3;
+// Rayon (m) en-deçà duquel la balle est considérée "toujours au même endroit".
+// Plus petit qu'un diamètre de balle (0.0295) : un vrai dégagement doit
+// vraiment sortir la balle de la poche, pas juste la faire vibrer dedans.
+const STUCK_RADIUS = 0.012;
+
+// Impulsion appliquée à chaque tentative de dégagement, de plus en plus
+// forte. Certains creux (ex. cibles-vortex profondes) absorbent une simple
+// pichenette sans jamais laisser la balle s'échapper : avant cette escalade,
+// la balle rebondissait indéfiniment dans la poche à vitesse quasi nulle,
+// ce qui pouvait aussi empêcher le minuteur de repartir (cf. ancre position
+// ci-dessous) et la balle restait bloquée pour de bon.
+const NUDGE_IMPULSES: ReadonlyArray<{ x: number; y: number; z: number }> = [
+  { x: 0.08, y: 0.02, z: 0.12 },
+  { x: 0.14, y: 0.05, z: 0.2 },
+  { x: 0.2, y: 0.08, z: 0.3 },
+];
+
 export class StuckBallDetector {
   private timer = 0;
   private nudgeCount = 0;
+  // Point de référence figé dès que la balle ralentit. Tant qu'elle reste
+  // dans STUCK_RADIUS de cette ancre, on continue d'accumuler le minuteur
+  // même si sa vitesse instantanée dépasse ponctuellement le seuil — ce qui
+  // arrive typiquement quand une balle coincée rebondit contre les parois
+  // d'une poche sans jamais en sortir. Un simple contrôle de vitesse remettait
+  // le minuteur à zéro à chaque micro-rebond et empêchait tout dégagement.
+  private anchor: { x: number; z: number } | null = null;
 
   update(
     ballSpeed: number,
-    ballPos: { x: number },
+    ballPos: BallPositionXZ,
     dt: number,
   ): StuckBallResult | null {
-    if (ballSpeed < 0.02) {
-      this.timer += dt;
-      if (this.timer > 1.0) {
+    const posZ = ballPos.z ?? 0;
+
+    if (this.anchor === null) {
+      if (ballSpeed >= SLOW_SPEED_THRESHOLD) return null;
+      this.anchor = { x: ballPos.x, z: posZ };
+      this.timer = dt;
+    } else {
+      const dx = ballPos.x - this.anchor.x;
+      const dz = posZ - this.anchor.z;
+      const driftedAway = Math.sqrt(dx * dx + dz * dz) > STUCK_RADIUS;
+      if (driftedAway && ballSpeed >= SLOW_SPEED_THRESHOLD) {
+        this.anchor = null;
         this.timer = 0;
-        this.nudgeCount++;
-        if (this.nudgeCount >= 3) {
-          this.nudgeCount = 0;
-          return { type: 'force_drain' };
-        }
-        const nudgeX = ballPos.x > 0 ? -0.08 : 0.08;
-        return { type: 'nudge', impulse: { x: nudgeX, y: 0.02, z: 0.12 } };
+        this.nudgeCount = 0;
+        return null;
       }
-      return null;
+      this.timer += dt;
     }
 
+    if (this.timer <= STUCK_TIMEOUT_S) return null;
+
     this.timer = 0;
-    this.nudgeCount = 0;
-    return null;
+    this.nudgeCount++;
+    if (this.nudgeCount >= MAX_NUDGES_BEFORE_DRAIN) {
+      this.nudgeCount = 0;
+      this.anchor = null;
+      return { type: 'force_drain' };
+    }
+
+    const strength = NUDGE_IMPULSES[Math.min(this.nudgeCount - 1, NUDGE_IMPULSES.length - 1)];
+    const nudgeX = ballPos.x > 0 ? -strength.x : strength.x;
+    return { type: 'nudge', impulse: { x: nudgeX, y: strength.y, z: strength.z } };
   }
 
   reset(): void {
     this.timer = 0;
     this.nudgeCount = 0;
+    this.anchor = null;
   }
 }

--- a/packages/maps/strangerthings/layout.ts
+++ b/packages/maps/strangerthings/layout.ts
@@ -89,8 +89,15 @@ export const layout: MapLayout = {
     ball: { x: 0.2355, y: 1.01, z: 0.161 },
     alternateWorld: { x: -0.0225, z: -0.48 },
     alternateWorldImpulse: { x: 0, y: 0, z: 0.055 },
-    normalReturn: { x: -0.0225, z: -0.12 },
-    normalReturnImpulse: { x: 0, y: 0, z: 0.05 },
+    // Retour monde normal : repositionné près du haut du plateau (comme
+    // alternateWorld) plutôt qu'à z=-0.12. À cette hauteur basse, la balle
+    // réapparaissait déjà quasiment au niveau des slingshots/flippers, tombait
+    // pile au centre (x=-0.0225) sans que rien ne puisse la dévier avant le
+    // drain → perte de vie inévitable. En la faisant réapparaître en haut,
+    // elle retraverse bumpers/pop zones/slingshots normalement, comme après
+    // un lancement classique.
+    normalReturn: { x: -0.0225, z: -0.46 },
+    normalReturnImpulse: { x: 0, y: 0, z: 0.06 },
   },
   // Couloir plongeur : géométrie analytique (pas de mesh). Littéraux map.
   shooterLane: {

--- a/packages/maps/zelda/layout.ts
+++ b/packages/maps/zelda/layout.ts
@@ -43,8 +43,13 @@ export const layout: MapLayout = {
     ball: { x: 0.2355, y: 1.01, z: 0.161 },
     alternateWorld: { x: -0.0225, z: -0.48 },
     alternateWorldImpulse: { x: 0, y: 0, z: 0.055 },
-    normalReturn: { x: -0.0225, z: -0.12 },
-    normalReturnImpulse: { x: 0, y: 0, z: 0.05 },
+    // Retour monde normal : repositionné près du haut du plateau (comme
+    // alternateWorld) plutôt qu'à z=-0.12 — même plateau physique que ST
+    // (cf. commentaire en tête de fichier), même bug/fix. À z=-0.12 la balle
+    // réapparaissait déjà au niveau des slingshots/flippers et tombait pile
+    // au centre sans rien pour la dévier avant le drain.
+    normalReturn: { x: -0.0225, z: -0.46 },
+    normalReturnImpulse: { x: 0, y: 0, z: 0.06 },
   },
   shooterLane: {
     xMin: 0.206,


### PR DESCRIPTION
…ints from GameOverlay

The "Reset ball" button has been removed from the display, while the shortcut key 'R' remains active. Additionally, keyboard hints for launching and resetting the ball have been removed to streamline the user interface. This change ensures a cleaner presentation during gameplay, aligning with the intended demo experience.