### PR TITLE
chore: prune code comments to the strict minimum across the app

### DIFF
--- a/apps/backglass/src/components/ErrorBoundary.tsx
+++ b/apps/backglass/src/components/ErrorBoundary.tsx
@@ -1,9 +1,9 @@
 import { Component, type CSSProperties, type ErrorInfo, type ReactNode } from 'react'
 
-const RELOAD_MS = 15_000 // delay before auto-reload after a crash
-const STABLE_MS = 30_000 // page stable for this long → crash loop considered broken
-const MAX_RELOADS = 3 // beyond this: stop reloading, stay on the safety net
-const CRASH_KEY = 'eb_crash_count' // persists ACROSS reloads (sessionStorage)
+const RELOAD_MS = 15_000
+const STABLE_MS = 30_000
+const MAX_RELOADS = 3
+const CRASH_KEY = 'eb_crash_count'
 
 // Inline styles: if the stylesheet itself caused the crash, the safety net
 // stays renderable (no external dependency).
@@ -28,10 +28,6 @@ interface State {
   failed: boolean
 }
 
-// Kiosk safety net: a render crash never shows a white screen. Show a minimal
-// scene, log the stack, and reload the cabinet after 15s (self-recovery
-// without human intervention). Anti-loop: if the crash persists across
-// reloads, stop reloading.
 export default class ErrorBoundary extends Component<Props, State> {
   state: State = { failed: false }
   private timer = 0
@@ -41,32 +37,24 @@ export default class ErrorBoundary extends Component<Props, State> {
     return { failed: true }
   }
 
-  // Page held stable for STABLE_MS → isolated crash, not a loop: reset the
-  // counter so a future incident can reload again.
-  // (Do NOT reset on every mount, otherwise the counter would never survive
-  // a reload and loop detection would be inoperative.)
+  // Reset the counter only after STABLE_MS, not on every mount — otherwise the
+  // counter never survives a reload and loop detection is inoperative.
   componentDidMount() {
     this.resetTimer = window.setTimeout(() => {
       try {
         sessionStorage.removeItem(CRASH_KEY)
-      } catch {
-        /* sessionStorage unavailable (private mode): harmless */
-      }
+      } catch {}
     }, STABLE_MS)
   }
 
   componentDidCatch(error: Error, info: ErrorInfo) {
     console.error('[backglass] render crash', error, info.componentStack)
     if (this.timer) window.clearTimeout(this.timer)
-    // Reloading every 15s forever is worse than a stable fallback screen:
-    // beyond MAX_RELOADS crashes in a row, stop.
     let count = 1
     try {
       count = Number(sessionStorage.getItem(CRASH_KEY) ?? 0) + 1
       sessionStorage.setItem(CRASH_KEY, String(count))
-    } catch {
-      /* sessionStorage unavailable: still reload once */
-    }
+    } catch {}
     if (count <= MAX_RELOADS) {
       this.timer = window.setTimeout(() => window.location.reload(), RELOAD_MS)
     }

--- a/apps/backglass/src/components/HallOfFame.tsx
+++ b/apps/backglass/src/components/HallOfFame.tsx
@@ -5,7 +5,7 @@ import type { Reactor } from '@/hooks/useIngameReactor'
 interface HallOfFameProps {
   entries: LeaderboardEntry[]
   highlightRank?: number
-  inverted?: boolean // alternate world: 3D flip
+  inverted?: boolean
   reactor?: Reactor
 }
 
@@ -41,7 +41,7 @@ export default function HallOfFame({
       if (r.kind === 'event' && r.label.startsWith('DROP') && rootRef.current) {
         const el = rootRef.current
         el.classList.remove('hof-shake')
-        void el.offsetWidth // force reflow → restarts the shake animation
+        void el.offsetWidth
         el.classList.add('hof-shake')
       }
     })
@@ -55,7 +55,6 @@ export default function HallOfFame({
         </h2>
 
         <div className="hof-list" style={{ height: SLOTS * ROW_H }}>
-          {/* ghost rows for empty slots */}
           {slots.map((rank) =>
             byRank.has(rank) ? null : (
               <div
@@ -71,7 +70,6 @@ export default function HallOfFame({
             ),
           )}
 
-          {/* real entries, positioned by rank (slides on reorder) */}
           {entries.map((e) => {
             const medal = e.rank <= 3 ? MEDAL[e.rank - 1] : null
             const hot = highlightRank === e.rank

--- a/apps/backglass/src/components/QrSlot.tsx
+++ b/apps/backglass/src/components/QrSlot.tsx
@@ -1,8 +1,7 @@
 interface QrSlotProps {
-  url?: string // future wiring (website feature)
+  url?: string
 }
 
-// Placeholder: NO real QR lib. Decorative pattern + invitation.
 export default function QrSlot({ url }: QrSlotProps) {
   void url
   return (

--- a/apps/backglass/src/components/ReactorFx.tsx
+++ b/apps/backglass/src/components/ReactorFx.tsx
@@ -6,7 +6,6 @@ interface ReactorFxProps {
   stageRef: RefObject<HTMLElement | null>
 }
 
-// Full-screen effects driven by the reactor (direct DOM, no re-render).
 export default function ReactorFx({ reactor, stageRef }: ReactorFxProps) {
   const portalRef = useRef<HTMLDivElement>(null)
 
@@ -15,7 +14,7 @@ export default function ReactorFx({ reactor, stageRef }: ReactorFxProps) {
     const replay = (el: HTMLElement | null, cls: string, ms: number) => {
       if (!el) return
       el.classList.remove(cls)
-      void el.offsetWidth // force reflow so the animation restarts
+      void el.offsetWidth
       el.classList.add(cls)
       const id = window.setTimeout(() => {
         handles.delete(id)
@@ -28,7 +27,6 @@ export default function ReactorFx({ reactor, stageRef }: ReactorFxProps) {
       if (r.kind === 'event' && r.label === 'PORTAL') {
         replay(portalRef.current, 'portal-wave-on', 1100)
       } else if (r.kind === 'gameStart') {
-        // wake-up: zones light up in sequence
         replay(stageRef.current, 'stage-waking', 1300)
       } else if (r.kind === 'lifeLost') {
         replay(stageRef.current, 'stage-dimmed', 1600)

--- a/apps/backglass/src/components/StatsBanner.tsx
+++ b/apps/backglass/src/components/StatsBanner.tsx
@@ -11,15 +11,12 @@ interface StatsBannerProps {
 
 const ROTATE_MS = 5000
 
-// Defense in depth: a kiosk banner NEVER crashes on a missing stat
-// (undefined/null → 0).
 function fmt(n: number | undefined | null): string {
   return (n ?? 0).toLocaleString('fr-FR')
 }
 
 function buildSlides(stats: GlobalStats, entries: LeaderboardEntry[]): string[] {
   const slides: string[] = [`PARTIES JOUÉES : ${fmt(stats.totalGames)}`]
-  // Totals per counter (label will come from the map; key for now).
   for (const t of stats.totals) {
     slides.push(`${t.label.toUpperCase()} : ${fmt(t.value)}`)
   }
@@ -42,7 +39,6 @@ export default function StatsBanner({ stats, entries, reactor }: StatsBannerProp
   const slides = buildSlides(stats, entries)
   const [idx, setIdx] = useState(0)
   const bannerRef = useRef<HTMLDivElement>(null)
-  // "SCORE À BATTRE" / invitation = always the last slide
   const toBeatIdx = slides.length - 1
 
   useEffect(() => {
@@ -56,7 +52,7 @@ export default function StatsBanner({ stats, entries, reactor }: StatsBannerProp
     if (!reactor) return
     return reactor.on((r) => {
       if (r.kind === 'multi') {
-        setIdx(toBeatIdx) // jump to SCORE À BATTRE (pressure!)
+        setIdx(toBeatIdx)
         const el = bannerRef.current
         if (el) {
           el.classList.remove('banner-gold')

--- a/apps/backglass/src/components/VhsGlitch.tsx
+++ b/apps/backglass/src/components/VhsGlitch.tsx
@@ -5,8 +5,6 @@ interface VhsGlitchProps {
   className?: string
 }
 
-// Reusable transition wrapper: scanlines + tracking band + brief RGB split
-// on entry. Used by every takeover.
 export default function VhsGlitch({ children, className }: VhsGlitchProps) {
   return (
     <div className={`vhs ${className ?? ''}`}>

--- a/apps/backglass/src/components/takeovers/CinematicTakeover.tsx
+++ b/apps/backglass/src/components/takeovers/CinematicTakeover.tsx
@@ -12,8 +12,6 @@ interface Props {
 
 export default function CinematicTakeover({ clip, payload }: Props) {
   const { renderMapTakeover } = useMapContent()
-  // hall_of_fame: CORE clip — the backglass knows the rank, fanfare only
-  // if deserved.
   if (clip === 'hall_of_fame') {
     if (payload && payload.rank <= 10) return <HighScoreTakeover payload={payload} />
     if (payload) return <RecapTakeover payload={payload} />
@@ -26,11 +24,9 @@ export default function CinematicTakeover({ clip, payload }: Props) {
     )
   }
 
-  // Map-specific takeover (VhsGlitch injected → no map→app dependency).
   const mapNode = renderMapTakeover(clip, { payload, Vhs: VhsGlitch })
   if (mapNode) return <>{mapNode}</>
 
-  // Clip without a dedicated takeover: neutral label, never a blank screen or a crash.
   return (
     <VhsGlitch className="tk-attract">
       <div className="tk-center">

--- a/apps/backglass/src/components/takeovers/RecapTakeover.tsx
+++ b/apps/backglass/src/components/takeovers/RecapTakeover.tsx
@@ -11,8 +11,6 @@ export default function RecapTakeover({ payload }: Props) {
   const s = payload.stats
   const qualifying = payload.rank <= 10
 
-  // Generic counters: labels come from the map (counterLabels), values from
-  // GameStats.counters. The core has no hardcoded ST keys.
   const counterCells = Object.entries(s.counters).map(([id, value]) => ({
     label: counterLabels[id] ?? id.toUpperCase(),
     value,

--- a/apps/backglass/src/hooks/backglassFetch.ts
+++ b/apps/backglass/src/hooks/backglassFetch.ts
@@ -1,8 +1,5 @@
 import type { LeaderboardEntry, GlobalStats } from '@pinball/shared-types'
 
-// Shape predicates: kiosk-safe — a malformed response must never replace a
-// valid state. Status + shape are validated before accepting.
-
 export function isLeaderboardShape(x: unknown): x is LeaderboardEntry[] {
   return Array.isArray(x)
 }
@@ -17,9 +14,6 @@ type FetchImpl = (url: string) => Promise<{
   json: () => Promise<unknown>
 }>
 
-// Generic fetch validated by a type guard. Rejects (Error) on a non-OK status
-// or invalid shape; returns the typed data otherwise. fetch is injectable
-// for tests.
 export async function safeFetch<T>(
   url: string,
   guard: (x: unknown) => x is T,

--- a/apps/backglass/src/hooks/heatModel.ts
+++ b/apps/backglass/src/hooks/heatModel.ts
@@ -1,25 +1,14 @@
-// ── Backglass reactor "heat" model ─────────────────────────────────────────
-// Heat math only (continuous decay, clamp, hit gain, FEVER lock, rounding) —
-// no React, no DOM. The `useIngameReactor` rAF loop just APPLIES the computed
-// value to the target element (writes `--heat`).
-
 export const clamp = (n: number, lo: number, hi: number) =>
   Math.min(hi, Math.max(lo, n))
 
 export const HEAT_DECAY = 0.5 // per second
 export const HIT_GAIN = 0.3
 
-// Hit intensity derived from the score delta, clamped to [0.1, 1].
 export const hitIntensity = (delta: number) => clamp(delta / 500, 0.1, 1)
 
-// Heat after a hit of the given intensity (capped at 1).
 export const heatAfterHit = (heat: number, intensity: number) =>
   Math.min(1, heat + intensity * HIT_GAIN)
 
-// Next heat value for one rAF loop frame.
-//  - heatLock (FEVER): locked at 1, no decay;
-//  - dtSeconds null (1st frame): no decay, heat unchanged;
-//  - otherwise: linear decay HEAT_DECAY/s, floored at 0.
 export const nextHeat = (
   heat: number,
   dtSeconds: number | null,
@@ -30,5 +19,4 @@ export const nextHeat = (
   return Math.max(0, heat - HEAT_DECAY * dtSeconds)
 }
 
-// Value written to `--heat`: rounded to 2 decimals.
 export const roundedHeat = (heat: number) => Math.round(heat * 100) / 100

--- a/apps/backglass/src/hooks/takeoverStack.ts
+++ b/apps/backglass/src/hooks/takeoverStack.ts
@@ -1,16 +1,3 @@
-// ── Backglass takeover state machine ────────────────────────────────────────
-// Decides which scene to display:
-//   - a STACK of candidate scenes, each with a PRIORITY and an expiration,
-//   - purge of expired scenes + chaining (`followUp`),
-//   - temporary highlight of a leaderboard row (high-score),
-//   - attract mode after an idle period,
-//   - active scene = highest priority.
-//
-// This class knows NEITHER React NOR Socket.io — `now` and callbacks are
-// injected, so it is unit-testable. The hook (useBackglassTakeover.ts) is a
-// thin orchestrator around it.
-// ────────────────────────────────────────────────────────────────────────────
-
 import type { GameOver } from '@pinball/shared-types';
 
 export type TakeoverScene =
@@ -20,16 +7,12 @@ export type TakeoverScene =
   | 'ATTRACT'
   | 'CINEMATIC';
 
-/** Scene actually displayed by the UI (result exposed to the component). */
 export interface Takeover {
   scene: TakeoverScene;
   payload?: GameOver & { rank: number };
   clip?: string;
 }
 
-// Chaining: the next scene is only pushed when the current one expires (its
-// duration starts then). The priority-stack model preempts but does not
-// sequence — followUp adds sequencing.
 export interface FollowUp {
   scene: TakeoverScene;
   durationMs: number;
@@ -37,7 +20,6 @@ export interface FollowUp {
   payload?: GameOver & { rank: number };
 }
 
-/** A candidate scene in the stack (with priority + expiration timestamp). */
 export interface StackEntry {
   scene: TakeoverScene;
   priority: number;
@@ -47,17 +29,12 @@ export interface StackEntry {
   followUp?: FollowUp;
 }
 
-/** Dependencies injected into `tick` (keep the class pure: no direct access). */
 export interface TakeoverTickDeps {
-  /** true if this clip must delay the hall of fame 3D flip (e.g. portal_swallow). */
   holdsHallFlip: (clip: string) => boolean;
-  /** Name to display on the Joyce wall in attract mode (leaderboard #1), or null. */
   attractJoyceName: () => string | null;
-  /** Emits a Joyce signal (side effect delegated to the hook). */
   onJoyce: (text: string) => void;
 }
 
-/** Derived state returned on each tick (consumed by the hook for its setState). */
 export interface TakeoverTickResult {
   top: StackEntry | null;
   highlightRank: number | undefined;
@@ -75,37 +52,23 @@ export class TakeoverStack {
   private highlightUntil = 0;
   private highlightRank: number | undefined = undefined;
 
-  /** Call once at startup: initializes the idle clocks. */
   start(now: number): void {
     this.lastActivity = now;
     this.lastJoyceIdle = now;
   }
 
-  /** Signals game activity → pushes back the attract mode trigger. */
   markActivity(now: number): void {
     this.lastActivity = now;
   }
 
-  /** Pushes a candidate scene (the highest priority wins on the next tick). */
   push(entry: StackEntry): void {
     this.stack.push(entry);
   }
 
-  /**
-   * Advances the machine to time `now`:
-   *  1. purge expired scenes,
-   *  2. chain the `followUp`s of scenes that just expired,
-   *  3. manage the high-score row highlight,
-   *  4. toggle attract mode based on idleness,
-   *  5. return the active scene (max priority) + derived state.
-   */
   tick(now: number, deps: TakeoverTickDeps): TakeoverTickResult {
-    // 1. purge expired scenes
     const expiring = this.stack.filter((e) => e.expiresAt <= now);
     this.stack = this.stack.filter((e) => e.expiresAt > now);
 
-    // 2. chaining: an expired scene with a followUp pushes the next one NOW
-    //    (its duration starts here, no longer masked).
     for (const e of expiring) {
       if (e.followUp) {
         this.stack.push({
@@ -117,9 +80,6 @@ export class TakeoverStack {
       }
     }
 
-    // 3. a HIGH_SCORE that just expired → highlight the row. If a followUp
-    //    (RECAP) comes next, extend the highlight so it survives the recap
-    //    and stays visible on the base scene.
     const highExpired = expiring.find((e) => e.scene === 'HIGH_SCORE');
     if (highExpired?.payload) {
       this.highlightRank = highExpired.payload.rank;
@@ -131,13 +91,11 @@ export class TakeoverStack {
       this.highlightRank = undefined;
     }
 
-    // 4. ATTRACT: no activity for ATTRACT_IDLE_MS
     const idle = now - this.lastActivity > ATTRACT_IDLE_MS;
     const hasReal = this.stack.some((e) => e.scene !== 'ATTRACT');
     this.stack = this.stack.filter((e) => e.scene !== 'ATTRACT');
     if (idle && !hasReal) {
       this.stack.push({ scene: 'ATTRACT', priority: 10, expiresAt: Infinity });
-      // leaderboard #1's name on the Joyce wall, periodically
       if (now - this.lastJoyceIdle > JOYCE_IDLE_MS) {
         this.lastJoyceIdle = now;
         const name = deps.attractJoyceName();
@@ -145,13 +103,11 @@ export class TakeoverStack {
       }
     }
 
-    // 5. active takeover = highest priority
     const top = this.stack.reduce<StackEntry | null>(
       (best, e) => (!best || e.priority > best.priority ? e : best),
       null,
     );
 
-    // Clip delaying the hall of fame 3D flip (e.g. portal_swallow).
     const holdHallFlip = this.stack.some(
       (e) => e.scene === 'CINEMATIC' && e.clip != null && deps.holdsHallFlip(e.clip),
     );

--- a/apps/backglass/src/hooks/useBackglassData.ts
+++ b/apps/backglass/src/hooks/useBackglassData.ts
@@ -22,14 +22,9 @@ export function useBackglassData() {
   const [stats, setStats] = useState<GlobalStats>(EMPTY_STATS)
   const [connected, setConnected] = useState(false)
   const [mapId, setMapId] = useState<string>(FORCED_MAP_ID ?? DEFAULT_MAP_ID)
-  // Ref to the current map: the useEffect([], []) closures always read the
-  // fresh value without being recreated.
   const mapIdRef = useRef<string>(FORCED_MAP_ID ?? DEFAULT_MAP_ID)
 
   useEffect(() => {
-    // Kiosk: an error response (JSON {error}, 5xx HTML, disconnect) must
-    // NEVER replace a valid state. Status + shape are validated, otherwise
-    // the previous data (or EMPTY_STATS) is kept.
     const fetchLeaderboard = () =>
       safeFetch(`/api/leaderboard?mapId=${mapIdRef.current}`, isLeaderboardShape)
         .then(setEntries)
@@ -48,33 +43,21 @@ export function useBackglassData() {
 
     socket.on('connect', () => setConnected(true))
     socket.on('disconnect', () => setConnected(false))
-    // leaderboard:refresh arrives after a game:over on any map. Re-fetch from
-    // the API with the current mapId to show only the active map's scores
-    // (the event payload is ignored).
     socket.on('leaderboard:refresh', () => {
       fetchLeaderboard()
     })
-    // the aggregates changed: re-fetch /api/stats
     socket.on('game:over', () => {
       fetchStats()
     })
-    // Active map sync (emitted on connect + on every change).
-    // Ignored when NEXT_PUBLIC_MAP_ID is forced (Fliphetic single-map prod).
     socket.on('map:selected', ({ mapId: id }) => {
       if (!FORCED_MAP_ID) {
         mapIdRef.current = id
         setMapId(id)
-        // Immediate re-fetch with the new map: the board and stats must
-        // switch right away, without waiting for the next poll.
         fetchLeaderboard()
         fetchStats()
       }
     })
 
-    // Claims arrive async (phone, after the game, from any cabinet): poll
-    // periodically to surface claimed names. The leaderboard:refresh socket
-    // event covers the immediate post-local-game refresh; the poll catches
-    // late claims.
     const poll = window.setInterval(() => {
       fetchLeaderboard()
     }, 30_000)

--- a/apps/backglass/src/hooks/useBackglassTakeover.ts
+++ b/apps/backglass/src/hooks/useBackglassTakeover.ts
@@ -6,8 +6,6 @@ import { useMapContent } from '@/map/content'
 import { TakeoverStack } from './takeoverStack'
 import type { Takeover } from './takeoverStack'
 
-// Re-export for existing consumers (the types live in takeoverStack.ts,
-// next to the state machine).
 export type { Takeover, TakeoverScene } from './takeoverStack'
 
 interface JoyceSignal {
@@ -21,11 +19,9 @@ interface TakeoverState {
   highlightRank: number | undefined
   agitation: number
   joyce: JoyceSignal
-  // true while a portal_swallow plays → the hall of fame 3D flip is delayed
-  // until the clip ends (in sync with the playfield switch).
   holdHallFlip: boolean
   fever: boolean
-  goldWaveId: number // incremented → replays the gold wave (5k/15k milestones)
+  goldWaveId: number
 }
 
 const TICK_MS = 250
@@ -50,9 +46,6 @@ function agitationAt(elapsed: number): number {
 
 export function useBackglassTakeover(entries: LeaderboardEntry[], socket: PinballSocket) {
   const { clipBehavior, eventTakeovers, clips } = useMapContent()
-  // Refs to the map data: the useEffect([], []) closure always reads the
-  // current values without being recreated. key={mapId} on the Stage forces a
-  // full remount when the map changes → refs cleanly reinitialized.
   const clipBehaviorRef = useRef(clipBehavior)
   clipBehaviorRef.current = clipBehavior
   const eventTakeoversRef = useRef(eventTakeovers)
@@ -63,15 +56,10 @@ export function useBackglassTakeover(entries: LeaderboardEntry[], socket: Pinbal
   const entriesRef = useRef(entries)
   entriesRef.current = entries
 
-  // The state machine (scene stack) — all decision logic lives there.
   const stackRef = useRef(new TakeoverStack())
-  // Derived signals managed by the hook (outside the stack's responsibility):
-  // alternate world, agitation, Joyce wall, fever, gold wave, last game:over.
   const alternateWorldRef = useRef(false)
   const agitationStartRef = useRef(-AGITATION_MS)
   const joyceRef = useRef<JoyceSignal>({ text: null, id: 0 })
-  // Last complete game:over (with stats + rank) — feeds the hall_of_fame clip
-  // (HighScore/Recap), which does not receive it via dmd:display.
   const lastGameOverRef = useRef<(GameOver & { rank: number }) | null>(null)
   const feverRef = useRef(false)
   const goldWaveRef = useRef(0)
@@ -112,9 +100,6 @@ export function useBackglassTakeover(entries: LeaderboardEntry[], socket: Pinbal
       lastGameOverRef.current = payload
 
       if (isHigh) {
-        // HIGH_SCORE then CHAINED RECAP: the recap only starts when the high
-        // score expires (followUp), not masked in parallel.
-        // The payload (stats) travels in the entry → not clobbered by an event.
         stack.push({
           scene: 'HIGH_SCORE',
           priority: 100,
@@ -139,9 +124,7 @@ export function useBackglassTakeover(entries: LeaderboardEntry[], socket: Pinbal
       alternateWorldRef.current = d.alternateWorld ?? false
       if ('mapState' in d) feverRef.current = mapStateFlag(d.mapState, 'fever')
       if (d.mode === 'CINEMATIC') {
-        // Kiosk guard: malformed server event without a clip. An unknown clip
-        // no longer crashes (clipShowMs guarantees a number → never NaN on
-        // expiresAt): it hits the default branch → generic scene.
+        // Guard a malformed server event with no clip (would produce NaN expiresAt).
         if (d.clip == null) return
         markActivity()
         const now = performance.now()
@@ -153,16 +136,10 @@ export function useBackglassTakeover(entries: LeaderboardEntry[], socket: Pinbal
             priority: 110,
             expiresAt: now + durationMs,
             clip,
-            // hall_of_fame has no stats via dmd:display: rewire the last
-            // complete game:over (HighScore/Recap).
             payload: isHall ? lastGameOverRef.current ?? undefined : undefined,
           })
-        // Data-driven dispatch provided by the map (joyce/wave/fever/takeover).
-        // hall_of_fame + unknown clips: generic takeover via clipShowMs.
         const b = clipBehaviorRef.current[clip]
         if (b?.goldWave) goldWaveRef.current += 1
-        // fever starts with the clip: during CINEMATIC no SCORE display
-        // (fever carrier) arrives, so activate it here without delay.
         if (b?.fever) feverRef.current = true
         if (b?.joyce) pushJoyce(typeof b.joyce === 'function' ? b.joyce(d.value) : b.joyce)
         if (!b?.noTakeover) pushTk(b?.takeoverMs ?? clipShowMs(clipsRef.current, clip))
@@ -171,7 +148,6 @@ export function useBackglassTakeover(entries: LeaderboardEntry[], socket: Pinbal
       if (d.mode === 'EVENT') {
         markActivity()
         agitationStartRef.current = performance.now()
-        // Event → map takeover (label → scene), data-driven.
         const ev = d.label ? eventTakeoversRef.current[d.label] : undefined
         if (ev) {
           stack.push({
@@ -191,9 +167,6 @@ export function useBackglassTakeover(entries: LeaderboardEntry[], socket: Pinbal
 
     const interval = window.setInterval(() => {
       const now = performance.now()
-      // All decision logic (purge / chaining / attract / priority) is delegated
-      // to the state machine. The hook only feeds it the time and some map
-      // data accessors, then projects the result into state.
       const { top, highlightRank, holdHallFlip } = stack.tick(now, {
         holdsHallFlip: (clip) => clipBehaviorRef.current[clip]?.holdsHallFlip ?? false,
         attractJoyceName: () => entriesRef.current.find((e) => e.rank === 1)?.name ?? null,
@@ -216,8 +189,7 @@ export function useBackglassTakeover(entries: LeaderboardEntry[], socket: Pinbal
 
     return () => {
       window.clearInterval(interval)
-      // Shared socket (lifted into BackglassStage): remove OUR handlers
-      // without disconnecting it — the caller owns its lifecycle.
+      // Shared socket: remove our handlers but do not disconnect (caller owns it).
       socket.off('game:start', markActivity)
       socket.off('score:update', markActivity)
       socket.off('game:over', onGameOver)

--- a/apps/backglass/src/hooks/useIngameReactor.ts
+++ b/apps/backglass/src/hooks/useIngameReactor.ts
@@ -14,9 +14,7 @@ export type Reaction =
 export interface Reactor {
   on: (cb: (r: Reaction) => void) => () => void
   getHeat: () => number
-  // Suspends reactions/heat (during a full-screen cinematic clip).
   setSuspended: (suspended: boolean) => void
-  // Locks heat at 1 (FEVER state: permanent blaze).
   setHeatLock: (locked: boolean) => void
 }
 
@@ -91,8 +89,6 @@ export function useIngameReactor(
     }
     socket.on('dmd:display', onDmdDisplay)
 
-    // Heat loop: continuous decay, direct --heat write (no re-render).
-    // Only write when the rounded value changes → 0 style invalidations at rest.
     let raf = 0
     let last: number | null = null
     let written = -1
@@ -111,8 +107,7 @@ export function useIngameReactor(
 
     return () => {
       cancelAnimationFrame(raf)
-      // Shared socket (lifted into BackglassStage): remove OUR handlers
-      // without disconnecting it — the caller owns its lifecycle.
+      // Shared socket: remove our handlers but do not disconnect (caller owns it).
       socket.off('game:start', onGameStart)
       socket.off('dmd:display', onDmdDisplay)
     }

--- a/apps/backglass/src/map/content.ts
+++ b/apps/backglass/src/map/content.ts
@@ -3,9 +3,6 @@ import { getBackglassContent } from '@pinball/maps/backglass'
 
 export type BackglassContent = NonNullable<ReturnType<typeof getBackglassContent>>
 
-// Fallback value: no-op for every field (the page gates on content presence
-// before rendering the Stage, so this fallback is never rendered in practice —
-// it avoids crashes if a consumer reads the context outside a Provider).
 export const EMPTY_CONTENT: BackglassContent = {
   JoyceWall: () => null,
   SideArt: () => null,
@@ -18,11 +15,6 @@ export const EMPTY_CONTENT: BackglassContent = {
   backglassThemeAlternate: {},
 } as unknown as BackglassContent
 
-// React context for the active map's backglass content.
-// Provided by BackglassPage (via MapContentProvider) and consumed by hooks and
-// child components via useMapContent(). Enables dynamic map switching without
-// a page reload (key={mapId} on the Stage forces a clean remount when the map
-// changes).
 const MapContentCtx = createContext<BackglassContent>(EMPTY_CONTENT)
 
 export const MapContentProvider = MapContentCtx.Provider

--- a/apps/backglass/src/pages/index.tsx
+++ b/apps/backglass/src/pages/index.tsx
@@ -14,9 +14,6 @@ import RecapTakeover from '@/components/takeovers/RecapTakeover'
 import AttractScene from '@/components/takeovers/AttractScene'
 import CinematicTakeover from '@/components/takeovers/CinematicTakeover'
 
-// BackglassPage: called at the root, owns the mapId lifecycle.
-// The map selection arrives via the socket (useBackglassData) and triggers a
-// clean Stage remount (key={mapId}) with the right map content.
 export default function BackglassPage() {
   const { entries, stats, connected, mapId } = useBackglassData()
   const content = getBackglassContent(mapId) ?? null
@@ -31,8 +28,8 @@ export default function BackglassPage() {
 
   return (
     <MapContentProvider value={content}>
-      {/* key={mapId}: remounts the whole Stage (hooks, takeover socket, art)
-          on every map change → no residual state from the previous map. */}
+      {/* key={mapId} remounts the Stage on map change so no state from the
+          previous map survives. */}
       <BackglassStage key={mapId} entries={entries} stats={stats} connected={connected} />
     </MapContentProvider>
   )
@@ -46,10 +43,6 @@ interface StageProps {
 
 function BackglassStage({ entries, stats, connected }: StageProps) {
   const { JoyceWall, SideArt, backglassTheme, backglassThemeAlternate } = useMapContent()
-  // ONE Socket.io connection for the whole Stage, shared between the takeover
-  // and reactor hooks. Created once (useState initializer), disconnected on
-  // unmount. key={mapId} on the Stage guarantees a fresh socket on every map
-  // change.
   const [socket] = useState<PinballSocket>(() => createPinballSocket())
   useEffect(() => {
     return () => {
@@ -63,18 +56,14 @@ function BackglassStage({ entries, stats, connected }: StageProps) {
   const goldWaveRef = useRef<HTMLDivElement>(null)
   const reactor = useIngameReactor(stageRef, socket)
 
-  // In-game reactor suspended during a cinematic clip (it must not paint
-  // heat/hits over the scene).
   useEffect(() => {
     reactor.setSuspended(takeover?.scene === 'CINEMATIC')
   }, [reactor, takeover?.scene])
 
-  // FEVER: heat locked at 1 (permanent blaze) while the state lasts.
   useEffect(() => {
     reactor.setHeatLock(fever)
   }, [reactor, fever])
 
-  // Gold wave (5k/15k milestones) — replays the animation on each increment.
   useEffect(() => {
     if (goldWaveId === 0) return
     const el = goldWaveRef.current
@@ -84,8 +73,8 @@ function BackglassStage({ entries, stats, connected }: StageProps) {
     el.classList.add('gold-wave-on')
   }, [goldWaveId])
 
-  // Scale-to-fit: the cabinet is exactly 1920×1080 (scale 1), but adapt to
-  // smaller dev windows without breaking the fixed layout.
+  // Fixed layout is authored for a 1920×1080 cabinet (scale 1); scale down to
+  // fit smaller dev windows.
   useEffect(() => {
     const fit = () => {
       const s = Math.min(window.innerWidth / 1920, window.innerHeight / 1080)
@@ -98,8 +87,6 @@ function BackglassStage({ entries, stats, connected }: StageProps) {
 
   const sideAgitation = alternateWorld ? 1 : Math.max(0.15, agitation)
 
-  // Map theme tokens set as custom properties (base + alternate world
-  // overrides). The backglass re-renders freely (no 3D scene).
   const themeStyle = {
     ...backglassTheme,
     ...(alternateWorld ? backglassThemeAlternate : {}),

--- a/apps/dmd/src/components/DmdCanvas.tsx
+++ b/apps/dmd/src/components/DmdCanvas.tsx
@@ -9,9 +9,6 @@ const GLITCH_MS = 350
 interface Props {
   display: DmdDisplay
   alternateWorld: boolean
-  /** DMD content of the active map (provided by the page, derived from mapId).
-   *  The component is mounted with key={mapId}: the LAYOUTS/PALETTE/BURST
-   *  constants are recomputed on each remount, never during the component's life. */
   mapDmdContent: DmdMapContent
 }
 
@@ -22,10 +19,6 @@ const canvasStyle: CSSProperties = {
   imageRendering: 'pixelated',
 }
 
-// rAF loop reading refs: ZERO re-renders per frame (project rule — a re-render
-// would unmount/remount the canvas). The LAYOUTS, ALTERNATE_PALETTE, BURST_MS
-// constants are computed once per mount (the page uses key={mapId} to force a
-// clean remount on every map change).
 export default function DmdCanvas({ display, alternateWorld, mapDmdContent }: Props) {
   const LAYOUTS = useMemo(() => makeLayouts(mapDmdContent), [mapDmdContent])
   const NORMAL_PALETTE = useMemo(
@@ -64,9 +57,8 @@ export default function DmdCanvas({ display, alternateWorld, mapDmdContent }: Pr
       const now = performance.now()
       const d = displayRef.current
 
-      // Effect triggers on mode OR clip change (two consecutive CINEMATIC
-      // clips keep mode='CINEMATIC' → the clock must still reset for the
-      // new clip).
+      // Reset on clip change too: two consecutive CINEMATIC clips keep
+      // mode='CINEMATIC', so mode-only detection would miss the clip switch.
       const clipNow = d.mode === 'CINEMATIC' ? d.clip : undefined
       if (d.mode !== prevMode || clipNow !== prevClip) {
         modeStartedAt = now
@@ -77,14 +69,12 @@ export default function DmdCanvas({ display, alternateWorld, mapDmdContent }: Pr
       }
 
       const cinematic = d.mode === 'CINEMATIC'
-      // CINEMATIC: clock relative to the mode's arrival (clip frames).
       const clock = cinematic ? now - modeStartedAt : now
 
       renderer.setPalette(alternateWorldRef.current ? ALTERNATE_PALETTE : NORMAL_PALETTE)
       renderer.clearGrid()
       LAYOUTS[d.mode](renderer.grid, d, clock)
       if (alternateWorldRef.current) rain.drawBackground(renderer.grid)
-      // Glitch/burst do NOT apply during a clip (it stands on its own).
       if (!cinematic && now < glitchUntil) {
         applyGlitch(renderer.grid, GRID_W, GRID_H, (glitchUntil - now) / GLITCH_MS)
       }

--- a/apps/dmd/src/components/NeonBand.tsx
+++ b/apps/dmd/src/components/NeonBand.tsx
@@ -3,15 +3,12 @@ import type { CSSProperties } from 'react'
 interface Props {
   text: string
   position: 'top' | 'bottom'
-  /** Neon color of the band. Default: ST red #E71D23. */
   color?: string
 }
 
-// Pure-CSS decorative band — color driven by the map via the `color` prop.
 export default function NeonBand({ text, position, color = '#E71D23' }: Props) {
   const isTop = position === 'top'
 
-  // Dimmed halo color (dark variant for the drop shadow + background).
   const hexToRgba = (hex: string, a: number) => {
     const r = parseInt(hex.slice(1, 3), 16)
     const g = parseInt(hex.slice(3, 5), 16)

--- a/apps/dmd/src/dmd/mapContent.ts
+++ b/apps/dmd/src/dmd/mapContent.ts
@@ -2,9 +2,6 @@ import type { DmdMapContent } from '@pinball/dmd-core'
 import { DEFAULT_MAP_ID } from '@pinball/shared-types'
 import { getDmdContent } from '@pinball/maps/dmd'
 
-// Resolves the active map's DMD content (build-time via NEXT_PUBLIC_MAP_ID)
-// through the registry — the app never imports @pinball/map-* directly.
-// A map without DMD content → generic engine only.
 const MAP_ID = process.env.NEXT_PUBLIC_MAP_ID ?? DEFAULT_MAP_ID
 
 export const mapDmdContent: DmdMapContent = getDmdContent(MAP_ID) ?? {}

--- a/apps/dmd/src/hooks/useDmdState.ts
+++ b/apps/dmd/src/hooks/useDmdState.ts
@@ -7,9 +7,6 @@ import { DEFAULT_MAP_ID } from '@pinball/shared-types';
 
 const INTRO: DmdDisplay = { mode: 'INTRO', player: '—', alternateWorld: false };
 
-// If NEXT_PUBLIC_MAP_ID is forced (Fliphetic single-map prod), use it as the
-// initial value and never change it (the playfield selector is hidden in that
-// case, so no map:selected will ever arrive).
 const FORCED_MAP_ID = process.env.NEXT_PUBLIC_MAP_ID;
 
 export function useDmdState() {
@@ -25,8 +22,6 @@ export function useDmdState() {
     socket.on('connect', () => setConnected(true));
     socket.on('disconnect', () => setConnected(false));
     socket.on('dmd:display', (data) => setDisplay(data));
-    // Dynamic map sync: emitted by the server on connect (current state) then
-    // on every selection. Ignored when NEXT_PUBLIC_MAP_ID is forced.
     socket.on('map:selected', ({ mapId: id }) => {
       if (!FORCED_MAP_ID) setMapId(id);
     });
@@ -36,7 +31,6 @@ export function useDmdState() {
     };
   }, []);
 
-  // Derived from the last received display — state-driven, no separate event.
   const alternateWorld = display.alternateWorld;
 
   return { display, alternateWorld, connected, mapId };

--- a/apps/dmd/src/pages/index.tsx
+++ b/apps/dmd/src/pages/index.tsx
@@ -107,7 +107,6 @@ function renderDisplay(d: DmdDisplay): ReactElement {
       )
 
     case 'CINEMATIC':
-      // No-op placeholder: real clip rendering is done by AsciiClipPlayer.
       return (
         <div className="flex flex-col items-center gap-4">
           <div className="text-6xl font-mono font-bold tabular-nums">
@@ -128,17 +127,11 @@ export default function ScoreboardPage() {
   const router = useRouter()
   const { display, alternateWorld, connected, mapId } = useDmdState()
 
-  // Display name of the active map (top band). Falls back to the uppercased
-  // id if the map is not in AVAILABLE_MAPS (unknown map in dev).
   const mapName =
     AVAILABLE_MAPS.find((m) => m.id === mapId)?.name ?? mapId.toUpperCase()
 
-  // DMD content of the active map. key={mapId} on DmdCanvas forces a clean
-  // remount (closes the previous rAF loop, recreates LAYOUTS/PALETTE/BURST).
   const mapDmdContent = getDmdContent(mapId) ?? {}
 
-  // ?flat: legacy flat JSX rendering (debug). Wait for router.isReady to
-  // avoid mounting the canvas then switching to flat.
   if (!router.isReady) {
     return <main style={{ minHeight: '100vh', background: '#000' }} />
   }

--- a/apps/input-bridge/src/dispatch.ts
+++ b/apps/input-bridge/src/dispatch.ts
@@ -1,19 +1,12 @@
 import type { ButtonId, ButtonAction } from '@pinball/shared-types';
 import { parseLine } from './parser';
 
-// Pure line → effects mapping via a `BridgeEmitter` port. No socket dependency
-// here: `handleLine` parses (parser.ts) then dispatches to the injected
-// emitter — testable without opening a socket. The real socket adapter is
-// `createSocketEmitter` (instantiated by index.ts).
-
 export interface BridgeEmitter {
   button(id: ButtonId, action: ButtonAction): void;
   tilt(): void;
   sensor(id: string, value: number): void;
 }
 
-// Structural: only the ability to emit `input:*` events is required, so the
-// adapter is decoupled from a concrete socket.io instance.
 export interface InputSocket {
   emit(event: 'input:button', data: { id: ButtonId; action: ButtonAction }): unknown;
   emit(event: 'input:tilt', data: { state: 'TRIGGERED' }): unknown;
@@ -51,8 +44,6 @@ export function handleLine(raw: string, emitter: BridgeEmitter): void {
       emitter.sensor(parsed.id, parsed.value);
       return;
     case 'unknown':
-      // Unrecognized lines (ESP32 boot noise, etc.) — ignored outside debug
-      // so the chip's startup does not flood the logs.
       if (process.env.INPUT_BRIDGE_VERBOSE) {
         console.error('[bridge] parse: unknown line:', JSON.stringify(parsed.line));
       }

--- a/apps/input-bridge/src/index.ts
+++ b/apps/input-bridge/src/index.ts
@@ -9,11 +9,8 @@ import { createSocketEmitter, handleLine, type BridgeEmitter } from './dispatch'
 import { createLineBuffer } from './line-buffer';
 import { runWithRetry, type OpenOutcome } from './serial-retry';
 
-// Serial reading via raw fs + stty (no @serialport): the serialport native
-// binding calls uv_default_loop, unsupported by Bun (SIGILL at runtime).
-// So we read the device as a file after putting it in raw mode, exactly like
-// the Fliphetic reference bridge. Bun supports node:fs/child_process.
-
+// Raw fs + stty instead of @serialport: the serialport native binding calls
+// uv_default_loop, which Bun does not support (SIGILL at runtime).
 function readConfig() {
   return {
     MODE: process.env.INPUT_BRIDGE_MODE === 'serial' ? 'serial' : 'mock',
@@ -37,9 +34,6 @@ socket.on('connect', () => console.log('[bridge] socket connected to', SERVER_UR
 socket.on('disconnect', (reason) => console.log('[bridge] socket disconnected:', reason));
 socket.on('connect_error', (err) => console.log('[bridge] connect_error:', err.message));
 
-// Playfield dev mode `simulate-esp32`: the server routes the event to us
-// (room `input-bridge`). Replay the protocol line straight through the
-// parser — identical path to a line received from a real ESP32.
 socket.on('dev:simulate-button', (data) => {
   if (MODE !== 'mock') {
     console.warn('[bridge] dev:simulate-button ignored (serial mode, use real ESP32):', data);
@@ -49,10 +43,6 @@ socket.on('dev:simulate-button', (data) => {
   console.log('[bridge] dev:simulate-button replayed as', `BTN:${data.id}:${data.action}`);
 });
 
-// Serial device IO adapter (no retry policy here — it lives in
-// serial-retry.ts). Puts the tty in raw mode at the right baud (busybox stty),
-// then reads the stream line by line. Open failure → 'failed'; otherwise wires
-// the stream's error/close to `reopen` (provided by the policy) and → 'opened'.
 function openSerialDevice(reopen: () => void): OpenOutcome {
   try {
     execFileSync('stty', [
@@ -80,8 +70,6 @@ function openSerialDevice(reopen: () => void): OpenOutcome {
   return 'opened';
 }
 
-// If the device is absent (ESP unplugged / not yet enumerated), retry every
-// 3 s — tolerates the USB reboot after flashing.
 function openSerial() {
   runWithRetry({
     openDevice: openSerialDevice,

--- a/apps/input-bridge/src/line-buffer.ts
+++ b/apps/input-bridge/src/line-buffer.ts
@@ -1,8 +1,3 @@
-// Splits a byte/string stream into lines (`\n` separator). No IO dependency:
-// `push(chunk)` accumulates, emits each complete line via the injected
-// callback, and guards against a newline-less line inflating the buffer
-// (>8192 → reset). Testable without a serial device.
-
 const OVERFLOW_LIMIT = 8192;
 
 export interface LineBuffer {
@@ -20,7 +15,7 @@ export function createLineBuffer(onLine: (line: string) => void): LineBuffer {
         buf = buf.slice(nl + 1);
         onLine(line);
       }
-      if (buf.length > OVERFLOW_LIMIT) buf = ''; // guard against a line without newline
+      if (buf.length > OVERFLOW_LIMIT) buf = '';
     },
   };
 }

--- a/apps/input-bridge/src/parser.ts
+++ b/apps/input-bridge/src/parser.ts
@@ -1,10 +1,6 @@
 import type { ButtonId, ButtonAction } from '@pinball/shared-types';
 import { CABINET_BUTTONS } from '@pinball/shared-types';
 
-// Pure parsing of the ESP32 ↔ input-bridge serial protocol (line-by-line text).
-// No side effects: no socket, no console. `index.ts` consumes the typed result
-// and emits. Exhaustive line decoding is tested HERE.
-
 export type ParsedLine =
   | { kind: 'button'; id: ButtonId; action: ButtonAction }
   | { kind: 'tilt' }

--- a/apps/input-bridge/src/serial-retry.ts
+++ b/apps/input-bridge/src/serial-retry.ts
@@ -1,27 +1,12 @@
-// Serial device retry/reopen policy, separated from the real IO (stty +
-// createReadStream). The device opens via the injected `openDevice` port:
-// either it fails right away (device absent → schedule a new attempt), or it
-// opens and will call `reopen` later (stream error/close). Either way the next
-// attempt is scheduled via the injected `schedule` port after
-// `RETRY_DELAY_MS`. Testable with a fake openDevice/schedule.
-
 export const RETRY_DELAY_MS = 3000;
 
-// Outcome of a device open attempt.
-// - 'failed': cannot open right now (device absent / not enumerated).
-// - 'opened': device open; a future reconnection will go through `reopen`.
 export type OpenOutcome = 'failed' | 'opened';
 
 export interface SerialRetryPorts {
-  // Attempts to open the device. Receives `reopen` to call back if the device
-  // opens then drops (error/close). Returns the attempt's immediate outcome.
   openDevice(reopen: () => void): OpenOutcome;
-  // Reschedules `run` after `delayMs` (setTimeout in production).
   schedule(run: () => void, delayMs: number): void;
 }
 
-// Infinite (re)open loop at fixed delay: unlimited retries, 3 s between
-// attempts, both after an open failure and after a stream drop.
 export function runWithRetry(ports: SerialRetryPorts): void {
   const attempt = (): void => {
     const reopen = (): void => ports.schedule(attempt, RETRY_DELAY_MS);

--- a/apps/playfield/src/audio/BossFightMusicController.ts
+++ b/apps/playfield/src/audio/BossFightMusicController.ts
@@ -1,7 +1,6 @@
 import { EARLY_SOUND_LOOP_SILENCE_THRESHOLD } from "./pinballAudioConfig";
 import type { SamplePlayer } from "./SamplePlayer";
 
-/** Gapless loop for boss-fight music (e.g. spawnDG). */
 export class BossFightMusicController {
   private activeUrl: string | null = null;
 
@@ -38,7 +37,6 @@ export class BossFightMusicController {
     }
   }
 
-  /** Immediate stop — no fade. */
   stopInstant(): void {
     if (!this.activeUrl) return;
     this.samples.stopGaplessLoop(this.activeUrl);

--- a/apps/playfield/src/audio/EarlySoundController.ts
+++ b/apps/playfield/src/audio/EarlySoundController.ts
@@ -10,7 +10,6 @@ export type EarlySoundPhase = "off" | "armed" | "playing" | "released";
 
 export class EarlySoundController {
   private phase: EarlySoundPhase = "off";
-  /** Blocks any resume while the boss holds the music track. */
   private handoffBlocked = false;
 
   constructor(private readonly samples: SamplePlayer) {}
@@ -70,7 +69,6 @@ export class EarlySoundController {
     this.phase = "released";
   }
 
-  /** Immediate stop — no fade (handoff to boss music). */
   stopInstant(): void {
     this.handoffBlocked = true;
     this.samples.stopGaplessLoop(getEarlySoundUrl());
@@ -87,7 +85,6 @@ export class EarlySoundController {
     this.phase = "off";
   }
 
-  /** Clears armed state only — intentionally does not stop an active loop. */
   disarm(): void {
     if (this.phase === "playing") return;
     this.phase = "off";

--- a/apps/playfield/src/audio/PlayfieldMusicDirector.ts
+++ b/apps/playfield/src/audio/PlayfieldMusicDirector.ts
@@ -18,15 +18,6 @@ type PendingBossResume = {
   };
 };
 
-/**
- * Playfield music orchestrator — one track at a time (early or boss).
- *
- * States:
- * - idle → early-sound (attract / game start)
- * - boss_fight → loops the active boss's revealSoundUrl
- * - boss_bridge → the defeated boss's music is kept until the next boss's
- *   reveal (e.g. spawnDG between the Demogorgon's death and Vecna's arrival)
- */
 export class PlayfieldMusicDirector {
   private pendingBossResume: PendingBossResume | null = null;
   private bossFightEnded = true;
@@ -37,7 +28,6 @@ export class PlayfieldMusicDirector {
   private suppressEarlyUntilReset = false;
 
   private postVictoryMusicHeld = false;
-  /** Alternate-world music playing (sacred-realm, etc.) on the boss bus. */
   private alternateWorldMusicActive = false;
 
   constructor(
@@ -49,7 +39,6 @@ export class PlayfieldMusicDirector {
     this.wantsEarly = wants;
   }
 
-  /** True while an exclusive track (early or boss) must keep the floor. */
   private isExclusiveMusicHeld(): boolean {
     return (
       this.isBossFightActive() ||
@@ -106,14 +95,12 @@ export class PlayfieldMusicDirector {
     };
   }
 
-  /** Alternate-world music (gapless loop on the boss bus). */
   onAlternateWorldEnter(url: string, volume: number): void {
     this.early.stopInstant();
     this.alternateWorldMusicActive = true;
     void this.boss.start(url, volume);
   }
 
-  /** Alternate world ends without a boss fight — resume the early-sound. */
   onAlternateWorldExit(): void {
     if (!this.alternateWorldMusicActive) return;
     this.alternateWorldMusicActive = false;
@@ -123,12 +110,11 @@ export class PlayfieldMusicDirector {
   }
 
   onBossReveal(def: BossDefinition): void {
-    this.alternateWorldMusicActive = false; // boss music takes over
+    this.alternateWorldMusicActive = false;
     this.clearBridge();
     this.bossFightEnded = false;
     this.latePhaseActivated = false;
 
-    // No fight music → the early-sound keeps playing during the fight.
     if (!def.revealSoundUrl) return;
 
     this.haltEarlyForBossHandoff();
@@ -178,9 +164,6 @@ export class PlayfieldMusicDirector {
       return;
     }
 
-    // Boss declaring keepMusicUntilReturnPortal: music continues until
-    // RETURN_PORTAL_TRANSITION_END. If victoryMusicUrl is set, switch to it
-    // at victory instead of keeping the fight music.
     if (def?.keepMusicUntilReturnPortal && this.boss.isPlaying()) {
       this.bossFightEnded = true;
       this.postVictoryMusicHeld = true;
@@ -197,7 +180,6 @@ export class PlayfieldMusicDirector {
     this.requestEarly();
   }
 
-  /** Return-portal cinematic end (Vecna finale photo) — resume early-sound. */
   onReturnPortalTransitionEnd(): void {
     if (!this.postVictoryMusicHeld && !this.boss.isPlaying()) return;
     this.clearBossMusicState();
@@ -235,7 +217,6 @@ export class PlayfieldMusicDirector {
     this.early.release();
   }
 
-  /** Exposed for tests — asserts a single music source is active. */
   getDebugState(): {
     bossFightEnded: boolean;
     musicBridgeActive: boolean;

--- a/apps/playfield/src/audio/SamplePlayer.ts
+++ b/apps/playfield/src/audio/SamplePlayer.ts
@@ -53,7 +53,6 @@ export class SamplePlayer {
     return this.ctx;
   }
 
-  /** Recomputes the buses from AUDIO_VOLUME (called at init). */
   syncBusGains(): void {
     if (!this.master || !this.musicBus || !this.cinematicBus || !this.sfxBus) return;
     this.master.gain.value = percentToGain(AUDIO_VOLUME.master);
@@ -77,7 +76,6 @@ export class SamplePlayer {
     return this.cinematicBus;
   }
 
-  /** Ducks music + sfx to let a cinematic hit through. */
   duckBackground(durationS = 2.5): void {
     const ctx = this.ctx;
     if (!ctx || !this.musicBus || !this.sfxBus) return;
@@ -184,7 +182,6 @@ export class SamplePlayer {
     try {
       handle.source.stop();
     } catch {
-      // already stopped
     }
     handle.source.disconnect();
     handle.gain.disconnect();
@@ -205,7 +202,6 @@ export class SamplePlayer {
     try {
       handle.source.stop(now + fadeOutS + 0.05);
     } catch {
-      // already stopped
     }
 
     window.setTimeout(() => {
@@ -222,24 +218,20 @@ export class SamplePlayer {
         source.disconnect();
         gain.disconnect();
       } catch {
-        // already disconnected
       }
     };
   }
 
-  /** Stops cinematic/boss tracks still playing (e.g. spawnDG). */
   stopActiveOneShots(): void {
     for (const { source, gain } of this.activeOneShots) {
       try {
         source.stop();
       } catch {
-        // already stopped
       }
       try {
         source.disconnect();
         gain.disconnect();
       } catch {
-        // already disconnected
       }
     }
     this.activeOneShots.clear();

--- a/apps/playfield/src/audio/pinballAudio.ts
+++ b/apps/playfield/src/audio/pinballAudio.ts
@@ -32,11 +32,8 @@ function warmAssets(): void {
   assetsWarmed = true;
   void samples.prepareGaplessLoop(getEarlySoundUrl());
   void samples.preloadBuffer(getGameOverUrl());
-  // Map-specific sounds (boss reveal, ambience) are warmed via
-  // warmMapSounds(urls) from the playfield (URLs provided by the map).
 }
 
-// Preloads the map's sounds (boss music as a gapless loop).
 export function warmMapSounds(urls: string[]): void {
   for (const url of urls) {
     void samples.prepareGaplessLoop(url);
@@ -44,8 +41,6 @@ export function warmMapSounds(urls: string[]): void {
   }
 }
 
-// Map event cinematic sound (ducking + impact). URL+volume come from the
-// map content (manifest.sounds).
 export function playMapCinematicSound(url: string, volumePercent = 100): void {
   const gain = percentToGain(volumePercent);
   void samples.resumeContext();
@@ -94,10 +89,8 @@ export function notifyBootPhase(phase: PinballBootPhase): void {
   if (phase === "attract" && earlySound.getPhase() !== "playing") {
     requestEarlySoundStart();
   }
-  // in_game: early-sound keeps playing until BOSS_REVEAL (the director handles the handoff).
 }
 
-/** Called as soon as Rapier/GLB init completes — primary start trigger. */
 export function onPlayfieldReady(): void {
   wantsEarlySound = true;
   musicDirector.setWantsEarly(true);
@@ -131,7 +124,7 @@ export function onMusicGameOver(): void {
   void samples.playOneShotBuffer(getGameOverUrl(), soundLevel("gameOver"));
 }
 
-/** @deprecated Use onMusicGameOver — kept for internal compatibility. */
+/** @deprecated Use onMusicGameOver. */
 export function playGameOverSound(): void {
   onMusicGameOver();
 }

--- a/apps/playfield/src/audio/pinballAudioConfig.ts
+++ b/apps/playfield/src/audio/pinballAudioConfig.ts
@@ -6,7 +6,6 @@ let _gameOverUrl   = DEFAULT_GAME_OVER_URL;
 let _alternateWorldMusicUrl: string | undefined;
 let _alternateWorldMusicVolume = 100;
 
-/** Called by PinballPlayfield on mount to wire the active map's sounds. */
 export function setMapAudioUrls(
   ambientMusic?: string,
   gameOverSound?: string,
@@ -24,12 +23,10 @@ export function getGameOverUrl():   string { return _gameOverUrl;   }
 export function getAlternateWorldMusicUrl(): string | undefined { return _alternateWorldMusicUrl; }
 export function getAlternateWorldMusicVolume(): number { return _alternateWorldMusicVolume; }
 
-// Aliases kept for compatibility with existing imports
 /** @deprecated Use getEarlySoundUrl() */
 export const EARLY_SOUND_URL = DEFAULT_EARLY_SOUND_URL;
 /** @deprecated Use getGameOverUrl() */
 export const GAME_OVER_URL   = DEFAULT_GAME_OVER_URL;
 
 export const EARLY_SOUND_FADE_OUT_S = 0.3;
-/** Peak threshold (abs-max) to detect silence at the MP3 loop's start/end. */
 export const EARLY_SOUND_LOOP_SILENCE_THRESHOLD = 0.004;

--- a/apps/playfield/src/audio/pinballAudioVolumes.ts
+++ b/apps/playfield/src/audio/pinballAudioVolumes.ts
@@ -1,18 +1,3 @@
-/**
- * Volume settings — 0–100 scale (intuitive).
- *
- * Final volume = master × bus × sound_level
- *
- * ~35% global boost (cabinet test — previous levels too low). The
- * music/sfx/cinematic ratios relative to each other are preserved.
- *
- * Examples:
- * - Music too loud → lower `music` (e.g. 50)
- * - Ambient sound too quiet → raise `cinematic` (per-sound volumes supplied by the map)
- * - Whole game louder → raise `master` (e.g. 90)
- */
-
-/** Global volume + per-category bus. */
 export const AUDIO_VOLUME = {
   master: 100,
   music: 85,
@@ -20,7 +5,6 @@ export const AUDIO_VOLUME = {
   sfx: 68,
 } as const;
 
-/** Per-file fine level (0–100+, relative to its bus; >100 = boost). */
 export const SOUND_VOLUME = {
   earlySound: 100,
   gameOver: 100,
@@ -32,7 +16,6 @@ export function percentToGain(percent: number): number {
   return Math.max(0, Math.min(100, percent)) / 100;
 }
 
-/** A file's level — to plug onto the already-set bus (>1.0 allowed for boost). */
 export function soundLevel(sound: SoundVolumeKey): number {
   return Math.max(0, SOUND_VOLUME[sound]) / 100;
 }

--- a/apps/playfield/src/components/pinball/CinematicOverlay.tsx
+++ b/apps/playfield/src/components/pinball/CinematicOverlay.tsx
@@ -4,9 +4,7 @@ import type { CinematicClip, CinematicFamily } from '@pinball/shared-types'
 
 interface CinematicOverlayProps {
   clip: CinematicClip | null
-  /** clipId → family mapping (provided by the map manifest). */
   clipFamilies?: Record<string, CinematicFamily>
-  /** Overlay videos/images per clipId (CSS fallback otherwise). */
   overlayFiles?: Record<string, string>
 }
 
@@ -16,10 +14,6 @@ function isVideo(file: string): boolean {
   return file.endsWith('.webm')
 }
 
-// DOM overlay played during cinematic freezes (above the 3D canvas, below
-// the GameOverlay). Animated asset when present (manifest), otherwise a
-// generic CSS fallback per family. One re-render per cinematic — never per
-// frame.
 export default function CinematicOverlay({ clip, clipFamilies, overlayFiles }: CinematicOverlayProps) {
   const [shown, setShown] = useState<CinematicClip | null>(null)
   const [visible, setVisible] = useState(false)
@@ -27,7 +21,6 @@ export default function CinematicOverlay({ clip, clipFamilies, overlayFiles }: C
   useEffect(() => {
     if (clip) {
       setShown(clip)
-      // next tick → opacity transition
       const id = window.requestAnimationFrame(() => setVisible(true))
       return () => window.cancelAnimationFrame(id)
     }
@@ -44,11 +37,10 @@ export default function CinematicOverlay({ clip, clipFamilies, overlayFiles }: C
   const wrapStyle: CSSProperties = {
     position: 'absolute',
     inset: 0,
-    zIndex: 5, // above the canvas, below the GameOverlay (z-10)
+    zIndex: 5,
     pointerEvents: 'none',
     opacity: visible ? 1 : 0,
     transition: `opacity ${FADE_MS}ms ease`,
-    // dark vignette — theatrical without hiding the 3D scene.
     background: 'radial-gradient(ellipse at 50% 50%, transparent 30%, rgba(0,0,0,0.55) 100%)',
   }
   const mediaStyle: CSSProperties = {

--- a/apps/playfield/src/components/pinball/GameOverlay.tsx
+++ b/apps/playfield/src/components/pinball/GameOverlay.tsx
@@ -9,8 +9,6 @@ import { bossHealthBarTheme } from "./bossHealthHud";
 import StyledQrCode from "./StyledQrCode";
 import type { PlayfieldBootPhase } from "./bootPhase";
 
-// Ball reset = DEV helper only (button + hint + R key). Must not exist in
-// prod (cabinet). NODE_ENV is inlined at Next build time.
 const IS_DEV = process.env.NODE_ENV !== "production";
 
 export type { PlayfieldBootPhase };
@@ -154,8 +152,6 @@ export default function GameOverlay({
     bootPhase === "in_game" && gameState === "idle" && plungerCharge !== null;
   const showGameOver = bootPhase === "in_game" && gameState === "game_over";
 
-  // Outro accent color: normal glow vs inverted world. Neutral fallbacks →
-  // a map without a theme stays clean (no hardcoded ST).
   const glow = alternateWorldActive ? "var(--glow-alt, #b14dff)" : "var(--glow, #ff2d2d)";
   const dot = "var(--vignette, #2a0606)";
   const title = outro?.title ?? "FIN DE PARTIE";
@@ -361,7 +357,6 @@ export default function GameOverlay({
             >
               Transmission entrante
             </p>
-            {/* 4 bracket corners */}
             <span className="absolute left-0 top-3 h-5 w-5 border-l-2 border-t-2" style={{ borderColor: glow }} />
             <span className="absolute right-0 top-3 h-5 w-5 border-r-2 border-t-2" style={{ borderColor: glow }} />
             <span className="absolute bottom-0 left-0 h-5 w-5 border-b-2 border-l-2" style={{ borderColor: glow }} />

--- a/apps/playfield/src/components/pinball/MapSelectorScreen.tsx
+++ b/apps/playfield/src/components/pinball/MapSelectorScreen.tsx
@@ -9,7 +9,6 @@ interface Props {
   onSelect: (id: string) => void;
 }
 
-/* ─── Per-map visual config ───────────────────────────────────────── */
 const THEME: Record<string, {
   accent: string;
   glow: string;
@@ -95,7 +94,6 @@ const THEME: Record<string, {
 
 const FALLBACK_THEME = THEME.strangerthings;
 
-/* ─── Component ───────────────────────────────────────────────────── */
 export function MapSelectorScreen({ maps, onSelect }: Props) {
   const [cursor, setCursor] = useState(0);
   const videoRefs = useRef<(HTMLVideoElement | null)[]>([]);
@@ -120,11 +118,8 @@ export function MapSelectorScreen({ maps, onSelect }: Props) {
     return () => window.removeEventListener("keydown", onKey);
   }, [go, confirm]);
 
-  // Physical cabinet buttons (ESP32 → server → input:button). The
-  // usePhysicalInputs hook is only mounted in PinballPlayfield — not rendered
-  // yet here → without this subscription the selector ignores physical
-  // buttons. Mapped by game ACTION (BUTTON_ACTION), not by id: left/right
-  // flip = navigate, PLUNGE/START = confirm. DOWN only (no UP repeat).
+  // PinballPlayfield isn't mounted yet, so this subscription is what lets the
+  // selector receive physical cabinet buttons.
   const { callbacksRef } = usePhysicalInputs();
   useEffect(() => {
     callbacksRef.current = {
@@ -150,7 +145,6 @@ export function MapSelectorScreen({ maps, onSelect }: Props) {
   const active = maps[cursor];
   const t = THEME[active.id] ?? FALLBACK_THEME;
 
-  // Target dimensions: 1080 x 1920
   const CARD_W = 800;
   const CARD_H = 1300;
   const SIDE_OFFSET = 920;
@@ -168,7 +162,6 @@ export function MapSelectorScreen({ maps, onSelect }: Props) {
       paddingTop: 80,
       paddingBottom: 80,
     }}>
-      {/* Ambient background */}
       <div style={{
         position: "absolute", inset: 0,
         background: `radial-gradient(ellipse 80% 60% at 50% 52%, ${t.glow}22 0%, transparent 65%)`,
@@ -176,7 +169,6 @@ export function MapSelectorScreen({ maps, onSelect }: Props) {
         pointerEvents: "none",
       }} />
 
-      {/* Header */}
       <div style={{
         position: "relative", zIndex: 2,
         fontSize: 18, letterSpacing: 14,
@@ -187,7 +179,6 @@ export function MapSelectorScreen({ maps, onSelect }: Props) {
         Select Your Map
       </div>
 
-      {/* ─── Carousel ──────────────────────────────────────────────── */}
       <div style={{
         position: "relative",
         width: "100%",
@@ -240,7 +231,6 @@ export function MapSelectorScreen({ maps, onSelect }: Props) {
                 `,
               }}
             >
-              {/* Video */}
               {m.previewVideo && (
                 <video
                   ref={(el) => { videoRefs.current[i] = el; }}
@@ -255,13 +245,11 @@ export function MapSelectorScreen({ maps, onSelect }: Props) {
                 />
               )}
 
-              {/* Gradient overlay */}
               <div style={{
                 position: "absolute", inset: 0,
                 background: mt.gradient,
               }} />
 
-              {/* Vignette on unselected cards */}
               {!selected && (
                 <div style={{
                   position: "absolute", inset: 0,
@@ -269,7 +257,6 @@ export function MapSelectorScreen({ maps, onSelect }: Props) {
                 }} />
               )}
 
-              {/* Logo */}
               <div style={{
                 position: "absolute",
                 top: 0, left: 0, right: 0,
@@ -281,7 +268,6 @@ export function MapSelectorScreen({ maps, onSelect }: Props) {
                 {mt.logoEl}
               </div>
 
-              {/* Decorative corners */}
               {[
                 { top: 20, left: 20, borderTop: true, borderLeft: true },
                 { top: 20, right: 20, borderTop: true, borderRight: true },
@@ -303,7 +289,6 @@ export function MapSelectorScreen({ maps, onSelect }: Props) {
                 }} />
               ))}
 
-              {/* Card footer */}
               <div style={{
                 position: "absolute", bottom: 0, left: 0, right: 0,
                 padding: "0 40px 52px",
@@ -344,7 +329,6 @@ export function MapSelectorScreen({ maps, onSelect }: Props) {
         })}
       </div>
 
-      {/* ─── Navigation ────────────────────────────────────────────── */}
       <div style={{
         position: "relative", zIndex: 2,
         display: "flex",

--- a/apps/playfield/src/components/pinball/PinballPlayfield.tsx
+++ b/apps/playfield/src/components/pinball/PinballPlayfield.tsx
@@ -38,8 +38,6 @@ import type { CinematicClip, ScoreUpdate } from "@pinball/shared-types";
 import { clipFreezeMs, DEFAULT_MAP_ID } from "@pinball/shared-types";
 
 const MAP_ID = process.env.NEXT_PUBLIC_MAP_ID ?? DEFAULT_MAP_ID;
-// Resolved at module level (MAP_ID is a build-time constant) — fallback
-// when no mapId prop is provided.
 const DEFAULT_RESOLVED_MAP = getMapPackage(MAP_ID);
 
 import { createPlayfieldScene } from "./scene/createPlayfieldScene";
@@ -101,14 +99,6 @@ import DebugPanel from "./DebugPanel";
 type AlternateWorldPersistence = "until_game_over" | "until_drain";
 const ALTERNATE_WORLD_PERSISTENCE: AlternateWorldPersistence = "until_game_over";
 
-/**
- * Keyboard mode — `NEXT_PUBLIC_KEYBOARD_MODE`:
- * - `direct`: applies locally (default). ~0 latency.
- * - `simulate-esp32`: emits a `dev:simulate-button` Socket.io event to the
- *   server, which turns it into an `input:button` broadcast. Validates the
- *   network chain without hardware.
- * - `disabled`: game keys ignored. `H` (debug) stays active.
- */
 type KeyboardMode = "direct" | "simulate-esp32" | "disabled";
 const KEYBOARD_MODE: KeyboardMode =
   (process.env.NEXT_PUBLIC_KEYBOARD_MODE as KeyboardMode) || "direct";
@@ -117,14 +107,12 @@ const PLAYFIELD_VIEW_MODE = parsePlayfieldViewMode(process.env.NEXT_PUBLIC_PLAYF
 const IS_PORTRAIT_FILL = PLAYFIELD_VIEW_MODE === 'portrait-fill';
 
 type PinballPlayfieldProps = {
-  /** HUD + portrait frame for the physical cabinet screen (`/pinball?cabinet`) */
   cabinetMode?: boolean;
-  /** Map id to load. Absent → NEXT_PUBLIC_MAP_ID, then DEFAULT_MAP_ID. */
   mapId?: string;
 };
 
-// NO SIGNAL guard: unknown map → fullscreen standby, no crash. Hook-free
-// wrapper so the Inner (all the hooks) only mounts when the map exists.
+// Hook-free wrapper so Inner (which holds all the hooks) only mounts once the
+// map resolves — an unknown map renders NO SIGNAL instead of crashing.
 export default function PinballPlayfield(props: PinballPlayfieldProps) {
   const resolvedMap = props.mapId ? getMapPackage(props.mapId) : DEFAULT_RESOLVED_MAP;
   if (!resolvedMap) return <NoSignal reason={`MAP "${props.mapId ?? MAP_ID}" INTROUVABLE`} />;
@@ -132,7 +120,6 @@ export default function PinballPlayfield(props: PinballPlayfieldProps) {
 }
 
 function PinballPlayfieldInner({ cabinetMode = false, resolvedMap }: PinballPlayfieldProps & { resolvedMap: ResolvedMap }) {
-  // Bosses, clips and sounds derive from the selected map (prop — changes on remount).
   const mapBosses = resolvedMap.layout.bosses ?? [];
   const mapClips = resolvedMap.manifest.clips;
   useMapAudio(resolvedMap.manifest);
@@ -158,7 +145,6 @@ function PinballPlayfieldInner({ cabinetMode = false, resolvedMap }: PinballPlay
   cameraDebugTuningRef.current = cameraDebugTuning;
   const playfieldRootHandleRef = useRef<THREE.Object3D | null>(null);
   const refitCameraRef = useRef<((root: THREE.Object3D) => void) | null>(null);
-  // DOM cinematic overlay (one re-render per cinematic, not per frame).
   const [cinematicClip, setCinematicClip] = useState<CinematicClip | null>(null);
   const debugVisibleRef = useRef(false);
 
@@ -170,14 +156,11 @@ function PinballPlayfieldInner({ cabinetMode = false, resolvedMap }: PinballPlay
   const [physicsReady, setPhysicsReady] = useState(false);
   const [sessionStarted, setSessionStarted] = useState(false);
   const [plungerCharge, setPlungerCharge] = useState<number | null>(null);
-  // Game-over outro: claim URL (arrives async via game:registered) + frozen
-  // score shown in the overlay. QR is rendered client-side (StyledQrCode).
   const [gameOverClaimUrl, setGameOverClaimUrl] = useState<string | null>(null);
   const [gameOverCode, setGameOverCode] = useState<string | null>(null);
   const [finalScore, setFinalScore] = useState(0);
   const physicsReadyRef = useRef(false);
   const sessionStartedRef = useRef(false);
-  /** Called from the game loop when the session starts (shows the ball). */
   const onSessionStartRef = useRef<(() => void) | null>(null);
 
   const handleCameraTuningChange = useCallback((next: PlayfieldCameraDebugTuning) => {
@@ -211,9 +194,6 @@ function PinballPlayfieldInner({ cabinetMode = false, resolvedMap }: PinballPlay
     notifyBootPhase(bootPhase);
   }, [bootPhase]);
 
-  // Auto-spawn: the map is already selected upstream, so start the session as
-  // soon as physics is ready — no START/SPACE wait. The ball appears in the
-  // shooter lane, ready to launch.
   useEffect(() => {
     if (shouldAutoBeginSession({ physicsReady, sessionStarted })) {
       beginSessionRef.current();
@@ -225,21 +205,15 @@ function PinballPlayfieldInner({ cabinetMode = false, resolvedMap }: PinballPlay
     setGameOverCode(d.code);
   });
 
-  // Cinematic director (stable). Ref → reachable from render-scope callbacks
-  // (onLifeLost) and the animate loop (useEffect).
   const cinematicsRef = useRef<CinematicDirector | null>(null);
   if (!cinematicsRef.current) cinematicsRef.current = new CinematicDirector();
   const cinematics = cinematicsRef.current;
 
-  // Resolved map (guaranteed non-null by the wrapper's NO SIGNAL guard).
   const mapPackageRef = useRef<ResolvedMap>(resolvedMap);
-  // Module ref (reachable from render-scope callbacks, e.g. reset).
   const mapModuleRef = useRef<MapModule | null>(null);
-  // emit (defined inside the effect) exposed to render-scope useGameState callbacks.
   const emitRef = useRef<GameEventListener | null>(null);
   const mapLayout = mapPackageRef.current.layout;
   const mapManifest = mapPackageRef.current.manifest;
-  // manifest.glb is already an absolute public URL (/maps/<id>/…).
   const playfieldUrl = mapManifest.glb;
 
   const playCinematic = useCallback(
@@ -248,8 +222,6 @@ function PinballPlayfieldInner({ cabinetMode = false, resolvedMap }: PinballPlay
       opts?: { once?: boolean; value?: number; onEnd?: () => void },
     ): boolean => {
       const freezeMs = clipFreezeMs(mapManifest.clips, clip);
-      // Freezing clip → goes through the director (physics pause). No freeze
-      // (0 ms) → plain DMD push, the game keeps running.
       if (freezeMs > 0) {
         const accepted = cinematics.play(
           {
@@ -257,18 +229,18 @@ function PinballPlayfieldInner({ cabinetMode = false, resolvedMap }: PinballPlay
             durationMs: freezeMs,
             freezePhysics: true,
             onEnd: () => {
-              setCinematicClip(null); // hide DOM overlay on resume
+              setCinematicClip(null);
               opts?.onEnd?.();
             },
           },
           { once: opts?.once },
         );
         if (!accepted) return false;
-        setCinematicClip(clip); // show DOM overlay during the freeze
+        setCinematicClip(clip);
       } else {
         opts?.onEnd?.();
       }
-      dmd.pushCinematic(clip, opts?.value); // SHOW duration handled by the orchestrator
+      dmd.pushCinematic(clip, opts?.value);
       return true;
     },
     [cinematics, dmd],
@@ -293,9 +265,8 @@ function PinballPlayfieldInner({ cabinetMode = false, resolvedMap }: PinballPlay
     buildEmit,
     addLife,
   } = useGameState({
-    // Deps resolved lazily (lambda): scoreSnapshot/mapStateExtraRef/… are
-    // declared further down (TDZ at render otherwise); the callbacks run
-    // post-render.
+    // Lazy lambda: scoreSnapshot/mapStateExtraRef/… are declared further down,
+    // so reading them eagerly here would hit a TDZ error at render.
     ...createDmdScoreCallbacks(() => ({
       dmd,
       mapBosses,
@@ -317,8 +288,6 @@ function PinballPlayfieldInner({ cabinetMode = false, resolvedMap }: PinballPlay
       resetMapModule: () => mapModuleRef.current?.onGameReset(),
       openShooterLaneGate: () => shooterLaneGateRef.current?.open(),
     })),
-    // Milestone + boss-armed effects (cinematics/celebrate/shake/hint) are
-    // handled by the map module (MILESTONE / BOSS_ARMED events).
     onMilestone: (threshold) => emitRef.current?.({ type: "MILESTONE", threshold }),
     onBossArmed: (bossId) => emitRef.current?.({ type: "BOSS_ARMED", bossId }),
   }, {
@@ -328,21 +297,13 @@ function PinballPlayfieldInner({ cabinetMode = false, resolvedMap }: PinballPlay
     bosses: mapBosses,
   });
 
-  // mapState patches pushed by the map module (ctx.setMapState), merged into
-  // every snapshot.
   const mapStateExtraRef = useRef<Record<string, number | boolean>>({});
 
-  // Single builder for the mapState injected into every DMD/score snapshot.
-  // Map counters come from the map module (mapStateExtraRef); fever stays
-  // driven by useGameState (multiplier mechanism).
   const buildMapState = (fever: boolean = isFeverActive()) => ({
     ...mapStateExtraRef.current,
     fever,
   });
 
-  // Current score snapshot (DMD/backglass) — `over` overrides fields when the
-  // fresh value isn't in the ref yet (e.g. lives just decremented).
-  // Referenced by useGameState callbacks (run post-render → TDZ ok).
   const scoreSnapshot = (over: Partial<ScoreUpdate> = {}): ScoreUpdate => ({
     player: playerRef.current,
     score: scoreRef.current,
@@ -367,7 +328,6 @@ function PinballPlayfieldInner({ cabinetMode = false, resolvedMap }: PinballPlay
     resetBallRef.current?.();
   }, []);
 
-  // Outro/QR auto-exit after 20s → reload → selector.
   useOutroAutoExit(gameState);
 
   const { callbacksRef: physicalInputsRef, simulateButton, isConnectedRef } = usePhysicalInputs();
@@ -377,11 +337,10 @@ function PinballPlayfieldInner({ cabinetMode = false, resolvedMap }: PinballPlay
     const mountEl = mountRef.current;
     if (!mountEl) return;
 
-    // ── Per-map config — must precede any physics/camera setup ──────────────
+    // Must run before any physics/camera setup.
     configureSurfaceCoefficients(resolvedMap.layout.geometry.coefficients);
     configureBallRadius(mapManifest.ballRadius ?? DEFAULT_BALL_RADIUS);
 
-    // ── Three.js setup ───────────────────────────────────────────────────────
     const rendering = mapManifest.rendering;
     const {
       scene,
@@ -427,19 +386,12 @@ function PinballPlayfieldInner({ cabinetMode = false, resolvedMap }: PinballPlay
 
     refitCameraRef.current = (root) => cameraRig.syncToRoot(root);
 
-    // ── Flipper visual state ─────────────────────────────────────────────────
     let flipperSetup: FlipperSetupResult | null = null;
-    // Flipper frame accumulators (smoothed swing + hit flash), mutated by the
-    // hot-loop steps.
     const flipperFrame = createFlipperFrameState();
-    // Shared mutable input state (flippers + plunger) — owned here, mutated by
-    // applyAction AND read by the animate loop.
     const inputState: InputState = createInputState();
 
-    // ── Juice: screen shake ──────────────────────────────────────────────────
     const screenShake = screenShakeRef.current!;
 
-    // ── Physics / game objects ───────────────────────────────────────────────
     let ballMesh: THREE.Object3D | null = null;
     let playfieldRootRef: THREE.Object3D | null = null;
     let physicsWorld: PhysicsWorld | null = null;
@@ -450,16 +402,10 @@ function PinballPlayfieldInner({ cabinetMode = false, resolvedMap }: PinballPlay
     let collisionProcessor: CollisionEventProcessor | null = null;
     const mapModule: MapModule | null = mapPackageRef.current?.module?.() ?? null;
     mapModuleRef.current = mapModule;
-    // Hoisted: the MapContext (built early) references it via closures, but it
-    // is only assigned once the event pipeline is ready (below).
     let emit: GameEventListener;
     let ballTrail: BallTrail | null = null;
     let shooterLaneGate: ShooterLaneGate | null = null;
 
-    // Playfield feedback during cinematic freezes (e.g. HETIC letter gain):
-    // a strobed flash makes the freeze read as intentional and points to the
-    // DMD, instead of a dead frozen scene. Flash-only (no black veil) — the
-    // DMD carries the content. Tunable via FREEZE_FEEDBACK.
     const freezeFeedbackStrobe = new PlayfieldCinematicStrobe();
     const FREEZE_FEEDBACK: CinematicFreezeFeedbackConfig = {
       hz: 9,
@@ -468,7 +414,6 @@ function PinballPlayfieldInner({ cabinetMode = false, resolvedMap }: PinballPlay
       fadeOutFraction: 0.4,
     };
 
-    // Quality governor: adjusts pixelRatio + feature flags from frame time.
     const quality = new QualityGovernor((tier) => {
       renderer.setPixelRatio(Math.min(window.devicePixelRatio, tier.dpr));
       renderer.setSize(
@@ -480,8 +425,6 @@ function PinballPlayfieldInner({ cabinetMode = false, resolvedMap }: PinballPlay
     });
     let flipperRig: FlipperBodiesResult | null = null;
     let physicsReady = false;
-    // Keyboard handlers kept in effect scope → safe cleanup even if init() is
-    // cancelled before wiring.
     let keydownHandler: ((e: KeyboardEvent) => void) | null = null;
     let keyupHandler: ((e: KeyboardEvent) => void) | null = null;
     let prevFrameTime = 0;
@@ -489,7 +432,6 @@ function PinballPlayfieldInner({ cabinetMode = false, resolvedMap }: PinballPlay
     const bossIntroHold = createBossIntroHoldState();
 
 
-    // ── Rapier debug renderer — all colliders ────────────────────────────────
     const rapierDebugGeo = new THREE.BufferGeometry();
     const rapierDebugMat = new THREE.LineBasicMaterial({ vertexColors: true, depthTest: false });
     const rapierDebugLines = new THREE.LineSegments(rapierDebugGeo, rapierDebugMat);
@@ -497,8 +439,6 @@ function PinballPlayfieldInner({ cabinetMode = false, resolvedMap }: PinballPlay
     rapierDebugLines.renderOrder = 1000;
     scene.add(rapierDebugLines);
     disposableMats.push(rapierDebugMat);
-    // Debug meshes (collidersOn state + H toggle) — assigned after the flipper
-    // hulls/pivot markers are built (buildFlipperBodies).
     let debugMeshManager: DebugMeshManager | null = null;
 
     const stuckDetector = new StuckBallDetector();
@@ -506,19 +446,11 @@ function PinballPlayfieldInner({ cabinetMode = false, resolvedMap }: PinballPlay
     const diag = new BallDiagnostics(mapLayout);
     let lastDebugPush = 0;
 
-    // SINGLE bottom-out trigger point: whatever the detection source (Rapier
-    // sensor, lost ball, stuck ball, or the geometric zone below the flippers),
-    // the decision happens here → one execute (idempotent via BottomOutBall's
-    // latch) + cause logging.
     const triggerBottomOut = (reason: BallResetReason) => {
       bottomOutBallUC?.execute();
       diag.noteReset(reason);
     };
 
-    // ── Debug: drag the ball with the mouse (`M` toggle) ─────────────────────
-    // Drag the ball anywhere on the table to test stuck spots. While dragging:
-    // orbit disabled, velocity forced to 0 (follows the cursor), shooter-lane
-    // locks bypassed. On release physics resumes.
     const ballDragController = new BallDragController({
       renderer,
       camera,
@@ -529,26 +461,21 @@ function PinballPlayfieldInner({ cabinetMode = false, resolvedMap }: PinballPlay
     });
     ballDragController.attach();
 
-    // Diagnostic logs gated by the HUD `[J]` toggle → fully silent in prod.
     const debugLog = (...args: unknown[]) => {
       if (!debugVisibleRef.current) return;
       // eslint-disable-next-line no-console
       console.info(...args);
     };
 
-    // ── Plunger kinematic ────────────────────────────────────────────────────
     let plungerBody: RAPIER.RigidBody | null = null;
     let plungerMesh: THREE.Mesh | null = null;
     let plungerRestZ = 0;
 
 
-    // ── GLTF + Physics setup ─────────────────────────────────────────────────
     const init = async () => {
       try {
         const gltf = await loadPlayfieldGlb(loader, playfieldUrl);
         if (cancelled) return; // StrictMode: first mount was unmounted mid-flight
-        // garlands/bumperVisuals/nestMarker/reveals are created by the map
-        // module, not here.
         const assembled = assemblePlayfieldModel(gltf, {
           scene,
           modelRoot,
@@ -570,19 +497,15 @@ function PinballPlayfieldInner({ cabinetMode = false, resolvedMap }: PinballPlay
         const flippers = setupFlippers(playfieldRoot, mapLayout.flipperPivots, getBallRadius());
         flipperSetup = flippers;
 
-        // ── Physics ──────────────────────────────────────────────────────────
         physicsWorld = await PhysicsWorld.create();
         if (cancelled) return; // bail before colliders/ball — World disposed in cleanup
         const world = physicsWorld.world;
-        // colliderMap created here (before the ctx) so it can be injected into the module.
         const colliderMap = new Map<number, string>();
 
-        // ── MapContext: built EARLY so module.setup can create its systems
-        // before they are consumed. emit is hoisted (assigned further down) →
-        // reached via closures.
+        // Built early so module.setup can create its systems before they are
+        // consumed; forward refs (ball/ballMesh/collisionProcessor/emit) are
+        // passed as live-bound getters.
         if (mapModule) {
-          // Forward refs (ball/ballMesh/collisionProcessor/emit, assigned
-          // later) are passed as live-bound getters.
           const mapCtx = createMapContext({
             scene,
             root: playfieldRoot,
@@ -622,7 +545,6 @@ function PinballPlayfieldInner({ cabinetMode = false, resolvedMap }: PinballPlay
           });
           mapModule.setup(mapCtx);
         }
-        // Async module preload (e.g. boss reveals) — blocks loading.
         await mapModule?.preload?.();
         if (cancelled) return; // bail before ball/collider creation
 
@@ -632,9 +554,6 @@ function PinballPlayfieldInner({ cabinetMode = false, resolvedMap }: PinballPlay
 
         modelRoot.updateMatrixWorld(true);
 
-        // Role-driven GLB: trimeshes (walls/lane) + derived drop targets +
-        // analytic colliders (floor/bumpers/sensors). Side effects on world +
-        // colliderMap.
         buildPlayfieldColliders({
           world,
           root: playfieldRoot,
@@ -645,7 +564,6 @@ function PinballPlayfieldInner({ cabinetMode = false, resolvedMap }: PinballPlay
 
         ballPhysicsInst = new BallPhysics(world, mapLayout);
 
-        // ── Flippers: kinematic bodies + debug hulls + pivot markers ──────────
         flipperRig = buildFlipperBodies({
           world,
           scene,
@@ -671,7 +589,6 @@ function PinballPlayfieldInner({ cabinetMode = false, resolvedMap }: PinballPlay
         ballPhysicsInst.setSpawnPosition(mapLayout.spawns.ball.x, mapLayout.spawns.ball.y, mapLayout.spawns.ball.z);
         ballPhysicsInst.body.wakeUp();
 
-        // ── Plunger visual + kinematic body ──────────────────────────────────
         const plungerSetup = buildPlungerBody({
           world,
           scene,
@@ -683,7 +600,6 @@ function PinballPlayfieldInner({ cabinetMode = false, resolvedMap }: PinballPlay
         plungerBody = plungerSetup.body;
         plungerRestZ = plungerSetup.restZ;
 
-        // ── Fixed cabinet camera (non-rotatable) — playable table only ─────────
         modelRoot.updateMatrixWorld(true);
         cameraRig.director.setBosses(mapBosses);
         const camFrameBox = cameraRig.syncToRoot(playfieldRoot);
@@ -692,12 +608,8 @@ function PinballPlayfieldInner({ cabinetMode = false, resolvedMap }: PinballPlay
           cameraRig.restoreBoss();
         };
 
-        // ── OrbitControls — free camera ──────────────────────────────────────
         cameraRig.attachOrbit(renderer.domElement);
 
-        // ── Use-case + event-router wiring. The intentional processor↔emit
-        // cycle lives in the factory; results are assigned into closure `let`s
-        // read by animate/applyAction/ctx.
         const wiring = wireGameplay({
           ball: ballPhysicsInst,
           colliderMap,
@@ -723,7 +635,7 @@ function PinballPlayfieldInner({ cabinetMode = false, resolvedMap }: PinballPlay
         });
         const plunger = wiring.plunger;
         emit = wiring.emit;
-        emitRef.current = emit; // exposed to useGameState callbacks (milestone/boss-armed)
+        emitRef.current = emit;
         launchBallUC = wiring.launchBallUC;
         drainBallUC = wiring.drainBallUC;
         bottomOutBallUC = wiring.bottomOutBallUC;
@@ -738,27 +650,15 @@ function PinballPlayfieldInner({ cabinetMode = false, resolvedMap }: PinballPlay
           stuckDetector.reset();
           bottomOutBallUC?.resetLatch();
           if (ballMesh) ballMesh.visible = true;
-          // Manual reset (R key / game-over hide): re-arm the drain latch so
-          // it stays repeatable, then force the drain.
+          // Re-arm the latch before forcing the drain, or the reset stops being repeatable.
           drainBallUC.resetLatch();
           drainBallUC.execute();
         };
 
-        // ── Input handling ────────────────────────────────────────────────────
         console.log("[PinballPlayfield] KEYBOARD_MODE =", KEYBOARD_MODE);
 
-        // Leaving the outro/QR screen (game over) → restart the workflow FROM
-        // THE START: full reload → pinball.tsx boot → MapSelectorScreen
-        // (multi-map) or forced-map attract (Fliphetic mono-map via
-        // NEXT_PUBLIC_MAP_ID), with fresh engine/sockets/refs state. Same path
-        // for manual replay (START/PLUNGE) and the 20s auto-exit (React
-        // effect) — we never replay the same map in place.
         const restartWorkflow = () => window.location.reload();
 
-        // Game-action router → effects (flippers/plunger/reset). Single source
-        // of truth, called by `input:button` network events and by the dev
-        // keyboard. All collaboration goes through getters/callbacks + the
-        // `inputState` object shared with the animate loop.
         const applyAction = createApplyAction({
           state: inputState,
           now: () => performance.now(),
@@ -779,9 +679,6 @@ function PinballPlayfieldInner({ cabinetMode = false, resolvedMap }: PinballPlay
           mapBosses,
           getCollisionProcessor: () => collisionProcessor,
           getGameState: () => gameStateRef.current,
-          // Cabinet cheat code: 3 left-facade buttons held together → ball
-          // reset (same path as the R key — resetBall guards itself: no-op
-          // outside a session or in game_over).
           onCheatReset: () => resetBallRef.current?.(),
         });
 
@@ -829,7 +726,6 @@ function PinballPlayfieldInner({ cabinetMode = false, resolvedMap }: PinballPlay
 
     void init();
 
-    // ── Render loop ───────────────────────────────────────────────────────────
     let frameId: number;
 
     const animate = (time: number) => {
@@ -845,10 +741,6 @@ function PinballPlayfieldInner({ cabinetMode = false, resolvedMap }: PinballPlay
       const freezeFrame =
         (mapModule?.shouldFreezePhysics?.() ?? false) || cinematics.shouldFreeze();
 
-      // Playfield feedback during a cinematic freeze (flash-only strobe):
-      // makes the freeze readable + points to the DMD. Driven by the
-      // director's elapsed time → 0 when no clip is active (mix decays,
-      // flash removed).
       const freezeFb = cinematicFreezeFeedback(
         cinematics.shouldFreeze() ? cinematics.activeElapsedMs(time) : -1,
         cinematics.activeDurationMs(),
@@ -856,18 +748,15 @@ function PinballPlayfieldInner({ cabinetMode = false, resolvedMap }: PinballPlay
       );
       freezeFeedbackStrobe.applyFlashOnly(freezeFb.on, freezeFb.mix);
 
-      // Boss intro hold (rising edge: capture + freeze the ball).
       stepBossIntroHold(bossIntroHold, bossIntroActive, ballPhysicsInst, inputState);
 
       if (physicsWorld && !freezeFrame) {
         const world = physicsWorld;
         world.update(dt, {
           onBeforeStep: () => {
-            // ── Flipper physics: kinematic targets set PER STEP ─────────────
-            // Advancing the swing at render rate swept a double arc per step
-            // at 120 Hz → the hull jumped over the ball (tunneling; no CCD on
-            // kinematic bodies). Here: one swing step per world.step(), fixed
-            // stepDt → constant arc.
+            // Advance the flipper swing PER STEP (fixed stepDt), not at render
+            // rate: at 120 Hz a render-rate arc tunnels the hull over the ball
+            // (no CCD on kinematic bodies).
             if (flipperSetup && flipperRig) {
               stepFlipperPhysics(flipperFrame, {
                 input: inputState,
@@ -884,8 +773,6 @@ function PinballPlayfieldInner({ cabinetMode = false, resolvedMap }: PinballPlay
           },
           onStep: () => {
             collisionProcessor?.process(world.eventQueue, gameStateRef.current);
-            // Capture the post-step position for render interpolation
-            // (prev/curr lerp bounds in syncToMeshInterpolated).
             ballPhysicsInst?.noteStepped();
           },
           onAfterSteps: () => {
@@ -895,10 +782,6 @@ function PinballPlayfieldInner({ cabinetMode = false, resolvedMap }: PinballPlay
       }
 
       if (!freezeFrame && flipperSetup && flipperRig) {
-        // ── Flipper visuals — AFTER the steps: the displayed Three pose
-        // follows the smoothed swing at refresh rate; on the next physics
-        // step, stepFlipperPhysics re-poses the pivot from the phys-swing
-        // (applyFlipperSwing = absolute rotation.set, no accumulation).
         stepFlipperKinematics(flipperFrame, {
           input: inputState,
           leftPivot: flipperSetup.leftPivot,
@@ -920,8 +803,6 @@ function PinballPlayfieldInner({ cabinetMode = false, resolvedMap }: PinballPlay
         && gameStateRef.current === 'playing'
         && flipperSetup?.zones
       ) {
-        // Launch assist: angVel derived from per-step physics deltas → fixed
-        // stepDt, not the render dt.
         stepFlipperAssist(flipperFrame, ballPhysicsInst, flipperSetup.zones, PhysicsWorld.STEP_INTERVAL);
       }
 
@@ -976,18 +857,14 @@ function PinballPlayfieldInner({ cabinetMode = false, resolvedMap }: PinballPlay
         }
       }
 
-      // ── OrbitControls update ─────────────────────────────────────────────
       cameraRig.updateFrame(dt, { freeze: freezeFrame, cinematicActive: cameraCinematicActive });
 
-      // ── Rapier debug render (all colliders) ─────────────────────────────
       if (debugMeshManager?.collidersOn && physicsWorld) {
         updateRapierDebugGeometry(rapierDebugGeo, physicsWorld.world.debugRender());
       }
 
-      // ── Quality governor (frame time → tiers) ───────────────────────────
       quality.frame(dt * 1000);
 
-      // ── Fire trail (intensity ∝ combo, max during fever) ────────────────
       if (ballTrail) {
         const feverNow = isFeverActive();
         const playing = !!ballMesh?.visible && gameStateRef.current === "playing";
@@ -1001,8 +878,6 @@ function PinballPlayfieldInner({ cabinetMode = false, resolvedMap }: PinballPlay
         );
       }
 
-      // ── Screen shake: transient offset applied AFTER camera placement,
-      // restored after render (no accumulation inside OrbitControls).
       const shake = screenShake.update(dt);
       camera.position.x += shake.x;
       camera.position.y += shake.y;
@@ -1013,7 +888,6 @@ function PinballPlayfieldInner({ cabinetMode = false, resolvedMap }: PinballPlay
 
     frameId = requestAnimationFrame(animate);
 
-    // ── Resize ────────────────────────────────────────────────────────────────
     const detachResize = attachResizeHandler({
       mountEl,
       camera,
@@ -1022,7 +896,6 @@ function PinballPlayfieldInner({ cabinetMode = false, resolvedMap }: PinballPlay
       getPlayfieldRoot: () => playfieldRootRef,
     });
 
-    // ── Cleanup ───────────────────────────────────────────────────────────────
     return () => {
       cancelled = true;
       cancelAnimationFrame(frameId);
@@ -1033,8 +906,6 @@ function PinballPlayfieldInner({ cabinetMode = false, resolvedMap }: PinballPlay
       if (keydownHandler) document.removeEventListener("keydown", keydownHandler);
       if (keyupHandler) document.removeEventListener("keyup", keyupHandler);
       if (mountEl.contains(renderer.domElement)) mountEl.removeChild(renderer.domElement);
-      // bumperVisuals + garlands + bossReveals + nestMarker are disposed by
-      // mapModule.dispose.
       ballTrail?.dispose();
       freezeFeedbackStrobe.dispose();
       shooterLaneGate?.dispose();

--- a/apps/playfield/src/components/pinball/StyledQrCode.tsx
+++ b/apps/playfield/src/components/pinball/StyledQrCode.tsx
@@ -3,15 +3,15 @@
 import { useEffect, useRef } from 'react';
 
 interface StyledQrCodeProps {
-  value: string; // claimUrl
-  color: string; // accent (eyes/corners) — resolved glow var
-  dotColor: string; // dark dots (resolved vignette var)
+  value: string;
+  color: string;
+  dotColor: string;
   logoUrl?: string;
-  size?: number; // default 180
+  size?: number;
 }
 
-// Client-styled QR via qr-code-styling. SSR-safe: the lib touches `window`
-// at load → dynamic import inside the useEffect only.
+// qr-code-styling touches `window` at load, so it must be dynamically
+// imported inside the effect (never at module top level) to stay SSR-safe.
 export default function StyledQrCode({
   value,
   color,

--- a/apps/playfield/src/components/pinball/bootPhase.ts
+++ b/apps/playfield/src/components/pinball/bootPhase.ts
@@ -1,10 +1,3 @@
-// Playfield boot phase: pure derivation from two progress booleans. The map
-// is already selected upstream, so there is no blocking "attract" screen:
-// as soon as physics is ready the session starts automatically (ball
-// auto-spawns in the shooter lane, ready to launch). The "attract" phase only
-// remains as a transient state between `physicsReady` and the auto-start
-// tick.
-
 export type PlayfieldBootPhase = "loading" | "attract" | "in_game";
 
 export interface BootPhaseInput {
@@ -21,8 +14,6 @@ export function computeBootPhase({
   return "in_game";
 }
 
-// Auto-spawn: the session must start on its own once physics is ready and no
-// session is active yet. No START/SPACE required.
 export function shouldAutoBeginSession({
   physicsReady,
   sessionStarted,

--- a/apps/playfield/src/components/pinball/createKeyboardRouter.ts
+++ b/apps/playfield/src/components/pinball/createKeyboardRouter.ts
@@ -4,27 +4,17 @@ import { gameKeyToAction, idForAction, isPreventDefaultKey } from "./keyboardMap
 import type { DebugMeshManager, PivotCoords } from "./debug/DebugMeshManager";
 
 export interface KeyboardRouterDeps {
-  /** unlocks audio on the first keydown (autoplay policy) */
   unlockAudio: () => void;
-  /** routes a physical button (direct or simulate-esp32 mode) */
   dispatchButton: (id: ButtonId, action: ButtonAction) => void;
   debug: DebugMeshManager;
   setFlipperPivotCoords: (c: PivotCoords | null) => void;
   debugVisibleRef: MutableRefObject<boolean>;
   setDebugVisible: (v: boolean) => void;
-  /** M: toggles ball-move mode (ballDragController) */
   toggleMoveMode: () => void;
-  /** R: ball reset (dev only) */
   resetBall: () => void;
-  /** process.env.NODE_ENV !== "production" (build-time) — gates the ball reset */
   isDev: boolean;
 }
 
-// Dev keyboard router: translates keydown/keyup into game actions (via
-// keyboardMap) and debug toggles (H colliders / J diagnostics / M ball move /
-// R reset). The Three side effects of the H toggle are isolated in
-// DebugMeshManager → this router only routes. `H` always stays active,
-// independent of KEYBOARD_MODE (handled upstream by dispatchButton).
 export function createKeyboardRouter(deps: KeyboardRouterDeps): {
   onKeyDown: (e: KeyboardEvent) => void;
   onKeyUp: (e: KeyboardEvent) => void;
@@ -47,7 +37,6 @@ export function createKeyboardRouter(deps: KeyboardRouterDeps): {
       deps.toggleMoveMode();
       return;
     }
-    // Ball reset = DEV helper only (cf. GameOverlay). Absent in prod.
     if ((e.key === "r" || e.key === "R") && deps.isDev) {
       deps.resetBall();
       return;

--- a/apps/playfield/src/components/pinball/createMapContext.ts
+++ b/apps/playfield/src/components/pinball/createMapContext.ts
@@ -13,11 +13,10 @@ import type { useDmdOrchestrator } from "@/hooks/useDmdOrchestrator";
 
 type Dmd = ReturnType<typeof useDmdOrchestrator>;
 
-// MapContext dependencies. Collaborators assigned AFTER this build
-// (ball / ballMesh / collisionProcessor / emit) are passed as live-bound
-// getters/closures — NEVER as snapshots, or the context freezes.
+// Collaborators assigned AFTER this build (ball / ballMesh /
+// collisionProcessor / emit) must be passed as live-bound getters, never as
+// snapshots, or the context freezes.
 export interface MapContextDeps {
-  // Passthrough (typed via MapContext → guaranteed match).
   scene: MapContext["scene"];
   root: MapContext["root"];
   camera: MapContext["camera"];
@@ -27,13 +26,11 @@ export interface MapContextDeps {
   colliderMap: MapContext["colliderMap"];
   lighting: MapContext["lighting"];
 
-  // Live forward refs.
   getBall: () => BallPhysics | null;
   getBallMesh: () => MapContext["ballMesh"];
   getCollisionProcessor: () => CollisionEventProcessor | null;
   emit: (e: GameEvent) => void;
 
-  // State refs.
   scoreRef: MutableRefObject<number>;
   comboRef: MutableRefObject<number>;
   multiplierRef: MutableRefObject<number>;
@@ -43,7 +40,6 @@ export interface MapContextDeps {
   mapStateExtraRef: MutableRefObject<Record<string, unknown>>;
   atmosphereAlternateRef: MutableRefObject<boolean>;
 
-  // Collaborators.
   dmd: Dmd;
   screenShakeAdd: (amount: number) => void;
   resetStuck: () => void;
@@ -55,9 +51,6 @@ export interface MapContextDeps {
   buildMapState: () => MapState;
 }
 
-// Builds the MapContext passed to mapModule.setup(): the bag of closures a
-// map module uses to drive scene / physics / score / DMD / cinematics. This
-// is the largest coupling surface of the init.
 export function createMapContext(deps: MapContextDeps): MapContext {
   const {
     scene, root, camera, physics, layout, manifest, colliderMap, lighting,

--- a/apps/playfield/src/components/pinball/debug/DebugMeshManager.ts
+++ b/apps/playfield/src/components/pinball/debug/DebugMeshManager.ts
@@ -20,10 +20,6 @@ export interface DebugMeshRefs {
   rightPivotMarker: THREE.Mesh | null;
 }
 
-// Debug meshes (collider wireframes + flipper hulls + pivot spheres). Owns the
-// `collidersOn` state (read by the animate loop for the Rapier debug render) and
-// centralizes the H toggle — keeps the Three side effects out of the keyboard
-// routing logic (cf. createKeyboardRouter).
 export class DebugMeshManager {
   private on = false;
 
@@ -35,14 +31,10 @@ export class DebugMeshManager {
     },
   ) {}
 
-  /** true when the collider debug render is active (read by animate). */
   get collidersOn(): boolean {
     return this.on;
   }
 
-  // H toggle: flips visibility of all debug meshes. Returns the pivots'
-  // world coordinates when turning on (both present), otherwise null — the
-  // caller pushes them into the overlay.
   toggleColliders(): PivotCoords | null {
     this.on = !this.on;
     this.meshes.colliders.visible = this.on;

--- a/apps/playfield/src/components/pinball/dmdScoreCallbacks.ts
+++ b/apps/playfield/src/components/pinball/dmdScoreCallbacks.ts
@@ -17,25 +17,18 @@ export interface DmdScoreCallbackDeps {
   playerRef: MutableRefObject<string>;
   scoreRef: MutableRefObject<number>;
   atmosphereAlternateRef: MutableRefObject<boolean>;
-  /** map counters (mapStateExtraRef.current) — only numbers go to the leaderboard */
   getMapCounters: () => Record<string, number | boolean>;
   setFinalScore: (score: number) => void;
   clearClaimQr: () => void;
-  /** reset hooks run on the return to idle (replay) */
   resetCinematics: () => void;
   resetAudio: () => void;
   resetMapModule: () => void;
   openShooterLaneGate: () => void;
 }
 
-/**
- * useGameState → DMD/backglass callbacks: score snapshots, display priority
- * (EVENT > MULTI > COMBO), lives, game over (stats + map counters),
- * intro/reset. Deps are resolved LAZILY via `getDeps()` at call time
- * (post-render) — required: several collaborators (snapshot,
- * mapStateExtraRef…) are declared AFTER the useGameState call in the
- * component (TDZ at render otherwise).
- */
+// Deps are resolved lazily via `getDeps()` at call time: several collaborators
+// (snapshot, mapStateExtraRef…) are declared AFTER the useGameState call, so
+// reading them at render would hit a TDZ error.
 export function createDmdScoreCallbacks(
   getDeps: () => DmdScoreCallbackDeps,
 ): Pick<
@@ -56,9 +49,6 @@ export function createDmdScoreCallbacks(
       d.dmd.emitScoreSnapshot(snap);
       d.dmd.pushScore(snap);
 
-      // Every event switches the display. Exclusive, by decreasing
-      // priority: labeled event → EVENT; new multiplier → MULTI; otherwise
-      // ongoing combo → COMBO.
       const label = eventLabel(event, d.mapBosses);
       if (label) {
         d.dmd.pushEvent(label, finalPoints, snap);
@@ -73,13 +63,10 @@ export function createDmdScoreCallbacks(
       const d = getDeps();
       d.dmd.emitScoreSnapshot(d.snapshot({ combo: 0, multiplier: 1, lives: livesRemaining }));
       d.dmd.pushLifeLost(livesRemaining, d.scoreRef.current, d.playerRef.current);
-      // Last life in play → 1.2s breather (no freeze: ball already drained).
       if (livesRemaining === 1) d.playCinematic("last_chance");
     },
 
     onLifeGained: (lives) => {
-      // Refresh the DMD immediately with the real counter — otherwise it
-      // desyncs until the next score event (especially past 3 lives).
       const d = getDeps();
       const snap = d.snapshot({ lives });
       d.dmd.emitScoreSnapshot(snap);
@@ -88,22 +75,18 @@ export function createDmdScoreCallbacks(
 
     onGameOver: (finalScore, stats) => {
       const d = getDeps();
-      d.setFinalScore(finalScore); // the QR arrives later via game:registered (async)
-      // Map counters: only numbers go to the leaderboard.
+      d.setFinalScore(finalScore);
       const counters: Record<string, number> = {};
       for (const [k, v] of Object.entries(d.getMapCounters())) {
         if (typeof v === "number") counters[k] = v;
       }
-      // No GAME_OVER display on the DMD: keep the last SCORE until the
-      // reset (INTRO). emitGameOver feeds the backglass/leaderboard.
       d.dmd.emitGameOver(d.playerRef.current, finalScore, d.mapId, { ...stats, counters });
-      // Pushed on EVERY game over; the backglass knows the rank → fanfare or recap.
       d.dmd.pushCinematic("hall_of_fame");
     },
 
     onGameStart: () => {
       const d = getDeps();
-      d.clearClaimQr(); // avoids a stale QR flashing on the next game
+      d.clearClaimQr();
       d.dmd.emitGameStart(d.playerRef.current);
       const snap = d.snapshot({ combo: 0, multiplier: 1 });
       d.dmd.emitScoreSnapshot(snap);
@@ -129,7 +112,6 @@ export function createDmdScoreCallbacks(
     },
 
     onFeverEnd: () => {
-      // Re-emit a fever:false snapshot so DMD/backglass settle back.
       const d = getDeps();
       const snap = d.snapshot({ mapState: d.buildMapState(false) });
       d.dmd.emitScoreSnapshot(snap);

--- a/apps/playfield/src/components/pinball/hotLoop/bossIntroHold.ts
+++ b/apps/playfield/src/components/pinball/hotLoop/bossIntroHold.ts
@@ -1,9 +1,6 @@
 import type { BallPhysics } from "@pinball/game-engine";
 import type { InputState } from "../createApplyAction";
 
-// Boss-intro hold state: on entering the intro, capture the ball position and
-// freeze it (release flippers + zero velocities); stepBallSync keeps it at `pos`
-// for the intro's duration. Rising-edge: capture happens only once per intro.
 export interface BossIntroHoldState {
   holding: boolean;
   pos: { x: number; y: number; z: number };

--- a/apps/playfield/src/components/pinball/hotLoop/computePlungerVisual.ts
+++ b/apps/playfield/src/components/pinball/hotLoop/computePlungerVisual.ts
@@ -1,9 +1,6 @@
 import { plungerChargeProgress, plungerLaunchFactor, PLUNGER_CHARGE_MS } from "@pinball/game-engine";
 import type { PlungerState } from "../createApplyAction";
 
-// Charge-gauge UI throttle (React setState capped at ~25 Hz to avoid
-// re-rendering at 60/120 Hz), + reset to null on release. Stateful by design
-// (last push + displayed gauge) — owned by the init closure.
 export const PLUNGER_CHARGE_UI_INTERVAL_MS = 40;
 
 export function createPlungerChargeUi(push: (charge: number | null) => void) {
@@ -35,19 +32,10 @@ export interface PlungerVisualInput {
 }
 
 export interface PlungerVisualResult {
-  /** plunger mesh Z position this frame */
   z: number;
-  /** FSM state after this frame (releasing→returning→idle transitions) */
   plungerState: PlungerState;
 }
 
-// Plunger visual FSM (pure): computes the mesh Z position + the state
-// transition for a given frame. `restZ` = rest position (>0).
-//
-// - charging: pullback ∝ charge factor
-// - releasing: forward strike, then → returning after 10% of the charge time
-// - returning: back to rest → idle
-// - idle: at rest
 export function computePlungerVisual(
   s: PlungerVisualInput,
   time: number,

--- a/apps/playfield/src/components/pinball/hotLoop/flipperFrame.ts
+++ b/apps/playfield/src/components/pinball/hotLoop/flipperFrame.ts
@@ -16,23 +16,15 @@ import {
 } from "@pinball/game-engine";
 import type { InputState } from "../createApplyAction";
 
-// Flipper accumulators, shared between the physics step (per Rapier step),
-// the visual step (per render frame) and the launch assist.
-//
-// Two distinct integrators over the SAME model (computeSwingStep, same target):
-// - phys* advances at STEP_INTERVAL in onBeforeStep → kinematic bodies sweep a
-//   constant arc per step (anti-tunneling, cf. PhysicsUpdateHooks);
-// - leftSwing/rightSwing advances at render dt → smooth displayed Three pose
-//   at refresh rate. Divergence is bounded (exponential convergence toward the
-//   same target): the visual/physics gap stays imperceptible.
+// Two integrators over the same target: phys* must advance at STEP_INTERVAL
+// (per Rapier step) so kinematic bodies sweep a constant arc and don't tunnel;
+// leftSwing/rightSwing advance at render dt for the displayed pose. Keep them
+// separate — collapsing them reintroduces tunneling.
 export interface FlipperFrameState {
-  /** VISUAL swing (render), radians. */
   leftSwing: number;
   rightSwing: number;
-  /** PHYSICS swing (per step), radians — source of the kinematic targets. */
   physLeftSwing: number;
   physRightSwing: number;
-  /** Physics swing from the previous step — yields the angVel physics sees. */
   physPrevLeft: number;
   physPrevRight: number;
   leftFlash: number;
@@ -52,15 +44,13 @@ export function createFlipperFrameState(): FlipperFrameState {
   };
 }
 
-// Smoothing normalized to 60 FPS: Math.pow(1 - SWING_SMOOTH, dt * 60)
-// reproduces the 60 Hz behavior exactly on every display (120 Hz → smaller
-// decay per frame, same real angular speed).
+// The `dt * 60` normalizes smoothing to 60 FPS so the angular speed is
+// framerate-independent — don't drop it.
 export function computeSwingStep(current: number, target01: number, dt: number): number {
   const decay = 1 - Math.pow(1 - SWING_SMOOTH, dt * 60);
   return current + (target01 * SWING_RAD - current) * decay;
 }
 
-// Linear hit-flash decay, floored at 0.
 export function decayFlash(flash: number, dt: number): number {
   return flash > 0 ? Math.max(0, flash - dt) : flash;
 }
@@ -77,14 +67,6 @@ export interface FlipperPhysicsDeps {
   rightOffset: THREE.Vector3;
 }
 
-// Flipper PHYSICS step, called in onBeforeStep BEFORE each world.step() with
-// stepDt = PhysicsWorld.STEP_INTERVAL: advances the phys-swing, poses the
-// Three pivot (world transform = source of the kinematic target) then pushes
-// the target to the Rapier body. One target per step → constant swept arc
-// regardless of refresh rate (anti-tunneling, cf. PhysicsUpdateHooks).
-// applyFlipperSwing does an absolute rotation.set (no accumulation): the
-// render can re-apply the visual swing after the steps without corrupting
-// physics.
 export function stepFlipperPhysics(
   s: FlipperFrameState,
   d: FlipperPhysicsDeps,
@@ -115,9 +97,6 @@ export interface FlipperKinematicsDeps {
   rightDebug: THREE.Mesh | null;
 }
 
-// Flipper VISUAL step (render, after the physics steps): smoothed Three.js
-// swing, hit-flash decay + apply, debug wireframe alignment. Does NOT touch
-// the Rapier bodies — those are driven by stepFlipperPhysics (per step).
 export function stepFlipperKinematics(
   s: FlipperFrameState,
   d: FlipperKinematicsDeps,
@@ -145,11 +124,9 @@ export function stepFlipperKinematics(
   }
 }
 
-// Launch assist: if the ball sits in the zone of a rising flipper, guarantee
-// an exit velocity (pure game-engine helper) + trigger the hit-flash. Only
-// called while playing, outside freezes. The angVel comes from the per-step
-// PHYSICS deltas (stepDt = STEP_INTERVAL) — the flipper speed Rapier actually
-// sees, not the visual swing speed at refresh rate.
+// angVel must come from the per-step PHYSICS deltas (stepDt = STEP_INTERVAL),
+// i.e. the flipper speed Rapier actually sees, not the visual swing speed at
+// refresh rate.
 export function stepFlipperAssist(
   s: FlipperFrameState,
   ball: BallPhysics,

--- a/apps/playfield/src/components/pinball/hotLoop/frameMath.ts
+++ b/apps/playfield/src/components/pinball/hotLoop/frameMath.ts
@@ -1,6 +1,3 @@
-// Frame time step (seconds), capped at 50 ms to avoid big physics jumps
-// after a stall/background tab. First frame (no previous time) → 16 ms
-// (~60 FPS).
 export const MAX_FRAME_DT = 0.05;
 export const FIRST_FRAME_DT = 0.016;
 
@@ -9,8 +6,6 @@ export function computeFrameDt(prevFrameTime: number, time: number): number {
   return Math.min((time - prevFrameTime) / 1000, MAX_FRAME_DT);
 }
 
-// Fire trail intensity [0,1]: 0 outside play, 1 during fever, otherwise a
-// linear ramp on combo (0 at combo≤3 → 1 at combo≥10).
 export function computeTrailIntensity(
   playing: boolean,
   fever: boolean,

--- a/apps/playfield/src/components/pinball/hotLoop/rapierDebugRender.ts
+++ b/apps/playfield/src/components/pinball/hotLoop/rapierDebugRender.ts
@@ -1,9 +1,7 @@
 import * as THREE from "three";
 
-// Prepares Rapier's debugRender buffer for Three: RGBA→RGB colors, and
-// non-finite vertices (NaN/Infinity returned by some colliders) squashed to 0
-// to avoid stray spikes + the computeBoundingSphere error (NaN radius).
-// Mutates `vertices` in place.
+// Non-finite vertices (some colliders return NaN/Infinity) must be squashed
+// to 0, or computeBoundingSphere throws on a NaN radius. Mutates `vertices`.
 export function sanitizeRapierDebugBuffers(
   vertices: Float32Array,
   colors: Float32Array,
@@ -20,7 +18,6 @@ export function sanitizeRapierDebugBuffers(
   return { vertices, rgb };
 }
 
-// Pushes the Rapier debug render into the LineSegments geometry (H toggle).
 export function updateRapierDebugGeometry(
   geo: THREE.BufferGeometry,
   raw: { vertices: Float32Array; colors: Float32Array },

--- a/apps/playfield/src/components/pinball/hotLoop/stepBallSync.ts
+++ b/apps/playfield/src/components/pinball/hotLoop/stepBallSync.ts
@@ -14,8 +14,8 @@ import {
 import type { GameState } from "@/hooks/useGameState";
 
 // Z threshold below which the stuck-ball detector is active (above = drain
-// zone, let the ball go). Inherited magic number — should eventually derive
-// from mapLayout.sensors; kept literal to preserve behavior.
+// zone, let the ball go).
+// TODO: derive from mapLayout.sensors instead of this inherited magic number.
 export const STUCK_ZONE_MAX_Z = 0.22;
 
 export interface BallSyncDeps {
@@ -33,20 +33,13 @@ export interface BallSyncDeps {
   bottomOutDetector: DetectBottomOut;
   triggerBottomOut: (reason: BallResetReason) => void;
   dt: number;
-  /** Fraction toward the next physics step (PhysicsWorld.interpolationAlpha)
-   * — smooths ball rendering on 120 Hz displays (physics at 60 steps/s). */
   alpha: number;
 }
 
-// Ball ↔ physics sync for one frame (called when the ball is visible and
-// physics is ready). Imperative orchestration of locks/snaps/clamps/detectors —
-// the DECISIONS are pure game-engine helpers (computeIdleSpawnLock/
-// LaneStraightLock/SurfaceSnap/SpeedClamp); here we read/apply on the body.
-// Args are live each frame → no stale binding. The step order is load-bearing.
+// The step order below is load-bearing — do not reorder the locks/snaps/clamps.
 export function stepBallSync(d: BallSyncDeps): void {
   const { ball, ballMesh, gameState, layout } = d;
 
-  // Boss intro: ball held in place (no physics).
   if (d.bossIntroActive && gameState === "playing") {
     const p = d.bossIntroBallPos;
     ball.body.setTranslation({ x: p.x, y: p.y, z: p.z }, true);
@@ -58,7 +51,6 @@ export function stepBallSync(d: BallSyncDeps): void {
 
   if (d.freezeFrame) return;
 
-  // Ball pinned at spawn while idle (including during charge) — prevents drifting.
   if (gameState === "idle" && d.physicsReady && !d.isDragging) {
     const lock = computeIdleSpawnLock(layout.spawns.ball);
     ball.body.setTranslation(lock.translation, true);
@@ -66,7 +58,6 @@ export function stepBallSync(d: BallSyncDeps): void {
     ball.body.setAngvel(lock.angvel, true);
   }
 
-  // Lateral shooter-lane lock during the climb (straight launch).
   if (gameState === "playing" && !d.isDragging && !d.shooterLaneGate?.isClosed()) {
     const laneLock = computeLaneStraightLock(
       ball.body.translation(),
@@ -84,7 +75,6 @@ export function stepBallSync(d: BallSyncDeps): void {
     }
   }
 
-  // Surface snap: re-sticks the ball to the tilted floor.
   if (gameState === "playing" && !d.isDragging) {
     const snap = computeSurfaceSnap(ball.body.translation(), ball.body.linvel(), layout.shooterLane);
     if (snap) {
@@ -95,7 +85,6 @@ export function stepBallSync(d: BallSyncDeps): void {
 
   ball.syncToMeshInterpolated(ballMesh, d.alpha);
 
-  // Speed clamp.
   const clampedVel = computeSpeedClamp(ball.body.linvel());
   if (clampedVel) ball.body.setLinvel(clampedVel, true);
 
@@ -103,8 +92,7 @@ export function stepBallSync(d: BallSyncDeps): void {
   const bVel = ball.body.linvel();
   const bSpd = Math.sqrt(bVel.x ** 2 + bVel.y ** 2 + bVel.z ** 2);
 
-  // Stuck-ball detector — outside the drain zone, and never during a debug
-  // drag (a ball held still would be force-drained = lost life).
+  // Skip during a debug drag: a ball held still would be force-drained = lost life.
   if (gameState === "playing" && !d.isDragging && bPos.z < STUCK_ZONE_MAX_Z) {
     const stuck = d.stuckDetector.update(bSpd, bPos, d.dt);
     if (stuck) {
@@ -118,10 +106,8 @@ export function stepBallSync(d: BallSyncDeps): void {
     d.stuckDetector.reset();
   }
 
-  // Bottom-out fallback — zone below the flippers outside the lane (not
-  // during a debug drag: the ball can be dragged through without draining).
+  // Skip during a debug drag: the ball can be dragged through without draining.
   if (gameState === "playing" && !d.isDragging && d.bottomOutDetector.check(bPos)) {
     d.triggerBottomOut("bottom_out_zone");
   }
-  // Nominal drain is handled by the Rapier bottom_out sensor (CollisionEventProcessor).
 }

--- a/apps/playfield/src/components/pinball/keyboardMap.ts
+++ b/apps/playfield/src/components/pinball/keyboardMap.ts
@@ -1,10 +1,6 @@
 import type { GameAction, ButtonId } from "@pinball/shared-types";
 import { CABINET_BUTTONS } from "@pinball/shared-types";
 
-// Resolves the physical id of the button mapped to a game action (survives a
-// GPIO remap, no hardcoded 'WHITE_LEFT' literal). Fail-fast: if the action is
-// no longer wired in CABINET_BUTTONS, throw explicitly instead of a `!` that
-// crashed silently later.
 export function idForAction(action: GameAction): ButtonId {
   const btn = CABINET_BUTTONS.find((b) => b.action === action);
   if (!btn) {
@@ -15,10 +11,6 @@ export function idForAction(action: GameAction): ButtonId {
   return btn.id;
 }
 
-// Dev keyboard keys → game action. null = non-game key (ignored by the
-// router; the H/J/M/R debug toggles are handled separately). The DOWN/UP
-// direction comes from the caller (keydown vs keyup) — this table only maps
-// key to action.
 const KEY_TO_ACTION: Readonly<Record<string, GameAction>> = {
   ArrowLeft: "FLIP_LEFT",
   q: "FLIP_LEFT",
@@ -33,8 +25,6 @@ export function gameKeyToAction(key: string): GameAction | null {
   return KEY_TO_ACTION[key] ?? null;
 }
 
-// Keys whose default browser behavior the router must cancel (arrow/space
-// scrolling).
 export function isPreventDefaultKey(key: string): boolean {
   return key === "ArrowLeft" || key === "ArrowRight" || key === " ";
 }

--- a/apps/playfield/src/components/pinball/physics/buildFlipperBodies.ts
+++ b/apps/playfield/src/components/pinball/physics/buildFlipperBodies.ts
@@ -8,7 +8,6 @@ import {
   type FlipperPivot,
 } from "@pinball/game-engine";
 
-// Debug colors (wireframe hull + pivot sphere) per flipper.
 const LEFT_DEBUG_COLOR = 0x00ffff;
 const RIGHT_DEBUG_COLOR = 0xff00ff;
 
@@ -32,16 +31,10 @@ export interface BuildFlipperBodiesDeps {
   rightFlipper: THREE.Mesh | null;
   leftPivot: FlipperPivot | null;
   rightPivot: FlipperPivot | null;
-  // Component dispose registries — the geos/mats created here are pushed in.
   disposableGeos: THREE.BufferGeometry[];
   disposableMats: THREE.Material[];
 }
 
-// Setup-only construction (no frame work): flipper kinematic bodies + debug
-// convex hulls, plus the pivot marker spheres (visible when H is active).
-// Meshes are added to the scene and registered for dispose. Nothing reads
-// them from the animate loop during construction — the returned refs are
-// assigned in the init closure afterwards.
 export function buildFlipperBodies(
   deps: BuildFlipperBodiesDeps,
 ): FlipperBodiesResult {
@@ -90,7 +83,6 @@ export function buildFlipperBodies(
   const left = makeBody(leftFlipper, LEFT_DEBUG_COLOR);
   const right = makeBody(rightFlipper, RIGHT_DEBUG_COLOR);
 
-  // Pivot debug markers — spheres visible when H is active.
   const pivotGeo = new THREE.SphereGeometry(0.008, 12, 12);
   const pivotMatL = new THREE.MeshBasicMaterial({ color: LEFT_DEBUG_COLOR, depthTest: false });
   const pivotMatR = new THREE.MeshBasicMaterial({ color: RIGHT_DEBUG_COLOR, depthTest: false });

--- a/apps/playfield/src/components/pinball/physics/buildPlayfieldColliders.ts
+++ b/apps/playfield/src/components/pinball/physics/buildPlayfieldColliders.ts
@@ -11,27 +11,20 @@ import type { MapManifest } from "@pinball/shared-types";
 
 export interface BuildPlayfieldCollidersDeps {
   world: RAPIER.World;
-  /** resolved GLB root (playfieldRoot) */
   root: THREE.Object3D;
   manifest: MapManifest;
   layout: MapLayout;
-  /** filled by the factory: collider handle → role name (later consumed by
-   * CollisionEventProcessor) */
   colliderMap: Map<number, string>;
 }
 
-// Builds every physics collider from the role-driven GLB (inert setup):
-// walls/lane = trimeshes classified by role; drop targets derived from the
-// GLB (LayoutResolver); floor/bumpers/sensors = analytic from the layout.
-// Side effects on `world` + `colliderMap`.
 export function buildPlayfieldColliders(deps: BuildPlayfieldCollidersDeps): void {
   const { world, root, manifest, layout, colliderMap } = deps;
 
   const meshResolver = new MeshRoleResolver(manifest.meshAliases);
   PlayfieldTrimeshBuilder.buildRoleDriven(root, world, meshResolver, manifest.elements ?? {});
 
-  // Drop targets derived from the GLB (deltas ≤ 0.7 mm validated); bumpers
-  // kept literal (Box3 center ≠ tuned collider). The comparison log stays on.
+  // Drop targets are derived from the GLB, but bumpers stay literal: a Box3
+  // center is not the tuned collider position.
   const derivedLayout = LayoutResolver.deriveAndCompare(root, meshResolver, layout);
   const resolvedLayout = LayoutResolver.withDerivedDropTargets(layout, derivedLayout);
   PlayfieldColliderFactory.createForMap(world, resolvedLayout, colliderMap);

--- a/apps/playfield/src/components/pinball/physics/buildPlungerBody.ts
+++ b/apps/playfield/src/components/pinball/physics/buildPlungerBody.ts
@@ -2,9 +2,6 @@ import * as THREE from "three";
 import type RAPIER from "@dimforge/rapier3d-compat";
 import { PlungerPhysics } from "@pinball/game-engine";
 
-// Plunger visual/geometric settings. Defaults reproduce the original
-// literals EXACTLY; passing a config allows per-map tuning without touching
-// the factory.
 export interface PlungerConfig {
   radius: number;
   restZ: number;
@@ -26,7 +23,6 @@ export const DEFAULT_PLUNGER_CONFIG: PlungerConfig = {
 export interface BuildPlungerBodyDeps {
   world: RAPIER.World;
   scene: THREE.Object3D;
-  // Anchor (ball spawn) — the plunger shares x/y and rests at restZ on Z.
   spawn: { x: number; y: number };
   disposableGeos: THREE.BufferGeometry[];
   disposableMats: THREE.Material[];
@@ -39,8 +35,6 @@ export interface PlungerBodyResult {
   restZ: number;
 }
 
-// Plunger setup: cylinder mesh + Rapier kinematic body at rest. The animate
-// loop only reads mesh/body/restZ AFTER this setup.
 export function buildPlungerBody(deps: BuildPlungerBodyDeps): PlungerBodyResult {
   const { world, scene, spawn, disposableGeos, disposableMats } = deps;
   const cfg = { ...DEFAULT_PLUNGER_CONFIG, ...deps.config };

--- a/apps/playfield/src/components/pinball/physics/setupFlippers.ts
+++ b/apps/playfield/src/components/pinball/physics/setupFlippers.ts
@@ -13,24 +13,17 @@ import {
 type FlipperPivotsConfig = Parameters<typeof attachFlipperAtHinge>[2];
 
 export interface FlipperSetupResult {
-  /** raw resolved meshes (for buildFlipperBodies) */
   leftMesh: THREE.Object3D | null;
   rightMesh: THREE.Object3D | null;
-  /** hinge pivots (null when the flipper is not a mesh) */
   leftPivot: FlipperPivot | null;
   rightPivot: FlipperPivot | null;
-  /** objects animate uses for transforms (= the mesh when isMesh) */
   leftObj: THREE.Object3D | null;
   rightObj: THREE.Object3D | null;
   leftFlashMats: FlashMat[];
   rightFlashMats: FlashMat[];
-  /** launch-guarantee zones, or null when a flipper is missing */
   zones: FlipperZones | null;
 }
 
-// Resolves + attaches the GLB flippers (inert setup): new format
-// (flipper-left/right) or legacy (geometric split). Attaches each flipper at
-// its hinge, collects hit-flash materials, computes the launch zones.
 export function setupFlippers(
   root: THREE.Object3D,
   flipperPivots: FlipperPivotsConfig,
@@ -67,7 +60,6 @@ export function setupFlippers(
     r.rightFlashMats = collectFlashMats(rightMesh);
   }
 
-  // Zones derived from the mesh bboxes (rest pose).
   if (r.leftObj && r.rightObj) {
     r.zones = computeFlipperZones(r.leftObj, r.rightObj, ballRadius);
   }

--- a/apps/playfield/src/components/pinball/scene/BallDragController.ts
+++ b/apps/playfield/src/components/pinball/scene/BallDragController.ts
@@ -3,9 +3,6 @@ import type { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js
 import type { BallPhysics, PlayfieldCamera } from "@pinball/game-engine";
 import { ballCenterOnSurface } from "@pinball/game-engine";
 
-/**
- * Convert a client pointer position (px) to NDC [-1, 1] using the canvas rect.
- */
 export function pointerToNdc(
   clientX: number,
   clientY: number,
@@ -26,11 +23,6 @@ export interface BallDragControllerDeps {
   getOrbitControls: () => OrbitControls | null;
 }
 
-/**
- * Debug: drag the ball with the mouse (toggle `M`), anywhere on the playfield
- * to test stuck spots. During the drag: orbit disabled, velocity forced to 0
- * (follows the cursor), lane locks bypassed. On release: physics resumes.
- */
 export class BallDragController {
   private moveMode = false;
   private dragging = false;
@@ -43,12 +35,8 @@ export class BallDragController {
     return this.moveMode;
   }
 
-  /**
-   * true ONLY during an active drag (pointer down→up). Game-loop locks
-   * (surface-snap, lane-lock) key off this flag, NOT moveMode: a released ball
-   * immediately regains free physics/interaction even while `M` mode stays
-   * active (repositionable multiple times).
-   */
+  // Game-loop locks (surface-snap, lane-lock) key off this flag, NOT moveMode,
+  // so a released ball regains free physics even while `M` mode stays active.
   get isDragging(): boolean {
     return this.dragging;
   }

--- a/apps/playfield/src/components/pinball/scene/PlayfieldCameraRig.ts
+++ b/apps/playfield/src/components/pinball/scene/PlayfieldCameraRig.ts
@@ -25,11 +25,6 @@ type CamFitSnapshot = {
   distance: number;
 };
 
-/**
- * Camera framing/reframing + capture of the cinematic director base.
- * The director stays exposed via `.director` for the event router
- * (play/playVictory/setBosses).
- */
 export class PlayfieldCameraRig {
   readonly director = new PlayfieldCameraDirector();
   private orbitControls: OrbitControls | null = null;
@@ -111,10 +106,6 @@ export class PlayfieldCameraRig {
     }
   }
 
-  /**
-   * Resize reframing fallback when the playfield root isn't loaded yet:
-   * re-orients the camera toward the target using the current mode's up vector.
-   */
   applyViewUpFallback(): boolean {
     if (!this.camFit) return false;
     this.deps.camera.up.copy(playfieldCameraUpForMode(this.deps.viewMode));

--- a/apps/playfield/src/components/pinball/scene/assemblePlayfieldModel.ts
+++ b/apps/playfield/src/components/pinball/scene/assemblePlayfieldModel.ts
@@ -14,8 +14,6 @@ import type { MapManifest } from "@pinball/shared-types";
 const GLB_LOAD_MAX_ATTEMPTS = 3;
 const GLB_LOAD_RETRY_BASE_MS = 1500;
 
-// Loads the GLB with retries (cabinet network can be slow at boot): linear
-// 1.5s/3s backoff between attempts.
 export async function loadPlayfieldGlb(loader: GLTFLoader, url: string): Promise<GLTF> {
   for (let attempt = 1; attempt <= GLB_LOAD_MAX_ATTEMPTS; attempt++) {
     try {
@@ -35,7 +33,6 @@ export interface AssembleModelDeps {
   rendering: MapManifest["rendering"];
   layout: MapLayout;
   freezeFeedbackStrobe: PlayfieldCinematicStrobe;
-  /** registers a subtree's geos/mats for dispose + enables shadows */
   collectDisposables: (root: THREE.Object3D) => void;
   disposableGeos: THREE.BufferGeometry[];
   disposableMats: THREE.Material[];
@@ -47,10 +44,6 @@ export interface AssembledModel {
   ballTrail: BallTrail;
 }
 
-// Scene assembly after GLB load (inert setup): mounts the root + strips
-// useless meshes + prepares materials, fire trail, freeze flash (mounted on
-// modelRoot — scene space, independent of map meshes), and the ball mesh
-// (hidden until the session starts).
 export function assemblePlayfieldModel(
   gltf: GLTF,
   d: AssembleModelDeps,

--- a/apps/playfield/src/components/pinball/scene/attachResizeHandler.ts
+++ b/apps/playfield/src/components/pinball/scene/attachResizeHandler.ts
@@ -6,13 +6,9 @@ export interface ResizeHandlerDeps {
   camera: THREE.Camera;
   renderer: THREE.WebGLRenderer;
   cameraRig: PlayfieldCameraRig;
-  /** live GLB root (null until the GLB is loaded) */
   getPlayfieldRoot: () => THREE.Object3D | null;
 }
 
-// Canvas resize: camera aspect + rig reframing + renderer size. Observes the
-// mount (ResizeObserver) + window resize/orientationchange, and runs an initial
-// pass on the next frame. Returns the detach (cleanup).
 export function attachResizeHandler(d: ResizeHandlerDeps): () => void {
   const handleResize = () => {
     const { clientWidth: w, clientHeight: h } = d.mountEl;

--- a/apps/playfield/src/components/pinball/scene/createEmitRouter.ts
+++ b/apps/playfield/src/components/pinball/scene/createEmitRouter.ts
@@ -20,27 +20,19 @@ import type { DmdOrchestrator } from "@/hooks/useDmdOrchestrator";
 type AlternateWorldPersistence = "until_game_over" | "until_drain";
 
 export interface EmitRouterDeps {
-  /** Base emit (buildEmit) — react-scope scoring/lives/reset. */
   baseEmit: GameEventListener;
-  /** Map module (optional depending on the map). */
   mapModule: MapModule | null;
-  /** Lazy access to the processor (assigned after the factory). */
   getCollisionProcessor: () => CollisionEventProcessor | null;
   cameraRig: PlayfieldCameraRig;
   dmd: DmdOrchestrator;
   screenShake: ScreenShake;
   diag: BallDiagnostics;
-  /** Lazy access to the shooter-lane gate (assigned after the factory). */
   getShooterLaneGate: () => ShooterLaneGate | null;
-  /** Lazy access to the playfield root (assigned at GLB load). */
   getPlayfieldRoot: () => THREE.Object3D | null;
   mapLayout: MapLayout;
   mapBosses: BossDefinition[];
-  /** Lazy access to the bottom-out use-case (assigned after the factory). */
   getBottomOutBallUC: () => BottomOutBall | null;
-  /** Lazy access to the drain use-case (assigned after the factory). */
   getDrainBallUC: () => DrainBall | null;
-  /** Releases the alternate world (react-scope: restoreBossCamera + clear session). */
   releaseAlternateWorld: () => void;
   livesRef: { current: number };
   gameStateRef: { current: GameState };
@@ -48,15 +40,6 @@ export interface EmitRouterDeps {
   ALTERNATE_WORLD_PERSISTENCE: AlternateWorldPersistence;
 }
 
-/**
- * Game-loop event router (the "god-router"). Closes over its collaborators
- * through the `deps` object (lazy getters for the `let`s assigned later in
- * PinballPlayfield's effect).
- *
- * Not pure: mutates THREE meshes (drop targets), drives Rapier via the
- * processor, the cinematic camera and the DMD. Lives in the apps/playfield
- * glue, not in game-engine.
- */
 export function createEmitRouter(deps: EmitRouterDeps): GameEventListener {
   const {
     baseEmit,
@@ -83,35 +66,17 @@ export function createEmitRouter(deps: EmitRouterDeps): GameEventListener {
     cameraRig.restoreBoss();
   };
 
-  /**
-   * Event sink injected into the CollisionEventProcessor and the game loop.
-   *
-   * GUARANTEED fan-out order per event (contract — see also the JSDoc of
-   * CollisionEventProcessor's `emit` parameter):
-   *
-   *   1. mapModule.onPreDrain(pre-decrement lives) — DRAIN/BOTTOM_OUT only.
-   *   2. baseEmit (useGameState) — scoring, life decrement, reset.
-   *   3. mapModule.onGameEvent — visuals, world switch, boss reveals.
-   *
-   * The load-bearing invariant is 1 before 2: `onPreDrain` runs BEFORE
-   * `baseEmit` reads/decrements lives, so a map can grant a save life on the
-   * last ball (it sees the pre-decrement count). Do not reorder these three
-   * calls. The react-scope effects that follow (screen shake, camera, DMD,
-   * cleanup) observe post-scoring state and carry no ordering contract among
-   * themselves.
-   */
+  // Load-bearing fan-out order: onPreDrain (1) must run before baseEmit (2)
+  // decrements lives, so a map can grant a last-ball save from the
+  // pre-decrement count; onGameEvent (3) runs last on post-scoring state. Do
+  // not reorder these three calls.
   const emit: GameEventListener = (event: GameEvent) => {
     const collisionProcessor = getCollisionProcessor();
 
-    // ── Phase 1: pre-drain (last-life save) ──────────────────────────────
-    // The map can grant a life BEFORE the decrement (handleDrain) to avoid
-    // the game over. It receives the pre-decrement life count (livesRef not
-    // yet modified by baseEmit).
     if (event.type === "DRAIN" || event.type === "BOTTOM_OUT") {
       mapModule?.onPreDrain?.(livesRef.current);
     }
 
-    // ── Phase 2: baseEmit (scoring / lives / reset, react-scope) ─────────
     baseEmit(event);
     if (
       "scoreIncrement" in event
@@ -128,16 +93,13 @@ export function createEmitRouter(deps: EmitRouterDeps): GameEventListener {
     }
     if (event.type === "BALL_LAUNCHED") diag.noteReset("launch");
 
-    // ── Phase 3: mapModule.onGameEvent (observes post-scoring state) ─────
     mapModule?.onGameEvent(event);
 
-    // ── Per-event screen shake (juice) ───────────────────────────────────
     if (event.type === "BUMPER_HIT") screenShake.add(0.25);
     else if (event.type === "SLINGSHOT_HIT") screenShake.add(0.2);
     else if (event.type === "DROP_TARGET_HIT") screenShake.add(0.35);
     else if (event.type === "DROP_TARGET_COMPLETE") screenShake.add(0.6);
     else if (event.type === "BOSS_TARGET_HIT") {
-      // Generic juice: any boss-target hit shakes the screen.
       screenShake.add(0.5);
     }
 
@@ -170,7 +132,6 @@ export function createEmitRouter(deps: EmitRouterDeps): GameEventListener {
       }
     }
     if (event.type === "PORTAL_ENTER") {
-      // The world switch itself is handled by the map module (onGameEvent).
       dmd.pushCinematic("portal_swallow");
     }
     if (event.type === "RETURN_PORTAL_ENTER") {
@@ -185,8 +146,7 @@ export function createEmitRouter(deps: EmitRouterDeps): GameEventListener {
       getShooterLaneGate()?.open();
     }
     if (event.type === 'DROP_TARGET_HIT') {
-      // GLB meshes follow the target_<id> convention (e.g. target_left_1);
-      // the drop id is drop_<id> → recover the visual mesh from it.
+      // drop_<id> → target_<id>: the GLB visual mesh uses the target_ prefix.
       const meshName = event.targetId.replace('drop_', 'target_');
       const mesh = getPlayfieldRoot()?.getObjectByName(meshName);
       if (mesh) mesh.visible = false;

--- a/apps/playfield/src/components/pinball/scene/createPlayfieldScene.ts
+++ b/apps/playfield/src/components/pinball/scene/createPlayfieldScene.ts
@@ -23,15 +23,6 @@ export interface PlayfieldScene {
   lights: PlayfieldSceneLights;
 }
 
-/**
- * Builds all of a map's lights from `rendering.lights`, with exact `??`
- * fallbacks. No renderer/DOM dependency: returns real THREE lights, added to
- * the scene by the caller.
- *
- * Optional lights (dir2, rim) are added straight to the scene here because
- * they are not exposed to the MapContext; ambient/hemi/dir/fill are returned
- * for the `MapContext.lighting` wiring.
- */
 export function buildManifestLights(
   scene: THREE.Scene,
   rendering: MapRenderingConfig | undefined,
@@ -59,9 +50,6 @@ export function buildManifestLights(
   dir.castShadow = false;
   scene.add(dir);
 
-  // Optional second sun (rl.dir2) on the opposite side → dual lighting that
-  // opens up the main light's shadow. Distinct from fill (reserved for
-  // UpsideDownAtmosphere). Absent from the config → single sun.
   if (rl?.dir2) {
     const dir2 = new THREE.DirectionalLight(rl.dir2.color, rl.dir2.intensity);
     dir2.position.set(rl.dir2.x, rl.dir2.y, rl.dir2.z);
@@ -69,8 +57,6 @@ export function buildManifestLights(
     scene.add(dir2);
   }
 
-  // Optional backlight (rl.rim) at the back of the table → metal edge
-  // highlight toward the camera. Near-zero cost. Absent from the config → no rim.
   if (rl?.rim) {
     const rim = new THREE.DirectionalLight(rl.rim.color, rl.rim.intensity);
     rim.position.set(rl.rim.x, rl.rim.y, rl.rim.z);
@@ -88,14 +74,6 @@ export function buildManifestLights(
   return { ambient, hemi, dir, fill };
 }
 
-/**
- * Bootstrap of a map's Three.js scene: renderer (PBR config + PMREM/
- * RoomEnvironment env map), scene + background, perspective camera + target,
- * lights from `manifest.rendering`, and the `modelRoot` group.
- *
- * React-adjacent glue (depends on the `mountEl` DOM) → lives in
- * apps/playfield. `renderer.domElement` is appended to `mountEl` here.
- */
 export function createPlayfieldScene(
   mountEl: HTMLElement,
   rendering: MapRenderingConfig | undefined,
@@ -114,12 +92,8 @@ export function createPlayfieldScene(
   const cameraTarget = new THREE.Vector3();
 
   const renderer = new THREE.WebGLRenderer({ antialias: true });
-  // Exposure + tonemapping from the map config (no global value).
   configureGltfRenderer(renderer, rendering);
 
-  // Environment map — per map (rendering.useEnvironment). ST: off → metal
-  // lit by the directionals + rim (no ambient reflections). Zelda: on →
-  // highly reflective gold/gems (Vectary look).
   if (rendering?.useEnvironment) {
     const pmrem = new THREE.PMREMGenerator(renderer);
     pmrem.compileEquirectangularShader();
@@ -131,9 +105,6 @@ export function createPlayfieldScene(
   renderer.shadowMap.enabled = false;
   mountEl.appendChild(renderer.domElement);
 
-  // ─── Lights — read from manifest.rendering ──────────────────────────────
-  // Each map fully controls its lighting setup. No shared value here: ST
-  // (cold/cinematic) and Zelda (warm/overhead) diverge.
   const lights = buildManifestLights(scene, rendering);
 
   const modelRoot = new THREE.Group();

--- a/apps/playfield/src/components/pinball/toGameEvent.ts
+++ b/apps/playfield/src/components/pinball/toGameEvent.ts
@@ -11,7 +11,6 @@ import {
 import { type ResolvedMap } from "@pinball/maps";
 import type { DevGameEventTrigger } from "@pinball/shared-types";
 
-// Maps a debug trigger → valid GameEvent (defaults from ScoringConstants).
 export function toGameEvent(d: DevGameEventTrigger, mapBosses: ResolvedMap['layout']['bosses']): GameEvent | null {
   switch (d.type) {
     case "BUMPER_HIT":
@@ -44,7 +43,6 @@ export function toGameEvent(d: DevGameEventTrigger, mapBosses: ResolvedMap['layo
     case "ASSIST":
       return { type: "ASSIST", assistId: "assist", scoreIncrement: ASSIST_SCORE };
     case "DEBUG_ADD_SCORE":
-      // Raw score → the score/tier pipeline reacts naturally.
       return { type: "ZONE_HIT", zone: "debug", scoreIncrement: d.amount ?? 1000 };
     case "DRAIN":
       return { type: "DRAIN" };
@@ -53,8 +51,6 @@ export function toGameEvent(d: DevGameEventTrigger, mapBosses: ResolvedMap['layo
     case "BALL_LAUNCHED":
       return { type: "BALL_LAUNCHED" };
     default: {
-      // Exhaustiveness guard: adding a DevGameEventTrigger.type without a case
-      // above makes `d.type` non-`never` here → typecheck fails.
       const _exhaustive: never = d.type;
       void _exhaustive;
       return null;

--- a/apps/playfield/src/components/pinball/wireGameplay.ts
+++ b/apps/playfield/src/components/pinball/wireGameplay.ts
@@ -34,7 +34,6 @@ export interface WireGameplayDeps {
   screenShake: ScreenShake;
   diag: BallDiagnostics;
   buildEmit: (hideBall: () => void) => GameEventListener;
-  /** hides the ball at game over (reads the live mesh) */
   hideBallMesh: () => void;
   restoreBossCamera: () => void;
   clearAlternateWorldSession: () => void;
@@ -57,12 +56,9 @@ export interface GameplayWiring {
   collisionProcessor: CollisionEventProcessor;
 }
 
-// Wires the gameplay core: event router (createEmitRouter), use-cases, and
-// CollisionEventProcessor. ⚠ INTENTIONAL CYCLE: the processor is built WITH
-// `emit`, and `emit` routes to the processor through lazy getters — the
-// getters below resolve to THIS factory's locals, assigned before any event.
-// Do not break this cycle (JSDoc contract in CollisionEventProcessor /
-// createEmitRouter).
+// INTENTIONAL CYCLE: the processor is built WITH `emit`, and `emit` routes
+// back to the processor through lazy getters that resolve to this factory's
+// locals (assigned before any event fires). Do not break this cycle.
 export function wireGameplay(d: WireGameplayDeps): GameplayWiring {
   const plunger = new Plunger();
 
@@ -78,7 +74,6 @@ export function wireGameplay(d: WireGameplayDeps): GameplayWiring {
     d.clearAlternateWorldSession();
   };
 
-  // Cycle forward refs: assigned below, read lazily by the router.
   let drainBallUC: DrainBall | null = null;
   let bottomOutBallUC: BottomOutBall | null = null;
   let collisionProcessor: CollisionEventProcessor | null = null;

--- a/apps/playfield/src/components/pinball/wireInputs.ts
+++ b/apps/playfield/src/components/pinball/wireInputs.ts
@@ -64,8 +64,8 @@ export function createPhysicalInputHandlers(d: PhysicalInputHandlersDeps) {
       console.log("[playfield] sensor reçu:", data, "— logique non implémentée");
     },
     onDevEvent: (trigger: DevGameEventTrigger) => {
-      // Boss via the real state path, not a raw emit — else ghost boss
-      // (visuals play but the fight is never armed).
+      // Route bosses through the real state path, not a raw emit, or the
+      // fight is never armed (visuals play but the boss is a ghost).
       if (trigger.type === "BOSS_REVEAL" || trigger.type === "BOSS_TARGET_HIT") {
         const processor = d.getCollisionProcessor();
         const bossId = trigger.bossId ?? d.mapBosses[0]?.id;

--- a/apps/playfield/src/hooks/gameStateUtils.ts
+++ b/apps/playfield/src/hooks/gameStateUtils.ts
@@ -1,20 +1,9 @@
-/**
- * gameStateUtils.ts — Pure functions and constants for game state logic.
- *
- * These utilities depend on no React state, refs, or hooks, so they can be
- * tested independently without mounting any component.
- */
-
 export const COMBO_DECAY_MS = 2000;
 export const MULTIPLIER_THRESHOLDS = [5, 10, 20, 40] as const;
 
 export const MILESTONES = [5_000, 15_000, 30_000];
-export const MILESTONE_REPEAT_EVERY = 25_000; // beyond 50k
+export const MILESTONE_REPEAT_EVERY = 25_000;
 
-/**
- * Returns the score multiplier for the current combo count.
- * Combo 0–4 → ×1, 5–9 → ×2, 10–19 → ×3, 20–39 → ×4, 40+ → ×5.
- */
 export function computeMultiplier(combo: number): number {
   if (combo < MULTIPLIER_THRESHOLDS[0]) return 1;
   if (combo < MULTIPLIER_THRESHOLDS[1]) return 2;
@@ -23,11 +12,6 @@ export function computeMultiplier(combo: number): number {
   return 5;
 }
 
-/**
- * Returns the highest milestone in {5k, 15k, 30k, 50k, 75k, 100k, …} crossed
- * between prev and next. All crossed milestones are recorded in `passed` to
- * prevent intermediate ones from re-triggering on the next event.
- */
 export function nextMilestone(prev: number, next: number, passed: Set<number>): number | null {
   let crossed: number | null = null;
   const mark = (m: number) => {
@@ -37,14 +21,10 @@ export function nextMilestone(prev: number, next: number, passed: Set<number>): 
     }
   };
   for (const m of MILESTONES) mark(m);
-  // Repeat every 25k beyond 50k.
   for (let m = 50_000; m <= next; m += MILESTONE_REPEAT_EVERY) mark(m);
   return crossed;
 }
 
-/**
- * Generates a random player name in the form PLAYER0000–PLAYER9999.
- */
 export function generatePlayerName(): string {
   const n = Math.floor(Math.random() * 10000).toString().padStart(4, "0");
   return `PLAYER${n}`;

--- a/apps/playfield/src/hooks/useDmdOrchestrator.ts
+++ b/apps/playfield/src/hooks/useDmdOrchestrator.ts
@@ -16,7 +16,6 @@ interface DisplayPushOpts {
   priority: number;
 }
 
-// Priorities (higher wins):
 const PRIO = {
   CINEMATIC: 110,
   GAME_OVER: 100,
@@ -35,8 +34,6 @@ const DURATIONS = {
 } as const;
 
 
-// alternateWorld is injected at emit time (atmosphereRef) — the stack stores
-// displays without that field. Distributive Omit over the union.
 type DisplayBase = DmdDisplay extends infer T
   ? T extends DmdDisplay
     ? Omit<T, 'alternateWorld'>
@@ -46,17 +43,14 @@ type DisplayBase = DmdDisplay extends infer T
 interface PendingDisplay {
   display: DisplayBase;
   priority: number;
-  expiresAt: number; // performance.now() + duration, Infinity when sticky
+  expiresAt: number;
 }
 
 export interface DmdOrchestrator {
-  // Low-level score broadcast (DMD data sync, independent of the display mode)
   emitScoreSnapshot: (s: ScoreUpdate) => void;
   emitGameStart: (player: string) => void;
   emitGameOver: (player: string, finalScore: number, mapId: string, stats: GameStats) => void;
-  // Fullscreen cinematic clip (max priority) — synced with playfield/backglass.
   pushCinematic: (clip: CinematicClip, value?: number) => void;
-  // High-level DMD: push a display, the orchestrator decides what to show
   pushIntro: (player: string) => void;
   pushScore: (s: ScoreUpdate) => void;
   pushEvent: (label: string, points: number, snap: ScoreUpdate) => void;
@@ -67,7 +61,6 @@ export interface DmdOrchestrator {
   setAtmosphere: (alternateWorldActive: boolean) => void;
 }
 
-// Readable labels for highlight events (boss defs injected by the map):
 function eventLabel(event: GameEvent, bosses: BossDefinition[]): string | null {
   switch (event.type) {
     case 'BOSS_REVEAL':
@@ -89,39 +82,31 @@ function eventLabel(event: GameEvent, bosses: BossDefinition[]): string | null {
       const label = bosses.find((b) => b.hud.assistLabel)?.hud.assistLabel ?? 'ASSIST';
       return label.toUpperCase();
     }
-    default: return null; // bumpers/slingshots/zones → no highlight, score only
+    default: return null;
   }
 }
 
-export { eventLabel }; // exported for tests
+export { eventLabel };
 
 export function useDmdOrchestrator(
   clips?: Record<string, ClipTimings>,
   onGameRegistered?: (data: GameRegistered) => void,
 ): DmdOrchestrator {
-  // Map clip table (manifest.clips), read through a ref so it stays fresh
-  // without recreating the orchestrator.
   const clipsRef = useRef(clips);
   clipsRef.current = clips;
-  // game:registered callback kept fresh via ref (no network-driven re-render).
   const onRegisteredRef = useRef(onGameRegistered);
   onRegisteredRef.current = onGameRegistered;
   const socketRef = useRef<PinballSocket | null>(null);
   const stackRef = useRef<PendingDisplay[]>([]);
-  const lastSentRef = useRef<string>(''); // JSON.stringify of the last display sent
+  const lastSentRef = useRef<string>('');
   const atmosphereRef = useRef<boolean>(false);
-  // Last player/score snapshot (feeds pushCinematic).
   const lastSnapRef = useRef<{ player: string; score: number }>({ player: '', score: 0 });
 
   useEffect(() => {
     socketRef.current = createPinballSocket();
 
-    // game:registered → routed to the callback (end-of-game QR). Cleared by
-    // the disconnect in the cleanup below.
     socketRef.current.on('game:registered', (d) => onRegisteredRef.current?.(d));
 
-    // Expiration tick: drop expired displays and emit the highest-priority
-    // one left (or SCORE by default).
     const tick = window.setInterval(() => {
       const now = performance.now();
       stackRef.current = stackRef.current.filter((p) => p.expiresAt > now);
@@ -142,7 +127,6 @@ export function useDmdOrchestrator(
     const top = stackRef.current
       .slice()
       .sort((a, b) => b.priority - a.priority)[0]!;
-    // alternateWorld injected here → the atmosphere travels with every display.
     const payload = { ...top.display, alternateWorld: atmosphereRef.current } as DmdDisplay;
     const serialized = JSON.stringify(payload);
     if (serialized === lastSentRef.current) return;
@@ -153,7 +137,6 @@ export function useDmdOrchestrator(
   const push = (display: DisplayBase, opts: DisplayPushOpts) => {
     const now = performance.now();
     const expiresAt = opts.duration ? now + opts.duration : Infinity;
-    // If the same mode is already present, replace it (data refresh)
     stackRef.current = stackRef.current.filter((p) => p.display.mode !== display.mode);
     stackRef.current.push({ display, priority: opts.priority, expiresAt });
     sendCurrent();
@@ -169,15 +152,11 @@ export function useDmdOrchestrator(
       socketRef.current?.emit('game:over', { player, finalScore, mapId, stats }),
 
     pushIntro: (player) => {
-      // Full reset: INTRO only shows at rest (ball not launched), so clear
-      // the stack (removes a sticky GAME_OVER / leftover SCORE).
       stackRef.current = [];
       push({ mode: 'INTRO', player }, { priority: PRIO.INTRO });
     },
 
     pushScore: (s) => {
-      // As soon as a score arrives (ball launched), INTRO and any sticky
-      // LIFE_LOST disappear; SCORE becomes the default display.
       stackRef.current = stackRef.current.filter(
         (p) => p.display.mode !== 'INTRO' && p.display.mode !== 'LIFE_LOST',
       );
@@ -219,16 +198,12 @@ export function useDmdOrchestrator(
       ),
 
     pushLifeLost: (livesRemaining, score, player) =>
-      // Sticky: persists until the next SCORE (ball relaunch), which removes
-      // it via pushScore. No duration.
       push(
         { mode: 'LIFE_LOST', livesRemaining, score, player },
         { priority: PRIO.LIFE_LOST },
       ),
 
     pushGameOver: (player, finalScore) => {
-      // GAME_OVER is sticky: no duration. To remove it, call pushIntro() on
-      // reset.
       stackRef.current = stackRef.current.filter(
         (p) => p.display.mode === 'INTRO' || p.display.mode === 'SCORE',
       );
@@ -242,7 +217,6 @@ export function useDmdOrchestrator(
       const { player, score } = lastSnapRef.current;
       push(
         { mode: 'CINEMATIC', clip, player, score, value },
-        // Fullscreen segment: SCORE mode resumes afterwards (fever shows in SCORE).
         {
           priority: PRIO.CINEMATIC,
           duration: clipTakeoverMs(clipsRef.current, clip) ?? clipShowMs(clipsRef.current, clip),
@@ -253,7 +227,6 @@ export function useDmdOrchestrator(
     setAtmosphere: (alternateWorldActive) => {
       if (atmosphereRef.current === alternateWorldActive) return;
       atmosphereRef.current = alternateWorldActive;
-      // Re-push the current display with the new atmosphere.
       lastSentRef.current = '';
       sendCurrent();
     },

--- a/apps/playfield/src/hooks/useGameState.ts
+++ b/apps/playfield/src/hooks/useGameState.ts
@@ -55,7 +55,7 @@ export interface ScoringCallbacks {
   onIdleReset?: () => void;
   onAtmosphereChange?: (alternateWorldActive: boolean) => void;
   onMilestone?: (threshold: number) => void;
-  onBossArmed?: (bossId: BossId) => void; // score threshold crossed → boss awakens (once per game)
+  onBossArmed?: (bossId: BossId) => void;
   onFeverEnd?: () => void;
 }
 
@@ -71,13 +71,9 @@ const initialBossHud = (bosses: BossDefinition[]): BossHudState =>
   Object.fromEntries(bosses.map((b) => [b.id, initialBossHudEntry()])) as BossHudState;
 
 export interface GameStateOptions {
-  /** Screen anchor for portal score pops (from layout.sensors.portal). */
   portalAnchor?: { x: number; z: number };
-  /** Screen anchors for bumper score pops (from layout.bumpers). */
   bumperAnchors?: { x: number; z: number }[];
-  /** Delay before the atmosphere hint disappears (from layout.atmosphere.hintMs). */
   atmosphereHintMs?: number;
-  /** Boss definitions for the active map (layout.bosses). */
   bosses?: BossDefinition[];
 }
 
@@ -87,9 +83,6 @@ export function useGameState(callbacks?: ScoringCallbacks, opts?: GameStateOptio
   const atmosphereHintMs = opts?.atmosphereHintMs ?? 45_000;
   const bosses = opts?.bosses ?? [];
   const bossIds = bosses.map((b) => b.id);
-  // `callbacks` is a literal object recreated on every render → read via a ref
-  // to avoid resetting the 250ms interval (combo decay + fever expiration)
-  // on every render, which could prevent it from ever firing.
   const callbacksRef = useRef(callbacks);
   callbacksRef.current = callbacks;
 
@@ -119,8 +112,6 @@ export function useGameState(callbacks?: ScoringCallbacks, opts?: GameStateOptio
   const lastEventTimeRef = useRef(0);
   const playerRef = useRef(player);
   const victoryTimersRef = useRef<Partial<Record<BossId, number>>>({});
-  // Assist flash timer (generic: the owning boss is derived from its def via `assist`).
-  // Only one assist can be active at a time.
   const assistTimerRef = useRef<number | null>(null);
   const scorePopIdRef = useRef(0);
   const scorePopTimersRef = useRef<Map<number, number>>(new Map());
@@ -145,7 +136,6 @@ export function useGameState(callbacks?: ScoringCallbacks, opts?: GameStateOptio
         setCombo(0);
         setMultiplier(1);
       }
-      // Fever expiration
       if (feverUntilRef.current && performance.now() > feverUntilRef.current) {
         feverUntilRef.current = 0;
         setFever(false);
@@ -195,7 +185,6 @@ export function useGameState(callbacks?: ScoringCallbacks, opts?: GameStateOptio
       window.clearTimeout(timer);
       delete victoryTimersRef.current[id];
     }
-    // Cancel the assist flash if this boss owns one (no hardcoded name).
     const def = getBossById(bosses, id);
     if (def?.assist && assistTimerRef.current !== null) {
       window.clearTimeout(assistTimerRef.current);
@@ -212,9 +201,6 @@ export function useGameState(callbacks?: ScoringCallbacks, opts?: GameStateOptio
 
   const clearAlternateWorldSession = useCallback(() => {
     clearAlternateWorldHint();
-    // Bosses tied to the alternate world (reveal gated by requiresAlternateWorld):
-    // reset HUD + re-arm without hardcoded names. They re-announce on the next
-    // alternate world entry.
     for (const def of bosses) {
       if (!def.reveal.requiresAlternateWorld) continue;
       clearBossHud(def.id);
@@ -252,7 +238,6 @@ export function useGameState(callbacks?: ScoringCallbacks, opts?: GameStateOptio
     callbacks?.onLifeGained?.(next);
   }, [callbacks]);
 
-  // Returns true when this drain ended the game (no lives left).
   const handleDrain = (hideBall: () => void): boolean => {
     const newLives = livesRef.current - 1;
     livesRef.current = newLives;
@@ -264,8 +249,6 @@ export function useGameState(callbacks?: ScoringCallbacks, opts?: GameStateOptio
       const stats: GameStats = {
         maxCombo: maxComboRef.current,
         maxMultiplier: maxMultiplierRef.current,
-        // Counters are filled by PinballPlayfield from mapState (fed by the map module).
-        // useGameState no longer tracks any map-specific counters.
         counters: {},
         durationS: gameStartRef.current
           ? Math.round((performance.now() - gameStartRef.current) / 1000)
@@ -323,8 +306,6 @@ export function useGameState(callbacks?: ScoringCallbacks, opts?: GameStateOptio
           maxMultiplierRef.current,
           multiplierRef.current,
         );
-        // During fever the effective multiplier is forced to 5 (combo keeps
-        // counting in the background).
         const mult = isFeverActive() ? 5 : multiplierRef.current;
         const finalPoints = event.scoreIncrement * mult;
         const prevScore = scoreRef.current;
@@ -340,13 +321,9 @@ export function useGameState(callbacks?: ScoringCallbacks, opts?: GameStateOptio
           newMultiplier: multiplierRef.current,
         });
 
-        // Score milestones (nextMilestone already records all crossed thresholds)
         const crossed = nextMilestone(prevScore, scoreRef.current, milestonesPassedRef.current);
         if (crossed) callbacks?.onMilestone?.(crossed);
 
-        // Boss awakening: threshold crossed → onBossArmed fires once per game.
-        // The set ensures uniqueness; the alternate-world/baseline gate is handled
-        // by bossThresholdMet (generic for all bosses, including world gate).
         for (const id of bossIds) {
           if (bossArmedFiredRef.current.has(id)) continue;
           const def = getBossById(bosses, id); if (!def) continue;
@@ -389,7 +366,6 @@ export function useGameState(callbacks?: ScoringCallbacks, opts?: GameStateOptio
           tone: "target",
         });
         const victory = event.hitCount >= def.targetHits;
-        // "Bosses defeated" counter: tracked by the map module (mapState).
         setBossHud((prev) => ({
           ...prev,
           [event.bossId]: {
@@ -431,7 +407,6 @@ export function useGameState(callbacks?: ScoringCallbacks, opts?: GameStateOptio
         }));
       }
       if (event.type === "ASSIST") {
-        // Owning boss is derived from its def (assist.id), not hardcoded.
         const assistBoss = bosses.find((b) => b.assist?.id === event.assistId);
         if (assistBoss) {
           const bossId = assistBoss.id;
@@ -462,14 +437,12 @@ export function useGameState(callbacks?: ScoringCallbacks, opts?: GameStateOptio
           clearAllBossHud();
         }
       }
-      // DROP_TARGET_COMPLETE (collection counter + cinematics): handled by the map module.
       if (event.type === "BALL_LAUNCHED") {
         if (gameStartRef.current === 0) gameStartRef.current = now;
         if (gameStateRef.current === "idle") callbacks?.onGameStart?.();
         updateGameState("playing");
       }
       if (event.type === "PORTAL_ENTER") {
-        // "Portals" counter: tracked by the map module (mapState).
         const point = jitterScreenPoint(
           playfieldToScreenPercent(portalAnchor.x, portalAnchor.z),
           3,
@@ -509,10 +482,8 @@ export function useGameState(callbacks?: ScoringCallbacks, opts?: GameStateOptio
       }
       if (event.type === "RETURN_PORTAL_TRANSITION_END") {
         setAlternateWorldActive(false);
-        // The ref (source of truth read by bossThresholdMet) must track the
-        // state — symmetric with PORTAL_TRANSITION_END. Otherwise the
-        // requiresAlternateWorld boss gates stay wrong after returning to the
-        // normal world.
+        // Keep the ref in sync: bossThresholdMet reads it, so a stale ref
+        // leaves requiresAlternateWorld boss gates wrong after returning.
         alternateWorldActiveRef.current = false;
         setAlternateWorldHint(false);
         if (alternateWorldHintTimerRef.current !== null) {
@@ -527,9 +498,6 @@ export function useGameState(callbacks?: ScoringCallbacks, opts?: GameStateOptio
         alternateWorldActiveRef.current = false;
         alternateWorldBaselineRef.current = 0;
         bossArmedFiredRef.current.clear();
-        // Back to the normal world: sync React state + atmosphere (HUD banner,
-        // trail, DMD) — otherwise they stay stuck in the alternate world.
-        // Symmetric with RETURN_PORTAL_TRANSITION_END.
         setAlternateWorldActive(false);
         setAlternateWorldHint(false);
         if (alternateWorldHintTimerRef.current !== null) {

--- a/apps/playfield/src/hooks/useMapAudio.ts
+++ b/apps/playfield/src/hooks/useMapAudio.ts
@@ -2,8 +2,6 @@ import { useEffect } from "react";
 import type { ResolvedMap } from "@pinball/maps";
 import { setMapAudioUrls } from "@/audio/pinballAudio";
 
-// Wires the map's audio URLs (ambient music, game-over sound, alternate-world
-// music) as a side effect, kept out of the render body.
 export function useMapAudio(manifest: ResolvedMap["manifest"]): void {
   useEffect(() => {
     setMapAudioUrls(
@@ -20,8 +18,6 @@ export function useMapAudio(manifest: ResolvedMap["manifest"]): void {
   ]);
 }
 
-// URLs to prewarm (warmMapSounds): boss sounds + alternate-world music +
-// manifest sounds. Derived from the resolved map.
 export function collectMapSoundUrls(resolvedMap: ResolvedMap): string[] {
   const bosses = resolvedMap.layout.bosses ?? [];
   return [

--- a/apps/playfield/src/hooks/useOutroAutoExit.ts
+++ b/apps/playfield/src/hooks/useOutroAutoExit.ts
@@ -1,15 +1,8 @@
 import { useEffect } from "react";
 import type { GameState } from "@/hooks/useGameState";
 
-// Idle delay on the outro/QR screen before restarting the workflow from the
-// start (reload → map selector). Frees the cabinet for the next player.
 export const OUTRO_IDLE_TIMEOUT_MS = 20_000;
 
-// Outro/QR auto-exit: after 20s in game_over, full reload → pinball.tsx boot
-// → MapSelectorScreen (or forced-map attract in mono-map). A React effect on
-// `gameState` is robust: unlike a timer in the animate closure, it is NOT
-// cancelled by network button echoes (simulate-esp32) arriving after
-// game_over; the cleanup only runs on a real exit from game_over.
 export function useOutroAutoExit(
   gameState: GameState,
   restart: () => void = () => window.location.reload(),
@@ -18,6 +11,7 @@ export function useOutroAutoExit(
     if (gameState !== "game_over") return;
     const handle = window.setTimeout(restart, OUTRO_IDLE_TIMEOUT_MS);
     return () => window.clearTimeout(handle);
-    // restart: stable identity expected (default = reload) — not a dep.
+    // restart deliberately excluded from deps: the default arg is a fresh
+    // closure each render and would reset the timer, so it never fires.
   }, [gameState]);
 }

--- a/apps/playfield/src/hooks/usePhysicalInputs.ts
+++ b/apps/playfield/src/hooks/usePhysicalInputs.ts
@@ -11,24 +11,12 @@ export interface PhysicalInputCallbacks {
   onButton?: (data: ButtonInput) => void;
   onTilt?: (data: TiltInput) => void;
   onSensor?: (data: SensorInput) => void;
-  // Inject a GameEvent from the /debug page (full chain).
   onDevEvent?: (data: DevGameEventTrigger) => void;
 }
 
 export interface UsePhysicalInputs {
   callbacksRef: React.MutableRefObject<PhysicalInputCallbacks>;
-  /**
-   * `isConnectedRef` is deliberately a ref to avoid triggering a re-render of
-   * the parent component (Three.js would unmount the scene). If a UI indicator
-   * is needed later, create a dedicated sub-component that subscribes to a store
-   * or event bus rather than lifting a useState up here.
-   */
   isConnectedRef: React.MutableRefObject<boolean>;
-  /**
-   * Emits a `dev:simulate-button` event to the server. Used by the
-   * `simulate-esp32` keyboard mode to validate the network chain without ESP32
-   * hardware. No-op if the socket isn't connected.
-   */
   simulateButton: (data: ButtonInput) => void;
 }
 

--- a/apps/playfield/src/pages/debug.tsx
+++ b/apps/playfield/src/pages/debug.tsx
@@ -10,17 +10,14 @@ import type {
 import { DEFAULT_MAP_ID } from '@pinball/shared-types'
 import { getMapPackage } from '@pinball/maps'
 
-// Active map: the debug page is data-driven (boss buttons + clips from the map).
 const MAP_ID = process.env.NEXT_PUBLIC_MAP_ID ?? DEFAULT_MAP_ID
 const MAP_PKG = getMapPackage(MAP_ID)
 const BOSSES = MAP_PKG?.layout.bosses ?? []
-// Map clips (manifest.clipFamilies) + generic core clips.
 const CINEMATIC_CLIPS = [
   ...(Object.keys(MAP_PKG?.manifest.clipFamilies ?? {}) as CinematicClip[]),
   'hall_of_fame' as CinematicClip,
   'skill_shot' as CinematicClip,
 ]
-// Editable mapState keys, declared by the map (no hardcoded keys).
 const MAP_STATE_NUMBERS = MAP_PKG?.manifest.debugMapState?.numbers ?? []
 const MAP_STATE_FLAGS = MAP_PKG?.manifest.debugMapState?.flags ?? []
 
@@ -42,7 +39,6 @@ export default function DebugPage() {
   const [combo, setCombo] = useState(6)
   const [multi, setMulti] = useState(3)
   const [lives, setLives] = useState(2)
-  // Generic numeric mapState (keys = the map's MAP_STATE_NUMBERS).
   const [mapNums, setMapNums] = useState<Record<string, number>>(() =>
     Object.fromEntries(MAP_STATE_NUMBERS.map((k) => [k, 0])),
   )
@@ -67,7 +63,6 @@ export default function DebugPage() {
 
   const pushDisplay = (d: DmdDisplay) => socketRef.current?.emit('dmd:display', d)
 
-  // Builds the generic mapState (numbers + flags set to false) for events.
   const mapStateOf = (nums: Record<string, number>) => ({
     ...nums,
     ...Object.fromEntries(MAP_STATE_FLAGS.map((f) => [f, false])),
@@ -94,7 +89,6 @@ export default function DebugPage() {
     }
   }
 
-  // ── Simulated game ─────────────────────────────────────────────────────
   const gameOverNormal = () =>
     socketRef.current?.emit('game:over', {
       player: PLAYER,

--- a/apps/playfield/src/pages/pinball.tsx
+++ b/apps/playfield/src/pages/pinball.tsx
@@ -16,7 +16,6 @@ const PORTRAIT_FILL =
   parsePlayfieldViewMode(process.env.NEXT_PUBLIC_PLAYFIELD_VIEW_MODE) === 'portrait-fill';
 const PORTRAIT_VIEWPORT =
   'width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover';
-// <link rel=preload> resource type inferred from the extension.
 function preloadAs(path: string): string {
   if (/\.(glb|gltf|bin)$/i.test(path)) return 'fetch';
   if (/\.(png|jpe?g|webp|gif|svg)$/i.test(path)) return 'image';
@@ -24,8 +23,6 @@ function preloadAs(path: string): string {
   return 'fetch';
 }
 
-// When NEXT_PUBLIC_MAP_ID is set (e.g. Fliphetic mono-map prod), bypass the
-// selector and load that map directly.
 const FORCED_MAP_ID = process.env.NEXT_PUBLIC_MAP_ID;
 
 export default function PinballPage() {
@@ -33,8 +30,6 @@ export default function PinballPage() {
     FORCED_MAP_ID ?? null,
   );
 
-  // Emits map:select to the server (→ broadcast to DMD/backglass) then
-  // updates local state. Ephemeral socket connection: create, emit, disconnect.
   const handleSelect = useCallback((mapId: string) => {
     const socket = createPinballSocket();
     socket.once('connect', () => {
@@ -48,7 +43,6 @@ export default function PinballPage() {
     ? (getMapPackage(selectedMapId)?.manifest.preload ?? [])
     : [];
 
-  // Map selector — shown when no map is forced and none is chosen yet.
   if (!selectedMapId) {
     return <MapSelectorScreen maps={AVAILABLE_MAPS} onSelect={handleSelect} />;
   }
@@ -65,11 +59,7 @@ export default function PinballPage() {
           <link key={p} rel="preload" href={p} as={preloadAs(p)} />
         ))}
       </Head>
-      {/*
-        key={selectedMapId} → fully remounts the component when the map changes
-        (e.g. back to menu + new selection). Ensures the physics engine, Three.js
-        loaders and internal refs start from scratch.
-      */}
+      {/* key forces a full remount on map change, resetting physics + Three.js. */}
       <PinballPlayfield key={selectedMapId} mapId={selectedMapId} />
     </>
   );

--- a/apps/server/src/infrastructure/GameStateManager.ts
+++ b/apps/server/src/infrastructure/GameStateManager.ts
@@ -1,9 +1,5 @@
 import { DEFAULT_MAP_ID } from '@pinball/shared-types';
 
-/**
- * Holds the current server-side game state.
- * Replaces the mutable global `let currentMapId` that lived in index.ts.
- */
 export class GameStateManager {
   private currentMapId: string = DEFAULT_MAP_ID;
 

--- a/apps/server/src/infrastructure/GlobalApiClient.ts
+++ b/apps/server/src/infrastructure/GlobalApiClient.ts
@@ -6,7 +6,7 @@ import type {
 } from '../use-cases/ports';
 export type { ScorePayload, ScoreRegistered } from '../use-cases/ports';
 
-// ETag cache: avoids re-downloading an unchanged board. Key = `${mapId}:${limit}`.
+// Key = `${mapId}:${limit}`.
 export type LeaderboardCache = Map<string, { etag: string; body: unknown }>;
 
 export interface GlobalApiConfig {
@@ -30,12 +30,11 @@ export function createGlobalApiClient({ fetch, config, cache }: GlobalApiDeps): 
 
     // cabinetId is derived from the token by the global server → not in the payload.
     const body = JSON.stringify(p);
-    // score is clamped to the contract [1, 99_999_999] by the caller.
 
     const MAX = 3;
     for (let attempt = 1; attempt <= MAX; attempt++) {
       const ctrl = new AbortController();
-      const t = setTimeout(() => ctrl.abort(), 10_000); // generous timeout
+      const t = setTimeout(() => ctrl.abort(), 10_000);
       try {
         const res = await fetch(`${base}/v1/scores`, {
           method: 'POST',
@@ -53,17 +52,14 @@ export function createGlobalApiClient({ fetch, config, cache }: GlobalApiDeps): 
           (e as { definitive?: boolean }).definitive = true;
           throw e;
         }
-        // 5xx → retry. Exhausted on the last attempt.
         if (attempt === MAX) throw new Error(`global /v1/scores ${res.status} (épuisé)`);
       } catch (err) {
-        // Definitive 4xx → no retry. gameId makes timeout/network/5xx safe to
-        // retry (the global API dedupes on gameId → idempotent).
         if ((err as { definitive?: boolean }).definitive) throw err;
         if (attempt === MAX) throw err;
       } finally {
         clearTimeout(t);
       }
-      await new Promise((r) => setTimeout(r, 500 * attempt)); // linear backoff
+      await new Promise((r) => setTimeout(r, 500 * attempt));
     }
     throw new Error('global /v1/scores: inatteignable');
   }

--- a/apps/server/src/infrastructure/PrismaGameRepository.ts
+++ b/apps/server/src/infrastructure/PrismaGameRepository.ts
@@ -9,10 +9,6 @@ import type {
   TodayRow,
 } from '../use-cases/ports';
 
-/**
- * Prisma-backed adapter for GameRepository. The composition root wires this in;
- * use-cases never import prisma directly.
- */
 export const prismaGameRepository: GameRepository = {
   async create(input: NewGame): Promise<{ id: string }> {
     const row = await prisma.game.create({

--- a/apps/server/src/interface/createApp.ts
+++ b/apps/server/src/interface/createApp.ts
@@ -1,19 +1,11 @@
 import express, { type Express } from 'express';
 import type { LeaderboardEntry, GlobalStats } from '@pinball/shared-types';
 
-/**
- * Read queries the HTTP API depends on. Injected so createApp can be
- * unit-tested with in-memory fakes — no prisma, no module mocking.
- */
 export interface LeaderboardQueries {
   worldTopTen(mapId?: string): Promise<LeaderboardEntry[]>;
   globalStats(mapId?: string): Promise<GlobalStats>;
 }
 
-/**
- * Builds the Express app (routes only — no listen, no socket, no module-level
- * side effects). The composition root (index.ts) injects the real queries.
- */
 export function createApp(queries: LeaderboardQueries): Express {
   const app = express();
 

--- a/apps/server/src/interface/index.ts
+++ b/apps/server/src/interface/index.ts
@@ -12,10 +12,6 @@ import { createLeaderboard } from '../use-cases/Leaderboard';
 import { createApp } from './createApp';
 import { createSocketGateway } from './socketGateway';
 
-// Composition root: wire the real adapters into the use-case factories. All
-// testable logic lives in createApp / createSocketGateway / the use-cases
-// (side-effect-free, port-injected). This module is the only place that knows
-// about prisma + the global API.
 const PORT = process.env.PORT || 3001;
 
 const games = prismaGameRepository;

--- a/apps/server/src/interface/socketGateway.ts
+++ b/apps/server/src/interface/socketGateway.ts
@@ -9,10 +9,6 @@ import type { GameStateManager } from '../infrastructure/GameStateManager';
 
 const INPUT_BRIDGE_ROOM = 'input-bridge';
 
-// Simple relay events: log + broadcast the payload verbatim to everyone.
-// Non-trivial handlers (map:select, dev:simulate-button, game:over, disconnect)
-// stay explicit below. Both keys of this list and the broadcast target are the
-// SAME event name — these are pure pass-through relays.
 const RELAY_EVENTS = [
   'input:button',
   'input:tilt',
@@ -22,15 +18,6 @@ const RELAY_EVENTS = [
   'dmd:display',
   'dev:trigger-game-event',
 ] as const satisfies readonly (keyof ClientToServerEvents & keyof ServerToClientEvents)[];
-
-// Narrow structural seams: only the members the connection handler touches.
-// Both the real socket.io `Server`/`Socket` AND the unit-test fakes satisfy
-// these — no `as unknown` double-cast.
-//
-// Listeners/emitters are typed against the event maps so payloads stay
-// inferred. The signatures are deliberately wide enough (a single broad
-// overload covering every event) that socket.io's per-event overloaded
-// methods remain assignable to them structurally.
 
 type ListenerFor<E> = E extends (...args: infer A) => void ? (...args: A) => void : never;
 
@@ -46,9 +33,6 @@ export interface SocketLike extends Emitter<ServerToClientEvents> {
   readonly id: string;
   readonly handshake: { auth: unknown };
   join(room: string): void | Promise<void>;
-  // Return is intentionally `void`: socket.io's real `on` returns `this`,
-  // which is assignable to a void-returning signature, while test fakes can
-  // return nothing — both satisfy this without a cast.
   on<Ev extends keyof ClientToServerEvents>(
     event: Ev,
     listener: ListenerFor<ClientToServerEvents[Ev]>,
@@ -56,20 +40,12 @@ export interface SocketLike extends Emitter<ServerToClientEvents> {
   on(event: 'disconnect', listener: () => void): void;
 }
 
-/**
- * Collaborators the socket gateway needs. Injected so the connection
- * handler is unit-testable with fakes — no prisma, no module mocking.
- */
 export interface SocketGatewayDeps {
   registerScore(data: GameOver): Promise<GameRegistered>;
   worldTopTen(mapId?: string): Promise<LeaderboardEntry[]>;
   gameState: GameStateManager;
 }
 
-/**
- * Builds the `connection` handler closed over its injected collaborators.
- * The composition root wires `io.on('connection', gateway)`.
- */
 export function createSocketGateway(deps: SocketGatewayDeps) {
   const { registerScore, worldTopTen, gameState } = deps;
 
@@ -82,8 +58,6 @@ export function createSocketGateway(deps: SocketGatewayDeps) {
       console.log('[server] input-bridge joined room');
     }
 
-    // Sync the newly connected client with the current map so DMD/backglass
-    // are up to date even if no `map:select` has been emitted yet.
     socket.emit('map:selected', { mapId: gameState.getMapId() });
 
     socket.on('map:select', ({ mapId }) => {
@@ -93,7 +67,6 @@ export function createSocketGateway(deps: SocketGatewayDeps) {
       io.emit('map:selected', { mapId });
     });
 
-    // Data-driven relays: each just logs + broadcasts verbatim.
     for (const event of RELAY_EVENTS) {
       socket.on(event, (...args: unknown[]) => {
         console.log('[server]', event, '→ broadcast');
@@ -101,9 +74,6 @@ export function createSocketGateway(deps: SocketGatewayDeps) {
       });
     }
 
-    // Dev `simulate-esp32` mode: route the event to the input-bridge room only.
-    // The input-bridge injects the raw protocol line into its mock port, its parser
-    // re-reads it and emits `input:button` back to the server, which broadcasts to all.
     socket.on('dev:simulate-button', (data) => {
       console.log('[server] dev:simulate-button', data.id, data.action, '→ input-bridge');
       io.to(INPUT_BRIDGE_ROOM).emit('dev:simulate-button', data);

--- a/apps/server/src/use-cases/Leaderboard.ts
+++ b/apps/server/src/use-cases/Leaderboard.ts
@@ -1,13 +1,11 @@
 import { type LeaderboardEntry, type GlobalStats, DEFAULT_MAP_ID } from '@pinball/shared-types';
 import type { GameRepository, LeaderboardGateway, CounterRow } from './ports';
 
-// Stable anonymous name per entry (same display on every poll, no random).
 export function anonName(playedAt: string): string {
   const n = Math.abs(Date.parse(playedAt)) % 10_000;
   return `PLAYER${n.toString().padStart(4, '0')}`;
 }
 
-// Sums numeric counters across all games.
 export function aggregateCounters(rows: CounterRow[]): { key: string; label: string; value: number }[] {
   const sums = new Map<string, number>();
   for (const row of rows) {
@@ -16,7 +14,6 @@ export function aggregateCounters(rows: CounterRow[]): { key: string; label: str
       if (typeof value === 'number') sums.set(key, (sums.get(key) ?? 0) + value);
     }
   }
-  // label = key for now; display labels will come from the map content.
   return [...sums.entries()].map(([key, value]) => ({ key, label: key, value }));
 }
 
@@ -31,10 +28,6 @@ export interface LeaderboardDeps {
   world: LeaderboardGateway;
 }
 
-/**
- * All data access goes through injected ports, so the mapping/fallback/
- * aggregation logic is unit-testable with in-memory fakes.
- */
 export function createLeaderboard({ games, world }: LeaderboardDeps) {
   async function topTen(mapId = DEFAULT_MAP_ID): Promise<LeaderboardEntry[]> {
     const rows = await games.topByScore(mapId, 10);
@@ -46,9 +39,6 @@ export function createLeaderboard({ games, world }: LeaderboardDeps) {
     }));
   }
 
-  // World leaderboard: proxy the global API, map to LeaderboardEntry.
-  // pseudo null = score not yet claimed (shown as stable anonymous name).
-  // Falls back to the local board if the global API is down (offline-safe).
   async function worldTopTen(mapId = DEFAULT_MAP_ID): Promise<LeaderboardEntry[]> {
     try {
       const data = (await world.getWorldLeaderboard(mapId, 10)) as {
@@ -56,13 +46,13 @@ export function createLeaderboard({ games, world }: LeaderboardDeps) {
       };
       return data.entries.map((e) => ({
         rank: e.rank,
-        name: e.pseudo ?? anonName(e.playedAt), // anonymous until claimed
+        name: e.pseudo ?? anonName(e.playedAt),
         score: e.score,
         date: e.playedAt,
       }));
     } catch (err) {
       console.error('[server] world leaderboard KO, fallback local:', (err as Error).message);
-      return topTen(mapId); // offline → local board
+      return topTen(mapId);
     }
   }
 

--- a/apps/server/src/use-cases/RegisterScore.ts
+++ b/apps/server/src/use-cases/RegisterScore.ts
@@ -7,19 +7,13 @@ export interface RegisterScoreDeps {
   scores: ScoreGateway;
 }
 
-/**
- * Receives a game repository + score gateway as ports, so it is unit-testable
- * with in-memory fakes — no prisma, no fetch, no mocking.
- */
 export function createRegisterScore({ games, scores }: RegisterScoreDeps) {
   return async function registerScore(data: GameOver): Promise<GameRegistered> {
     const score = Math.max(1, Math.min(99_999_999, data.finalScore)); // API contract [1..99999999]
-    const playedAt = new Date().toISOString(); // ISO with offset (Z)
-    // Idempotency: one gameId per game, constant across all internal postScore
-    // retries → the global API dedupes on it (no double insert).
+    const playedAt = new Date().toISOString();
     const gameId = randomUUID();
 
-    // 1) local record first (never lost, even if the global API is down)
+    // Local record first: never lost even if the global API is down.
     const local = await games.create({
       player: data.player,
       mapId: data.mapId,
@@ -30,7 +24,6 @@ export function createRegisterScore({ games, scores }: RegisterScoreDeps) {
       durationS: data.stats.durationS,
     });
 
-    // 2) global API → code + claimUrl
     const reg = await scores.postScore({
       gameId,
       mapId: data.mapId,
@@ -42,7 +35,6 @@ export function createRegisterScore({ games, scores }: RegisterScoreDeps) {
       playedAt,
     });
 
-    // 3) link the claim code to the local record (support/debug)
     await games.setCode(local.id, reg.code);
     console.log('[server] score global enregistré scoreId=', reg.scoreId, 'code=', reg.code);
 

--- a/apps/server/src/use-cases/ports.ts
+++ b/apps/server/src/use-cases/ports.ts
@@ -1,6 +1,3 @@
-// The use-case layer depends on these interfaces, never on prisma or fetch
-// directly. Infrastructure provides adapters; tests provide fakes.
-
 export interface NewGame {
   player: string;
   mapId: string;
@@ -11,7 +8,6 @@ export interface NewGame {
   durationS: number;
 }
 
-// Domain row views the use-cases consume (not prisma model types).
 export interface ScoreRow {
   player: string;
   score: number;
@@ -30,21 +26,14 @@ export interface TodayRow {
 }
 
 export interface GameRepository {
-  /** Persists a new local game record, returns its id. */
   create(input: NewGame): Promise<{ id: string }>;
-  /** Links the global claim code to an existing local record. */
   setCode(id: string, code: string): Promise<void>;
-  /** Top `take` games for a map, highest score first. */
   topByScore(mapId: string, take: number): Promise<ScoreRow[]>;
-  /** Counters of every game for a map (for aggregation). */
   allCounters(mapId: string): Promise<CounterRow[]>;
-  /** Game with the highest combo for a map, or null. */
   topByCombo(mapId: string): Promise<ComboRow | null>;
-  /** Highest-scoring game for a map since `since`, or null. */
   topTodayByScore(mapId: string, since: Date): Promise<TodayRow | null>;
 }
 
-// Score submission to the global API (idempotent on gameId).
 export interface ScorePayload {
   gameId: string;
   mapId: string;

--- a/packages/config/.eslintrc.json
+++ b/packages/config/.eslintrc.json
@@ -11,6 +11,7 @@
   "parser": "@typescript-eslint/parser",
   "plugins": ["@typescript-eslint"],
   "rules": {
+    "no-empty": ["error", { "allowEmptyCatch": true }],
     "@typescript-eslint/no-unused-vars": [
       "error",
       {

--- a/packages/dmd-core/src/AsciiClipPlayer.ts
+++ b/packages/dmd-core/src/AsciiClipPlayer.ts
@@ -1,8 +1,5 @@
 import { GRID_W, GRID_H } from './DmdRenderer';
 
-// Generic primitives for reading/transforming ASCII clips. No map content:
-// frames + charMaps are provided by the caller.
-
 export interface ParsedClip {
   fps: number;
   frames: string[][];
@@ -41,7 +38,6 @@ export function parseClip(src: string, charMap: Record<string, number>): ParsedC
   return { fps, frames, charMap };
 }
 
-// Draws the current frame of a frame-by-frame clip, centered on the grid.
 export function drawClipFrame(grid: Uint8Array, clip: ParsedClip, elapsedMs: number): void {
   if (!clip.frames.length) return;
   const raw = Math.floor((elapsedMs / 1000) * clip.fps);
@@ -53,7 +49,6 @@ function easeOutCubic(t: number): number {
   return 1 - Math.pow(1 - t, 3);
 }
 
-// Deterministic hash (x,y) → [0,1) — stable across frames (no flicker).
 function hash01(x: number, y: number): number {
   let n = (x * 374761393 + y * 668265263) | 0;
   n = (n ^ (n >> 13)) * 1274126177;
@@ -61,7 +56,6 @@ function hash01(x: number, y: number): number {
   return ((n >>> 0) % 1000) / 1000;
 }
 
-// Generic blit: map(char, x, y) → palette index (0 = do not draw).
 export function blit(
   grid: Uint8Array,
   lines: string[],
@@ -85,8 +79,6 @@ export function blit(
   }
 }
 
-// Radial reveal: a cell only appears if its distance to the anchor
-// (bottom-center) is within the revealed radius. The 15% front is accented.
 export function revealRadial(
   grid: Uint8Array,
   frame: string[],
@@ -109,8 +101,6 @@ export function revealRadial(
   });
 }
 
-// Dissolve: each cell has a stable threshold; it disappears once t01 exceeds
-// it, passing through ':' (dust).
 export function dissolve(
   grid: Uint8Array,
   frame: string[],

--- a/packages/dmd-core/src/DmdRenderer.ts
+++ b/packages/dmd-core/src/DmdRenderer.ts
@@ -15,12 +15,8 @@ import {
 
 export { GRID_W, GRID_H, PITCH } from './dmdGrid'
 
-// Builds an offscreen sprite (pre-rendered dot) for a color. Injectable so
-// tests avoid the global `document`.
 export type SpriteFactory = (color: string) => HTMLCanvasElement | null
 
-// Default impl: pre-renders a dot via document.createElement('canvas').
-// Halo via radial gradient (NOT shadowBlur — too expensive per dot).
 export const documentSpriteFactory: SpriteFactory = (color) => {
   const s = document.createElement('canvas')
   s.width = PITCH
@@ -38,14 +34,9 @@ export const documentSpriteFactory: SpriteFactory = (color) => {
   return s
 }
 
-// Dot-matrix renderer: logical 128×32 grid of palette indices, rendered as
-// dots (circle + halo) on a 1920×480 canvas. No React. Pure logic (grid,
-// draw plan, color stops) lives in ./dmdGrid; this class is the thin canvas
-// IO caller.
 export class DmdRenderer {
   readonly grid: Uint8Array
   private ctx: CanvasRenderingContext2D
-  // sprites[colorIndex] = pre-rendered offscreen (null for index 0 = off).
   private sprites: (HTMLCanvasElement | null)[] = []
   private palette: Palette = PALETTE_NORMAL
   private spriteFactory: SpriteFactory
@@ -74,7 +65,7 @@ export class DmdRenderer {
     this.grid.fill(0)
   }
 
-  // Phosphor decay (no clearRect) + draw the lit dots.
+  // Semi-transparent fill (NOT clearRect) leaves a phosphor-decay trail.
   render(): void {
     this.ctx.fillStyle = 'rgba(0,0,0,0.28)'
     this.ctx.fillRect(0, 0, CANVAS_W, CANVAS_H)
@@ -84,7 +75,6 @@ export class DmdRenderer {
     }
   }
 
-  // Pre-renders one dot per color of the active palette.
   private buildSprites(): void {
     const palette = this.palette
     this.sprites = [null]

--- a/packages/dmd-core/src/content.ts
+++ b/packages/dmd-core/src/content.ts
@@ -1,12 +1,8 @@
 import type { DmdDisplay } from '@pinball/shared-types';
 import type { DotColor } from './palette';
 
-// DMD content contract provided by a map. The engine (makeLayouts) stays
-// generic; the map injects its cinematics, palettes and overlays.
-
 export type ScoreDisplay = Extract<DmdDisplay, { mode: 'SCORE' }>;
 
-// Minimal context passed to a clip handler (decoupled from the DmdDisplay shape).
 export interface ClipContext {
   clip: string;
   value: number;
@@ -23,21 +19,12 @@ export type AttractRenderer = (
 ) => void;
 
 export interface DmdMapContent {
-  /** Map's normal palette (replaces the engine's PALETTE_NORMAL if provided).
-   *  Lets each map have its own default dot colors. */
   paletteNormal?: Record<DotColor, string>;
-  /** Alternate palette applied when display.alternateWorld. */
   paletteAlternateWorld?: Record<DotColor, string>;
-  /** NeonBand color (top/bottom of the DMD screen). Default: ST red. */
   neonColor?: string;
-  /** Cinematic handlers by clipId (take precedence over engine defaults). */
   cinematicHandlers?: Record<string, ClipHandler>;
-  /** Overlay drawn on top of SCORE mode (e.g. HETIC row). */
   scoreOverlay?: ScoreOverlay;
-  /** Full-screen banner when mapState.fever is active. */
   feverBanner?: FeverBanner;
-  /** Full attract-mode rendering (otherwise minimal engine default). */
   attract?: AttractRenderer;
-  /** Game Over burst duration (exit effect, ms). */
   alternateWorldBurstMs?: number;
 }

--- a/packages/dmd-core/src/dmdGrid.ts
+++ b/packages/dmd-core/src/dmdGrid.ts
@@ -1,12 +1,9 @@
-// PURE core of the DMD renderer (no canvas/DOM dependency). Lets the grid,
-// color resolution and draw plan be tested without a 2D context.
-
 export const GRID_W = 96
 export const GRID_H = 32
 export const PITCH = 20
 
-export const CANVAS_W = GRID_W * PITCH // 1920
-export const CANVAS_H = GRID_H * PITCH // 640
+export const CANVAS_W = GRID_W * PITCH
+export const CANVAS_H = GRID_H * PITCH
 
 export function hexToRgb(hex: string): [number, number, number] {
   const h = hex.replace('#', '')
@@ -17,7 +14,6 @@ export function hexToRgb(hex: string): [number, number, number] {
   ]
 }
 
-// Dot color stops (halo via radial gradient).
 export type GradientStop = { offset: number; color: string }
 
 export function spriteGradientStops(color: string): GradientStop[] {
@@ -30,10 +26,8 @@ export function spriteGradientStops(color: string): GradientStop[] {
   ]
 }
 
-// One lit dot to draw: color index + pixel position.
 export type DotDraw = { colorIndex: number; px: number; py: number }
 
-// Grid scan → list of lit dots (index 0 skipped). Row-major order (y then x).
 export function gridDrawPlan(grid: Uint8Array): DotDraw[] {
   const plan: DotDraw[] = []
   for (let y = 0; y < GRID_H; y++) {

--- a/packages/dmd-core/src/effects.ts
+++ b/packages/dmd-core/src/effects.ts
@@ -1,12 +1,9 @@
 import { DOT } from './palette'
 
-// Effects applied on the buffer AFTER layout, before render.
-
 function clamp01(v: number): number {
   return Math.max(0, Math.min(1, v))
 }
 
-// Shifts a band of rows horizontally by `dx` dots.
 function shiftBand(grid: Uint8Array, gridW: number, y0: number, rows: number, dx: number): void {
   for (let y = y0; y < y0 + rows; y++) {
     const base = y * gridW
@@ -18,7 +15,6 @@ function shiftBand(grid: Uint8Array, gridW: number, y0: number, rows: number, dx
   }
 }
 
-// Inverts a band (lit ↔ off dots; newly lit dots take the event color).
 function invertBand(grid: Uint8Array, gridW: number, gridH: number): void {
   const rows = 3 + Math.floor(Math.random() * 4)
   const y0 = Math.floor(Math.random() * (gridH - rows))
@@ -34,15 +30,15 @@ function invertBand(grid: Uint8Array, gridW: number, gridH: number): void {
 export function applyGlitch(grid: Uint8Array, gridW: number, gridH: number, t01: number): void {
   const intensity = clamp01(t01)
 
-  const bandCount = 2 + Math.floor(Math.random() * 3) // 2..4
+  const bandCount = 2 + Math.floor(Math.random() * 3)
   for (let b = 0; b < bandCount; b++) {
-    const rows = 3 + Math.floor(Math.random() * 4) // 3..6
+    const rows = 3 + Math.floor(Math.random() * 4)
     const y0 = Math.floor(Math.random() * (gridH - rows))
-    const dx = (1 + Math.floor(Math.random() * 3)) * (Math.random() < 0.5 ? -1 : 1) // ±1..3
+    const dx = (1 + Math.floor(Math.random() * 3)) * (Math.random() < 0.5 ? -1 : 1)
     shiftBand(grid, gridW, y0, rows, dx)
   }
 
-  const noise = 6 + Math.floor(Math.random() * 7 * intensity) // 6..12, decreases with t01
+  const noise = 6 + Math.floor(Math.random() * 7 * intensity)
   for (let i = 0; i < noise; i++) {
     const x = Math.floor(Math.random() * gridW)
     const y = Math.floor(Math.random() * gridH)
@@ -59,8 +55,6 @@ interface RainColumn {
   trailLen: number
 }
 
-// Matrix-style dot rain. The renderer's phosphor decay creates the natural
-// trail gradient.
 export class MatrixRain {
   private cols: RainColumn[] = []
 
@@ -78,7 +72,7 @@ export class MatrixRain {
       x,
       headY,
       speed: 0.3 + Math.random() * 0.5,
-      trailLen: 6 + Math.floor(Math.random() * 9), // 6..14
+      trailLen: 6 + Math.floor(Math.random() * 9),
     }
   }
 
@@ -91,7 +85,7 @@ export class MatrixRain {
     }
   }
 
-  // Purple background rain: does NOT overwrite dots already set by the layout.
+  // Must NOT overwrite dots already set by the layout (hence the grid[i]===0 guard).
   drawBackground(grid: Uint8Array): void {
     this.step()
     for (const c of this.cols) {
@@ -105,7 +99,6 @@ export class MatrixRain {
     }
   }
 
-  // Green burst covering everything, max density at start (t01=1) → thins out.
   drawBurst(grid: Uint8Array, t01: number): void {
     this.step()
     const density = clamp01(t01)

--- a/packages/dmd-core/src/fonts.ts
+++ b/packages/dmd-core/src/fonts.ts
@@ -1,7 +1,5 @@
-// Bitmap fonts for the dot-matrix renderer.
-// Each glyph = an array of `height` rows; each row is a bitmask of `width`
-// bits (most significant bit = leftmost column).
-// The target buffer stores a palette INDEX per dot (0 = off).
+// Each glyph = `height` rows; each row is a bitmask of `width` bits,
+// most significant bit = leftmost column.
 
 export interface BitmapFont {
   width: number
@@ -9,8 +7,6 @@ export interface BitmapFont {
   glyphs: Record<string, number[]>
 }
 
-// 5×7 — arcade charset. A-Z, 0-9, space, punctuation, 'x', '+', '-', ':',
-// '●' (filled disc for lives).
 const GLYPHS_5X7: Record<string, number[]> = {
   ' ': [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
   '.': [0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x04],
@@ -61,7 +57,6 @@ const GLYPHS_5X7: Record<string, number[]> = {
 
 export const FONT_5X7: BitmapFont = { width: 5, height: 7, glyphs: GLYPHS_5X7 }
 
-// 12×22 — large full-frame digits (Williams DMD style), 3-dot strokes.
 const GLYPHS_12X22: Record<string, number[]> = {
   '0': [0x3fc, 0x7fe, 0xe07, 0xe07, 0xe07, 0xe07, 0xe07, 0xe07, 0xe07, 0xe07, 0xe07, 0xe07, 0xe07, 0xe07, 0xe07, 0xe07, 0xe07, 0xe07, 0xe07, 0xe07, 0x7fe, 0x3fc],
   '1': [0x070, 0x1f0, 0x7f0, 0x7f0, 0x070, 0x070, 0x070, 0x070, 0x070, 0x070, 0x070, 0x070, 0x070, 0x070, 0x070, 0x070, 0x070, 0x070, 0x1fc, 0x3fc, 0x3fc, 0x3fc],
@@ -82,8 +77,6 @@ export function measureText(text: string, font: BitmapFont, spacing = 1, scale =
   return (text.length * font.width + (text.length - 1) * spacing) * scale
 }
 
-// `scale`: each glyph dot is drawn as a scale×scale block; per-character
-// advance = (width + spacing) × scale.
 export function drawText(
   grid: Uint8Array,
   gridW: number,

--- a/packages/dmd-core/src/index.ts
+++ b/packages/dmd-core/src/index.ts
@@ -1,5 +1,3 @@
-// @pinball/dmd-core — generic DMD rendering engine (dot-matrix, palettes,
-// bitmap fonts, effects). No map-specific content.
 export * from './palette';
 export * from './fonts';
 export * from './dmdGrid';

--- a/packages/dmd-core/src/layoutHelpers.ts
+++ b/packages/dmd-core/src/layoutHelpers.ts
@@ -2,14 +2,10 @@ import { FONT_5X7, drawText, measureText } from './fonts';
 import { GRID_W, GRID_H } from './DmdRenderer';
 import { DOT } from './palette';
 
-// Generic drawing helpers shared by the layout engine and map-provided clip
-// handlers. No map-specific content.
-
 export function centerX(width: number): number {
   return Math.round((GRID_W - width) / 2);
 }
 
-// "Pulse": skips the draw for 1 frame when the sine wave dips.
 export function flickerSkip(clockMs: number, period: number, floor: number): boolean {
   return Math.sin(clockMs / period) < floor;
 }
@@ -27,8 +23,6 @@ export function drawCentered(
   drawText(grid, GRID_W, x, y, text, font, color, spacing, scale);
 }
 
-// Full-frame flash at scale 2: one line if it fits (≤ 8 chars), otherwise
-// label + value on two lines.
 export function drawFlash(grid: Uint8Array, label: string, value: string, color: number): void {
   if (!value) {
     const scale = measureText(label, FONT_5X7, 1, 2) <= GRID_W ? 2 : 1;
@@ -51,7 +45,6 @@ export function plot(grid: Uint8Array, x: number, y: number, color: number): voi
   grid[py * GRID_W + px] = color;
 }
 
-// Seeded deterministic RNG (stable across frames → no flicker).
 export function seeded(n: number): number {
   const x = Math.sin(n * 127.1 + 311.7) * 43758.5453;
   return x - Math.floor(x);
@@ -61,7 +54,6 @@ export function fmtNum(n: number): string {
   return String(n).replace(/\B(?=(\d{3})+(?!\d))/g, ' ');
 }
 
-// Procedural star border (hall_of_fame): stars confined to the edges.
 export function drawStarBorder(grid: Uint8Array, ms: number): void {
   const phase = Math.floor(ms / 350);
   for (let y = 0; y < GRID_H; y++) {
@@ -77,7 +69,6 @@ export function drawStarBorder(grid: Uint8Array, ms: number): void {
   }
 }
 
-// Orange/cyan chaser lights scrolling along one row.
 export function drawChenillard(grid: Uint8Array, clockMs: number, y: number): void {
   const off = Math.floor(clockMs / 60);
   for (let x = 0; x < GRID_W; x++) {

--- a/packages/dmd-core/src/layouts.ts
+++ b/packages/dmd-core/src/layouts.ts
@@ -19,9 +19,6 @@ import type { ClipContext, ClipHandler, DmdMapContent, ScoreDisplay } from './co
 type Variant<M extends DmdDisplay['mode']> = Extract<DmdDisplay, { mode: M }>;
 export type LayoutFn = (grid: Uint8Array, display: DmdDisplay, clockMs: number) => void;
 
-// Lives row (generic). The HETIC row (ST) is drawn by content.scoreOverlay.
-// Above 3 lives (bonus/rescue) we switch to a compact "N ●" counter — driven
-// by the real number, never capped.
 function drawLivesRow(grid: Uint8Array, lives: number, y: number): void {
   const view = livesDisplay(lives);
   if (view.kind === 'count') {
@@ -36,14 +33,12 @@ function drawLivesRow(grid: Uint8Array, lives: number, y: number): void {
   }
 }
 
-// Default fever banner (chaser lights + big score). Maps can override it.
 function defaultFeverBanner(grid: Uint8Array, score: number, clockMs: number): void {
   drawChenillard(grid, clockMs, 0);
   drawChenillard(grid, -clockMs, GRID_H - 1);
   drawCentered(grid, String(score), 2, FONT_12X22, DOT.event);
 }
 
-// ── Milestone clips (procedural, generic) ─────────────────────────────────
 function clipMilestone5k(grid: Uint8Array, value: number, ms: number): void {
   const t = Math.min(1, ms / 4000);
   const cx = GRID_W / 2;
@@ -136,8 +131,6 @@ function clipHallOfFame(grid: Uint8Array, score: number, clockMs: number): void 
   }
 }
 
-// Engine default cinematic handlers (generic). A map can override them via
-// content.cinematicHandlers.
 const CORE_CINEMATICS: Record<string, ClipHandler> = {
   milestone_5k: (g, ms, c) => clipMilestone5k(g, c.value || 5000, ms),
   milestone_15k: (g, ms, c) => clipMilestone15k(g, c.value || 15000, ms),
@@ -165,7 +158,6 @@ function defaultAttract(grid: Uint8Array, display: { player: string }, clockMs: 
   }
 }
 
-// Builds the layout table for a given map content.
 export function makeLayouts(content: DmdMapContent = {}): Record<DmdDisplay['mode'], LayoutFn> {
   const attract = content.attract ?? defaultAttract;
   const feverBanner = content.feverBanner ?? defaultFeverBanner;

--- a/packages/dmd-core/src/livesDisplay.ts
+++ b/packages/dmd-core/src/livesDisplay.ts
@@ -1,11 +1,4 @@
-// DMD lives display rule.
-//
-// Up to 3 lives: row of ● dots (direct visual count). Beyond that (bonus /
-// rescue lives) dots don't scale → switch to a compact "N ●" counter. Driven
-// by the REAL number of lives, never capped at 3 (otherwise DMD ↔ game
-// desync). Shared by the canvas rendering (drawLivesRow) and the flat JSX
-// rendering (apps/dmd ?flat).
-
+// Never cap the lives count, or the DMD desyncs from the game.
 export const DOTS_MAX_LIVES = 3;
 
 export type LivesDisplay =

--- a/packages/dmd-core/src/palette.ts
+++ b/packages/dmd-core/src/palette.ts
@@ -1,6 +1,3 @@
-// DMD palettes. The grid buffer stores an INDEX (1..N) per dot; the color is
-// resolved at render time via INDEX_TO_COLOR + the active palette.
-
 export type DotColor =
   | 'score'
   | 'lives'
@@ -28,7 +25,8 @@ export const PALETTE_NORMAL: Record<DotColor, string> = {
   rainGo: '#22CC44',
 }
 
-// Index → DotColor mapping (1='score', 2='lives', …). Index 0 = dot off.
+// Order maps grid index → color (index 1 = element 0). Index 0 = dot off; must
+// stay in sync with DOT below.
 export const INDEX_TO_COLOR: DotColor[] = [
   'score',
   'lives',

--- a/packages/game-engine/src/domain/AtmosphereBlend.ts
+++ b/packages/game-engine/src/domain/AtmosphereBlend.ts
@@ -1,24 +1,7 @@
-/**
- * Pure cross-fade integrator shared by map atmosphere systems (Stranger Things
- * Upside Down, Zelda Sacred Realm). Owns {mix, targetMix, visited, pulseT,
- * lastAppliedMix} only — NO Three/material/light dependency. Each map class keeps
- * its own setup/dispose and a thin applyEase(ease) that mutates materials/lights.
- *
- * Integration rules:
- *  - step = dt / blendDuration ; mix moves toward targetMix, clamped.
- *  - ease = smoothstep(mix) = mix*mix*(3 - 2*mix).
- *  - fullyActive = mix >= 1 && targetMix >= 1.
- *  - lastAppliedMix early-out: skip apply when |mix - lastAppliedMix| < 0.001.
- *  - sporeIntensity ramp (ST): full when mix>=1 while heading active; otherwise a
- *    0.85→1 window when targetMix>=1, else mix itself.
- */
-
 export type AtmosphereTick = {
   mix: number;
   ease: number;
-  /** mix >= 1 && targetMix >= 1, computed from the post-step mix. */
   fullyActive: boolean;
-  /** mix >= 1 && targetMix >= 1, computed from the pre-step mix (live-pulse gate). */
   fullyActivePre: boolean;
   sporeIntensity: number;
 };
@@ -35,7 +18,6 @@ export class AtmosphereBlend {
     this.blendDuration = blendDuration;
   }
 
-  /** True when fully settled at rest (no transition pending and not visited). */
   isIdle(): boolean {
     return this.mix === 0 && this.targetMix === 0 && !this.visited;
   }
@@ -48,7 +30,6 @@ export class AtmosphereBlend {
     this.lastAppliedMix = -1;
   }
 
-  /** Should applyEase actually run for this mix? (lastAppliedMix early-out). */
   shouldApply(t: number): boolean {
     if (Math.abs(t - this.lastAppliedMix) < 0.001) return false;
     this.lastAppliedMix = t;
@@ -59,7 +40,6 @@ export class AtmosphereBlend {
     return t * t * (3 - 2 * t);
   }
 
-  /** Advance the cross-fade by dt and return per-tick blend factors. */
   step(dt: number): AtmosphereTick {
     const fullyActivePre = this.mix >= 1 && this.targetMix >= 1;
 
@@ -91,7 +71,6 @@ export class AtmosphereBlend {
     return this.mix;
   }
 
-  /** Latch reset once fully back at rest — call after applying. */
   releaseVisitedIfAtRest(): void {
     if (this.mix === 0 && this.targetMix === 0) {
       this.visited = false;

--- a/packages/game-engine/src/domain/Ball.ts
+++ b/packages/game-engine/src/domain/Ball.ts
@@ -1,42 +1,24 @@
-// Ball — GLB ball size=[0.0269] → radius 0.01345.
 export const DEFAULT_BALL_RADIUS = 0.01374;
 let _ballRadius = DEFAULT_BALL_RADIUS;
 export function getBallRadius(): number { return _ballRadius; }
-// Configures the radius for the current map. Must be called before any physics setup.
+// Must be called before any physics setup.
 export function configureBallRadius(r: number): void { _ballRadius = r; }
-// Restores the default radius. Mainly for tests.
 export function resetBallRadius(): void { _ballRadius = DEFAULT_BALL_RADIUS; }
-// Kept for compatibility (static value = DEFAULT_BALL_RADIUS).
 export const BALL_RADIUS = DEFAULT_BALL_RADIUS;
-export const BALL_MASS            = 0.08;   // 80 g — official standard
-export const BALL_RESTITUTION     = 0.4;    // steel on varnished wood: low bounce
-export const BALL_FRICTION        = 0.05;   // polished steel, very slippery
-// Rolling resistance: deceleration ≈ damping × v. 0.04 × 2 m/s ≈ 0.08 m/s²,
-// consistent with a steel ball on waxed wood.
+export const BALL_MASS            = 0.08;
+export const BALL_RESTITUTION     = 0.4;
+export const BALL_FRICTION        = 0.05;
 export const BALL_LINEAR_DAMPING  = 0.04;
 export const BALL_ANGULAR_DAMPING = 0.05;
 
-// Ball speed ceiling (m/s). The sim is ~1:1 real scale (mass 80g, Ø27mm, g,
-// 6.5° tilt) → these are real m/s. Real pinball: roll 0.5–1.5, launch 2.5–4.5,
-// active play 4–8, peaks ~10. 7 = lively play without tunneling
-// (CCD on + 0.02-thick shooter lane walls).
 export const BALL_MAX_SPEED = 7.0;
 
-// Ball spawn lives in the map layout (layout.spawns.ball); the engine reads the
-// injected layout. bottomOutLaneSepX(spawnX) parameterizes the bottom-out zone
-// (PlayfieldGeometry).
-
-// Plunger — impulse = mass * Δv. At full charge: 0.26/0.08 = 3.25 m/s
-// (realistic full plunge, below the BALL_MAX_SPEED clamp).
 export const PLUNGER_IMPULSE_Z = -0.26;
 
-// Playfield — GLB: center=[0,1.0171,-0.0671] size=[0.53,0.1019,0.9697]
-// Surface is already tilted in GLB geometry → gravity stays straight down
+// Surface is already tilted in the GLB geometry, so gravity stays straight down.
 export const PLAYFIELD_TILT_DEG  = 6.5;
-export const PLAYFIELD_SURFACE_Y = 1.0681; // top of playfield mesh = 1.0171 + 0.1019/2
+export const PLAYFIELD_SURFACE_Y = 1.0681;
 
-// Portal position comes from the map layout (layout.sensors.portal);
-// portal radii/scores stay generic here.
 export const PORTAL_HOLE_RADIUS = 0.02;
 export const PORTAL_COVER_RADIUS = 0.021;
 export const PORTAL_SENSOR_RADIUS = 0.017;
@@ -48,23 +30,17 @@ export const RETURN_PORTAL_ENTER_SCORE = 500;
 export const ASSIST_SCORE = 100;
 export const ASSIST_INTERVAL = 3.2;
 
-// Bump-right / bump-left (wicks). Push direction is fixed per side, not
-// contact-position dependent → no coordinates needed here.
-export const BUMP_EJECT_SCALE     = 0.45;  // 45% of a pop bumper kick
-// Anti multi-bounce: the same wick cannot re-trigger within this delay
-// (a stuck/vibrating ball must not farm score + impulses).
+export const BUMP_EJECT_SCALE     = 0.45;
+// Anti multi-bounce: the same wick cannot re-trigger within this delay so a
+// stuck/vibrating ball can't farm score + impulses.
 export const BUMP_HIT_COOLDOWN_MS = 60;
 
 export const BUMPER_RADIUS       = 0.038;
-export const BUMPER_RESTITUTION  = 0.20;  // lowered from 0.30 (−33%) — softer collider bounce
-// Pop bumper kick: Δv = impulse/mass = 0.11/0.08 = 1.38 m/s (−35% vs original 2.25 m/s).
+export const BUMPER_RESTITUTION  = 0.20;
 export const BUMPER_EJECT_IMPULSE = 0.11;
 
-/** Above this lift-off (m) over the surface, the ball is snapped back to the
- *  tilted playfield (absorbs normal physics jitter, ~6 mm). */
 export const SURFACE_SNAP_THRESHOLD = 0.006;
 
-// Walls — from GLB playfield mesh extents
 export const WALL_LEFT_X    = -0.265;
 export const WALL_RIGHT_X   =  0.265;
 export const WALL_TOP_Z     = -0.552;
@@ -72,10 +48,7 @@ export const WALL_BOTTOM_Z  =  0.418;
 export const WALL_HEIGHT    =  0.06;
 export const WALL_THICKNESS =  0.006;
 
-// Drain threshold is analytic — see DRAIN_Z_THRESHOLD in PlayfieldGeometry.
-
-// Slingshots — from GLB slingshot center=[−0.0225,1.032,0.1162] size=[0.2881,_,0.1132]
-// Y lowered to surface level so ball doesn't land on top
+// Y is lowered to surface level so the ball doesn't land on top of the slingshot.
 export const SLINGSHOT_LEFT_CENTER  = { x: -0.166, y: 1.005, z: 0.116 } as const;
 export const SLINGSHOT_RIGHT_CENTER = { x:  0.121, y: 1.005, z: 0.116 } as const;
 export const SLINGSHOT_RESTITUTION  = 0.8;

--- a/packages/game-engine/src/domain/BossDefeatTimers.ts
+++ b/packages/game-engine/src/domain/BossDefeatTimers.ts
@@ -1,25 +1,11 @@
-// Registry of boss-defeat timers shared by map modules (ST, Zelda). On defeat,
-// the module slows time (setTimeScale) then schedules a setTimeout to restore
-// it + play the cinematic. Untracked, these timers leak: they fire after a
-// reset/dispose (restoring the timescale of a finished game) and stack when
-// the same boss re-triggers.
-//
-// This registry keeps one timer per bossId (a new one cancels the previous)
-// and cancels everything on reset/dispose. The scheduler is injectable so
-// tests run without a DOM; defaults to `window`.
-
 export interface TimerScheduler {
   setTimeout(handler: () => void, timeout: number): number;
   clearTimeout(handle: number): void;
 }
 
 export interface BossDefeatTimers {
-  // Schedules (or replaces) a boss defeat timer. `delayMs` preserves the
-  // per-map historical delay (200 ms ST, 400 ms Zelda).
   schedule(bossId: string, delayMs: number, run: () => void): void;
-  // Cancels one boss timer (no-op if none).
   clear(bossId: string): void;
-  // Cancels all pending timers (reset/dispose).
   clearAll(): void;
 }
 
@@ -46,8 +32,7 @@ export function createBossDefeatTimers(
   }
 
   function schedule(bossId: string, delayMs: number, run: () => void): void {
-    // One timer per boss: cancel any previous one before arming a new one
-    // (no stacking when BOSS_TARGET_HIT re-triggers at the threshold).
+    // One timer per boss: cancel any previous one so re-triggers don't stack.
     clear(bossId);
     handles[bossId] = scheduler.setTimeout(() => {
       delete handles[bossId];

--- a/packages/game-engine/src/domain/BossRegistry.ts
+++ b/packages/game-engine/src/domain/BossRegistry.ts
@@ -86,24 +86,12 @@ export type BossDefinition = {
   targetPulse: BossTargetPulseConfig;
   revealSoundUrl?: string;
   revealSoundVolume?: number;
-  /** Late-phase music (e.g. win-music when hitCount >= threshold). */
   latePhaseSoundUrl?: string;
   latePhaseSoundVolume?: number;
   latePhaseHitThreshold?: number;
-  /** After BOSS_FIGHT_END, keeps revealSoundUrl until this boss's BOSS_REVEAL. */
   keepMusicUntilBossReveal?: BossId;
-  /**
-   * On victory (BOSS_FIGHT_END), keeps the current music until the return
-   * portal cinematic ends (RETURN_PORTAL_TRANSITION_END) instead of cutting it
-   * immediately. Useful when an ending track must accompany the exit
-   * cinematic. Data-driven: no hardcoded boss logic on the apps side.
-   */
   keepMusicUntilReturnPortal?: boolean;
-  /**
-   * Music played on victory over this boss (BOSS_FIGHT_END), replacing the
-   * current fight music. Requires keepMusicUntilReturnPortal:true for the
-   * music to survive until RETURN_PORTAL_TRANSITION_END.
-   */
+  // Requires keepMusicUntilReturnPortal:true to survive until RETURN_PORTAL_TRANSITION_END.
   victoryMusicUrl?: string;
   victoryMusicVolume?: number;
   assist?: { id: string };

--- a/packages/game-engine/src/domain/BumperEjection.ts
+++ b/packages/game-engine/src/domain/BumperEjection.ts
@@ -4,11 +4,6 @@ export interface EjectionImpulse {
   z: number;
 }
 
-/**
- * Radial ejection impulse: pushes the ball away from the bumper in the XZ
- * plane. The `|| 1` guard avoids division by zero when the ball sits exactly
- * at the center.
- */
 export function radialEjectionImpulse(
   ballPos: { x: number; z: number },
   bumperPos: { x: number; z: number },
@@ -16,14 +11,10 @@ export function radialEjectionImpulse(
 ): EjectionImpulse {
   const dx = ballPos.x - bumperPos.x;
   const dz = ballPos.z - bumperPos.z;
-  const len = Math.sqrt(dx * dx + dz * dz) || 1;
+  const len = Math.sqrt(dx * dx + dz * dz) || 1; // || 1: avoid /0 when ball is at center
   return { x: (dx / len) * magnitude, y: 0, z: (dz / len) * magnitude };
 }
 
-/**
- * Deterministic sided impulse: bump_left pushes right (+X), bump_right pushes
- * left (-X). Horizontal direction is independent of the impact point.
- */
 export function sidedEjectionImpulse(side: 'left' | 'right', magnitude: number): EjectionImpulse {
   const xDir = side === 'left' ? 1 : -1;
   return { x: xDir * magnitude, y: 0, z: 0 };

--- a/packages/game-engine/src/domain/BumperVisualMath.ts
+++ b/packages/game-engine/src/domain/BumperVisualMath.ts
@@ -6,10 +6,6 @@ export interface BumperPoint {
   z: number;
 }
 
-/**
- * Index of the layout bumper closest to a world position (squared distance,
- * no sqrt). Returns 0 when the list is empty.
- */
 export function nearestBumperIndex(pos: BumperPoint, bumpers: readonly BumperPoint[]): number {
   let best = 0;
   let bestDist = Infinity;
@@ -27,22 +23,13 @@ export function nearestBumperIndex(pos: BumperPoint, bumpers: readonly BumperPoi
   return best;
 }
 
-/**
- * Bumper "punch" scale factor: 1 → 1+peak → 1 over the duration, easeOutBack
- * on the way up then linear back down. `remaining` is the time left (s),
- * `duration` the total duration (s). remaining <= 0 → factor 1.
- */
 export function bumperPunchScale(remaining: number, duration: number, peak: number): number {
   if (remaining <= 0) return 1;
-  const prog = 1 - remaining / duration; // 0 → 1
+  const prog = 1 - remaining / duration;
   const env = prog < 0.5 ? easeOutBack(prog * 2) : 1 - (prog - 0.5) * 2;
   return 1 + peak * Math.max(0, env);
 }
 
-/**
- * Decrements every timer in `timers` by `dt` in place, deleting entries that
- * reach 0 or below. Only mutates the injected Map; no THREE dependency.
- */
 export function tickPunchTimers(timers: Map<number, number>, dt: number): void {
   for (const [idx, t] of timers) {
     const next = t - dt;
@@ -51,18 +38,12 @@ export function tickPunchTimers(timers: Map<number, number>, dt: number): void {
   }
 }
 
-/** Minimal scale-punch target: a mesh with a bumper index. */
 export interface BumperScaleTarget {
   bumperIndex: number;
   baseScale: { x: number; y: number; z: number };
   mesh: { scale: { copy(v: { x: number; y: number; z: number }): { multiplyScalar(s: number): unknown } } };
 }
 
-/**
- * Applies the "punch" scale to each part: `baseScale × bumperPunchScale(...)`
- * from the remaining time in `timers` (missing → 0 → factor 1, i.e. back to
- * baseScale).
- */
 export function applyPunchScale(
   parts: readonly BumperScaleTarget[],
   timers: Map<number, number>,
@@ -76,33 +57,16 @@ export function applyPunchScale(
   }
 }
 
-/**
- * Classification of a GLB node by the bumper matcher:
- * - `skip`: not a bumper (ignored).
- * - `hide`: must be hidden (legacy mesh replaced), no part.
- * - `part`: a visual bumper of category `kind`.
- *
- * `kind` is map-defined (free string) — the core does not know the specific
- * categories (gltf/base/ring on the ST side, etc.).
- */
 export type BumperMatch<K extends string> =
   | { action: 'skip' }
   | { action: 'hide' }
   | { action: 'part'; kind: K };
 
-/**
- * Bumper matching rule: if `pattern` matches the normalized name, the node
- * gets `result`. Rules are evaluated in order, first match wins.
- */
 export interface BumperMatchRule<K extends string> {
   pattern: RegExp;
   result: BumperMatch<K>;
 }
 
-/**
- * Classifies a normalized mesh name through an ordered rule list (first
- * matching pattern wins). No matching rule → `skip`.
- */
 export function classifyBumperName<K extends string>(
   normalizedName: string,
   rules: readonly BumperMatchRule<K>[],

--- a/packages/game-engine/src/domain/CameraCinematicConstants.ts
+++ b/packages/game-engine/src/domain/CameraCinematicConstants.ts
@@ -17,9 +17,6 @@ export type BossCameraCinematicConfig = {
   distanceScale: number;
 };
 
-/**
- * Default camera→boss facing direction, shared by ST + Zelda boss cinematics.
- */
 export const DEFAULT_BOSS_FACE_DIR: BossCameraFocus = { x: -0.52, y: 0.2, z: 0.83 };
 
 export const CAMERA_CINEMATIC_DISTANCE_MIN = 0.05;

--- a/packages/game-engine/src/domain/FlipperConstants.ts
+++ b/packages/game-engine/src/domain/FlipperConstants.ts
@@ -1,35 +1,18 @@
-// ── Geometry ────────────────────────────────────────────────────────────────
 export const SWING_RAD    = 0.75;
 export const SWING_SMOOTH = 0.78;
 export const HINGE_INSET_FROM_EDGE = 0.0;
 
-// Flipper Z zone (PlayfieldGeometry + BallDiagnostics). X bounds are derived
-// from the mesh bboxes at load time (see FlipperZones.ts).
 export const FLIPPER_Z_MIN = 0.20;
 export const FLIPPER_Z_MAX = 0.33;
 
-// ── Contact physics ──────────────────────────────────────────────────────────
-export const FLIPPER_POWER       = 0.138;   // kept for compatibility (unused)
+export const FLIPPER_POWER       = 0.138;
 export const FLIPPER_RESTITUTION = 0.82;
 export const FLIPPER_FRICTION    = 0.05;
 
-// ── Guaranteed minimum launch speed (uniform launches) ────────────────
-/** Guaranteed minimum Z speed when the flipper hits the ball (m/s, negative = up the table). */
 export const FLIPPER_MIN_LAUNCH_VZ = -2.8;
-/**
- * Flipper upswing angular velocity (rad/s) above which the ball is guaranteed
- * FLIPPER_MIN_LAUNCH_VZ. Normalized to rad/s (was 0.004 rad/frame × 60 = 0.24)
- * → fps-independent.
- */
 export const FLIPPER_MIN_LAUNCH_ANGVEL = 0.24;
-/**
- * Attenuation factor applied to the X velocity component on a guaranteed
- * launch. Without it, accumulated X produces unrealistic sideways launches;
- * we want launches mostly up the table (−Z).
- */
 export const FLIPPER_LAUNCH_VX_ATTENUATION = 0.3;
 
-// ── Game ──────────────────────────────────────────────────────────────────────
 export const INITIAL_LIVES    = 3;
 export const PLUNGER_CHARGE_MS = 1800;
 export const PLUNGER_MIN_FACTOR = 0.6;

--- a/packages/game-engine/src/domain/HeticProgress.ts
+++ b/packages/game-engine/src/domain/HeticProgress.ts
@@ -1,20 +1,13 @@
-// Pure decisions shared by map modules (ST, Zelda): HETIC counter progression
-// and milestone clip selection per score threshold.
-
 export interface HeticProgress {
   display: number;
   completed: boolean;
 }
 
-// Display state of the HETIC counter after an increment.
-// count >= 5 → full word (display 5, completed). The caller handles the reset.
 export function resolveHeticProgress(count: number): HeticProgress {
   if (count < 5) return { display: count, completed: false };
   return { display: 5, completed: true };
 }
 
-// MapContext subset needed by the HETIC rollover, so advanceHetic can be
-// tested with a fake ctx (spies).
 export interface HeticContext {
   setMapState(patch: { hetic: number }): void;
   playCinematic(clipId: string, opts?: { value?: number; onEnd?: () => void }): void;
@@ -22,9 +15,6 @@ export interface HeticContext {
   refreshScoreSnapshot(): void;
 }
 
-// Shared HETIC rollover effect (DROP_TARGET_COMPLETE): increments the counter,
-// plays the letter or full-word cinematic (with 30s Fever), and returns the
-// next counter value (reset to 0 after completion). The caller stores it.
 export function advanceHetic(ctx: HeticContext, currentCount: number): number {
   const next = currentCount + 1;
   const progress = resolveHeticProgress(next);
@@ -36,7 +26,6 @@ export function advanceHetic(ctx: HeticContext, currentCount: number): number {
   ctx.setMapState({ hetic: progress.display });
   ctx.playCinematic('hetic_complete', {
     onEnd: () => {
-      // 30s Fever: forced multiplier + immediate SCORE refresh.
       ctx.forceMultiplier(5, 30_000);
       ctx.refreshScoreSnapshot();
     },
@@ -51,7 +40,6 @@ export type MilestoneClipId =
   | 'milestone_30k'
   | 'milestone_big';
 
-// Milestone clip for a given score threshold.
 export function selectMilestoneClip(threshold: number): MilestoneClipId {
   if (threshold === 5000) return 'milestone_5k';
   if (threshold === 15000) return 'milestone_15k';

--- a/packages/game-engine/src/domain/LiveGameSnapshot.ts
+++ b/packages/game-engine/src/domain/LiveGameSnapshot.ts
@@ -1,7 +1,3 @@
-/**
- * State snapshot read by UI hooks that must emit network events (DMD display,
- * score broadcast) without touching useGameState's internal refs.
- */
 export interface LiveGameSnapshot {
   score: number;
   lives: number;

--- a/packages/game-engine/src/domain/MapEventHelpers.ts
+++ b/packages/game-engine/src/domain/MapEventHelpers.ts
@@ -1,23 +1,14 @@
-// onGameEvent effects shared between map modules (ST, Zelda). Each helper
-// takes only the MapContext subset it needs, so it can be tested with a fake
-// ctx (spies) without the full MapContext.
-
 import type { GameEvent } from './GameEvents';
 
-// MapContext subset needed by the shared-events DMD banner.
 export interface DmdEventContext {
   pushDmdEvent(label: string, points: number): void;
 }
 
-// BOSS_LOCKED_HIT → DMD banner "ENCORE <remaining> PTS".
 export function handleBossLockedHit(ctx: DmdEventContext, e: GameEvent): void {
   if (e.type !== 'BOSS_LOCKED_HIT') return;
   ctx.pushDmdEvent(`ENCORE ${e.remaining} PTS`, 0);
 }
 
-// BOSS_ARMED → timestamps the nest arming + DMD banner "LE NID S EVEILLE".
-// The late hint (dueLateHints) consumes armedAt. The caller (map) handles
-// map-specific visual effects (garlands celebrate, screenShake).
 export function handleBossArmed(
   ctx: DmdEventContext,
   e: GameEvent,
@@ -29,14 +20,10 @@ export function handleBossArmed(
   ctx.pushDmdEvent('LE NID S EVEILLE', 0);
 }
 
-// True when the event is a drain game over (DRAIN/BOTTOM_OUT + gameState
-// game_over): the caller must then end all boss fights.
 export function isGameOverDrain(e: GameEvent, gameState: string): boolean {
   return (e.type === 'DRAIN' || e.type === 'BOTTOM_OUT') && gameState === 'game_over';
 }
 
-// Does hitCount reach a boss victory threshold? Centralizes the
-// `boss && e.hitCount >= boss.targetHits` pattern repeated per boss.
 export function isBossTargetDefeated(
   targetHits: number | undefined,
   hitCount: number,

--- a/packages/game-engine/src/domain/MapLayout.ts
+++ b/packages/game-engine/src/domain/MapLayout.ts
@@ -1,8 +1,5 @@
 import type { BossDefinition } from './BossRegistry';
 
-// Placement/geometry data for a map, injected into the engine. TYPES live in
-// game-engine; VALUES live in the map package (layout.ts).
-
 export interface MapPoint3 {
   x: number;
   y: number;
@@ -23,19 +20,19 @@ export interface DropTargetDef {
 }
 
 export interface SensorLayout {
-  popZones: MapPoint3[]; // pop-bumper zone sensors
-  rocket: MapPoint3; // ramp sensor
-  bossReveal: MapPoint3; // boss-reveal flash anchor (normal world)
-  portal: MapPoint3; // alternate-world portal anchor
-  scoop?: MapPoint3; // saucer hole sensor: capture → rewards → kick. Optional.
+  popZones: MapPoint3[];
+  rocket: MapPoint3;
+  bossReveal: MapPoint3;
+  portal: MapPoint3;
+  scoop?: MapPoint3;
 }
 
 export interface SpawnLayout {
-  ball: MapPoint3; // shooter lane spawn
-  alternateWorld: MapPoint2; // alternate-world spawn
-  alternateWorldImpulse: MapPoint3; // alternate-world entry impulse
-  normalReturn: MapPoint2; // return-to-normal-world spawn
-  normalReturnImpulse: MapPoint3; // return impulse
+  ball: MapPoint3;
+  alternateWorld: MapPoint2;
+  alternateWorldImpulse: MapPoint3;
+  normalReturn: MapPoint2;
+  normalReturnImpulse: MapPoint3;
 }
 
 export interface ShooterLaneLayout {
@@ -74,25 +71,24 @@ export interface SurfaceCoefficients {
 }
 
 export interface PlayfieldBounds {
-  leftX: number; // WALL_LEFT_X
-  rightX: number; // WALL_RIGHT_X
-  topZ: number; // WALL_TOP_Z
-  bottomZ: number; // WALL_BOTTOM_Z
+  leftX: number;
+  rightX: number;
+  topZ: number;
+  bottomZ: number;
 }
 
 export interface GeometryLayout {
   coefficients: SurfaceCoefficients;
   bounds: PlayfieldBounds;
   shade: {
-    width: number; // PLAYFIELD_SHADE_W
-    depth: number; // PLAYFIELD_SHADE_D
-    y: number; // PLAYFIELD_SHADE_Y
-    z: number; // PLAYFIELD_SHADE_Z
-    maxOpacity: number; // PLAYFIELD_SHADE_MAX_OPACITY
+    width: number;
+    depth: number;
+    y: number;
+    z: number;
+    maxOpacity: number;
   };
 }
 
-// All alternate-world atmosphere tuning (atmosphere is provided by the map).
 export interface AtmosphereLayout {
   transition: {
     durationS: number;
@@ -132,9 +128,7 @@ export interface AtmosphereLayout {
   blendStrobeHz: number;
   sporeCount: number;
   hintMs: number;
-  /** Active-atmosphere banner label (e.g. « monde alternatif »). */
   bannerLabel: string;
-  /** Atmosphere-entry hint label (e.g. « Le monde s'est inversé… »). */
   hintLabel: string;
 }
 

--- a/packages/game-engine/src/domain/MapModule.ts
+++ b/packages/game-engine/src/domain/MapModule.ts
@@ -62,12 +62,8 @@ export interface MapContext {
 export interface MapModule {
   setup(ctx: MapContext): void;
   preload?(): Promise<void>;
-  /**
-   * Called BEFORE the life decrement (handleDrain) applies, on a
-   * DRAIN/BOTTOM_OUT, with the PRE-decrement life count. Lets a map grant a
-   * life before the decrement (e.g. last-life save) to avoid the game over.
-   * Must do NOTHING besides that save.
-   */
+  // Called BEFORE the life decrement, with the PRE-decrement count, so a map
+  // can grant a life to avoid game over. Must do NOTHING besides that save.
   onPreDrain?(livesBeforeDrain: number): void;
   onGameEvent(e: GameEvent): void;
   update(dt: number): void;

--- a/packages/game-engine/src/domain/NestState.ts
+++ b/packages/game-engine/src/domain/NestState.ts
@@ -3,11 +3,8 @@ import type { BossDefinition, BossGateContext } from './BossRegistry';
 
 export type NestState = 'locked' | 'armed' | 'revealed';
 
-// Delay before the late nest hint: armed > 45 s without a reveal.
 export const NEST_LATE_HINT_MS = 45_000;
 
-// Boss nest state: triggered → revealed; else score threshold met → armed;
-// else locked.
 export function resolveNestState(
   boss: BossDefinition,
   gate: BossGateContext,
@@ -17,8 +14,7 @@ export function resolveNestState(
   return bossThresholdMet(boss, gate) ? 'armed' : 'locked';
 }
 
-// Which candidate bosses must emit their late hint now (armed >= 45 s, not
-// yet emitted). Idempotent; the caller marks hintFired after emitting.
+// Caller must mark hintFired after emitting; this function does not mutate it.
 export function dueLateHints(
   bossIds: readonly string[],
   armedAt: Readonly<Record<string, number>>,

--- a/packages/game-engine/src/domain/PlayfieldGeometry.ts
+++ b/packages/game-engine/src/domain/PlayfieldGeometry.ts
@@ -9,9 +9,6 @@ import {
 import { FLIPPER_Z_MAX } from './FlipperConstants';
 import type { SurfaceCoefficients } from './MapLayout';
 
-// Tilted-surface curve, parameterized per map (layout.geometry.coefficients).
-// Default = Stranger Things values → identical behavior as long as no map
-// calls configureSurfaceCoefficients().
 const DEFAULT_SURFACE_COEFFICIENTS: SurfaceCoefficients = {
   base: 1.068,
   zOffset: 0.552,
@@ -21,16 +18,12 @@ const DEFAULT_SURFACE_COEFFICIENTS: SurfaceCoefficients = {
 
 let surfaceCoefficients: SurfaceCoefficients = DEFAULT_SURFACE_COEFFICIENTS;
 
-/**
- * Configures the surface curve from the map layout. Call once at load time,
- * BEFORE any physics/camera setup (spawns, colliders and camera framing all
- * derive from surfaceYAtZ).
- */
+// Call once at load time, BEFORE any physics/camera setup: spawns, colliders
+// and camera framing all derive from surfaceYAtZ.
 export function configureSurfaceCoefficients(coefficients: SurfaceCoefficients): void {
   surfaceCoefficients = coefficients;
 }
 
-/** Restores the default curve (Stranger Things). Mainly for tests. */
 export function resetSurfaceCoefficients(): void {
   surfaceCoefficients = DEFAULT_SURFACE_COEFFICIENTS;
 }
@@ -40,7 +33,6 @@ export function surfaceYAtZ(z: number): number {
   return base - ((z + zOffset) / zSpan) * yDrop;
 }
 
-/** Sphere center resting on the tilted surface at the given Z. */
 export function ballCenterOnSurface(z: number, margin = 0.002): number {
   return surfaceYAtZ(z) + getBallRadius() + margin;
 }
@@ -49,8 +41,6 @@ export const DRAIN_Z_THRESHOLD = WALL_BOTTOM_Z + DEFAULT_BALL_RADIUS * 2;
 
 export const BOTTOM_OUT_Z = FLIPPER_Z_MAX + 0.025;
 
-// Bottom-out zone X separator, derived from the spawn:
-// laneSepX = spawnX - 2 × ball radius.
 export function bottomOutLaneSepX(spawnX: number): number {
   return spawnX - getBallRadius() * 2;
 }
@@ -59,10 +49,8 @@ export function isInBottomOutZone(x: number, z: number, laneSepX: number = WALL_
   return z >= BOTTOM_OUT_Z && x <= laneSepX;
 }
 
-// ── Diagnostics: lost-ball detection (out of world) ──────────────────────────
 // Playfield surface ∈ [0.958, 1.068]; below 0.90 the ball fell into the void.
 export const BALL_LOST_Y_THRESHOLD = 0.90;
-// Margin beyond the walls before the ball counts as out of bounds.
 export const BALL_OOB_MARGIN = 0.08;
 
 export function isBallOutOfBounds(x: number, z: number): boolean {

--- a/packages/game-engine/src/domain/PlayfieldVisualConstants.ts
+++ b/packages/game-engine/src/domain/PlayfieldVisualConstants.ts
@@ -1,7 +1,5 @@
-// Default rendering values — used when manifest.rendering is absent. Maps
-// MUST declare their own MapRenderingConfig in manifest.rendering to customize
-// rendering. These constants must NOT be tuned for a specific map.
-
+// Defaults used when manifest.rendering is absent. Do NOT tune these for a
+// specific map — maps declare their own MapRenderingConfig in manifest.rendering.
 export const DEFAULT_TONE_MAPPING_EXPOSURE = 1.3;
 export const DEFAULT_MAP_COLOR_DARKEN = 0.9;
 export const DEFAULT_ENVIRONMENT_BLUR = 0.04;
@@ -10,8 +8,7 @@ export const DEFAULT_ENV_METALLIC = 1.0;
 export const DEFAULT_ENV_SEMI     = 1.0;
 export const DEFAULT_ENV_BASE     = 1.0;
 
-// Legacy aliases (some files still import the old names). Remove once all
-// consumers migrate to manifest.rendering.
+// TODO: remove these aliases once all consumers migrate to manifest.rendering.
 /** @deprecated use manifest.rendering.toneMappingExposure */
 export const PLAYFIELD_TONE_MAPPING_EXPOSURE = DEFAULT_TONE_MAPPING_EXPOSURE;
 /** @deprecated use manifest.rendering.colorDarken */

--- a/packages/game-engine/src/domain/RenderInterpolation.ts
+++ b/packages/game-engine/src/domain/RenderInterpolation.ts
@@ -1,26 +1,15 @@
-// Render interpolation: physics runs at 60 real steps/s but the screen may
-// refresh at 120/144 Hz. Rendering lerps the ball position between the last
-// two physics states — purely visual, zero impact on the simulation.
-
 export interface Vec3Like {
   x: number;
   y: number;
   z: number;
 }
 
-/**
- * Max plausible distance the ball can travel in ONE physics step:
- * BALL_MAX_SPEED (7 m/s) × SIM_TIMESTEP (1/98 s) ≈ 0.071 m. Anything beyond is
- * necessarily an external teleport (direct setTranslation: map scoop, boss
- * intro hold, debug drag, stepBallSync locks) → rendering must snap instead of
- * lerping, or the ball streaks across the playfield for a frame.
- */
+// Max plausible distance the ball travels in one physics step is
+// BALL_MAX_SPEED (7 m/s) × SIM_TIMESTEP (1/98 s) ≈ 0.071 m. Beyond this is an
+// external teleport (setTranslation from scoop/boss hold/debug drag/locks);
+// rendering must snap instead of lerping.
 export const BALL_INTERPOLATION_TELEPORT_DIST = 0.08;
 
-/**
- * Per-component lerp, alpha clamped to [0,1] (never extrapolates).
- * Writes into the caller-provided `out` — zero allocation in the hot path.
- */
 export function lerpVec3(prev: Vec3Like, curr: Vec3Like, alpha: number, out: Vec3Like): Vec3Like {
   const t = alpha < 0 ? 0 : alpha > 1 ? 1 : alpha;
   out.x = prev.x + (curr.x - prev.x) * t;

--- a/packages/game-engine/src/domain/RevealCountdown.ts
+++ b/packages/game-engine/src/domain/RevealCountdown.ts
@@ -1,12 +1,8 @@
-/**
- * Countdown driven by dt (game frames), not wall clock: a
- * setTimeout/performance.now would keep running during physics freezes
- * (cinematics, time-scale), while the delay must follow game time.
- */
+// Driven by dt (game time), not wall clock: a wall-clock timer would keep
+// running during physics freezes (cinematics, time-scale).
 export class RevealCountdown {
   private remainingS = 0;
 
-  /** Idempotent: a countdown already running is not overwritten. */
   start(delayS: number): void {
     if (this.remainingS > 0) return;
     this.remainingS = delayS;
@@ -20,7 +16,6 @@ export class RevealCountdown {
     return this.remainingS > 0;
   }
 
-  /** Returns true only on the frame where the delay expires. */
   tick(dt: number): boolean {
     if (this.remainingS <= 0) return false;
     this.remainingS -= dt;

--- a/packages/game-engine/src/domain/ScoringConstants.ts
+++ b/packages/game-engine/src/domain/ScoringConstants.ts
@@ -1,6 +1,3 @@
-// Boss scores (reveal/target) come from the map's boss definitions
-// (manifest.scoring + layout.bosses).
-
 export const SCORE_BUMPER = 1000;
 export const SCORE_BUMP   = 30;
 export const SCORE_SLINGSHOT = 10;
@@ -8,4 +5,4 @@ export const SCORE_POP_ZONE = 50;
 export const SCORE_RAMP = 200;
 export const SCORE_DROP_TARGET = 75;
 export const SCORE_DROP_COMPLETE = 500;
-export const SCORE_SCOOP = 2500; // scoop/saucer capture (big bonus + map rewards)
+export const SCORE_SCOOP = 2500;

--- a/packages/game-engine/src/index.ts
+++ b/packages/game-engine/src/index.ts
@@ -1,4 +1,3 @@
-// Domain
 export * from './domain/Ball';
 export * from './domain/Plunger';
 export * from './domain/GameEvents';
@@ -22,7 +21,6 @@ export * from './domain/AtmosphereBlend';
 export * from './domain/RevealCountdown';
 export * from './domain/RenderInterpolation';
 
-// Use-cases
 export * from './use-cases/LaunchBall';
 export * from './use-cases/BumperHit';
 export * from './use-cases/BumpHit';
@@ -34,7 +32,6 @@ export * from './use-cases/SnapBallToSurface';
 export * from './use-cases/BallFrameCorrections';
 export * from './use-cases/FlipperLaunchAssist';
 
-// Infrastructure
 export * from './infrastructure/PhysicsWorld';
 export * from './infrastructure/BallPhysics';
 export * from './infrastructure/PlayfieldTrimeshBuilder';

--- a/packages/game-engine/src/infrastructure/AlternateWorldState.ts
+++ b/packages/game-engine/src/infrastructure/AlternateWorldState.ts
@@ -1,9 +1,5 @@
 import type { BossGateContext } from '../domain/BossRegistry';
 
-// Value object owning the alternate-world / score-baseline state machine that
-// used to live inline in CollisionEventProcessor. Pure state only: transitions
-// mutate the four fields and never reach out to bosses/portal/collision side
-// effects — the CEP owns that orchestration and drives this object.
 export class AlternateWorldState {
   private active = false;
   private normalWorldScoreBaseline = 0;

--- a/packages/game-engine/src/infrastructure/AtmosphereLighting.ts
+++ b/packages/game-engine/src/infrastructure/AtmosphereLighting.ts
@@ -1,16 +1,5 @@
 import * as THREE from 'three';
 
-/**
- * Shared SETUP/TEARDOWN plumbing for map atmosphere systems (Stranger Things
- * Upside Down, Zelda Sacred Realm). The per-element apply-side lerps live in
- * `AtmosphereTint`; the blend integrator in `AtmosphereBlend` (domain). These
- * helpers capture/restore the scene lighting snapshot, collect the material
- * snapshots, and run the fog apply/restore lifecycle.
- *
- * game-engine takes THREE types only — no map import.
- */
-
-/** The five lighting handles every atmosphere mutates. Identical per map. */
 export type SceneLighting = {
   scene: THREE.Scene;
   renderer: THREE.WebGLRenderer;
@@ -20,11 +9,6 @@ export type SceneLighting = {
   fill: THREE.DirectionalLight;
 };
 
-/**
- * Snapshot of the scene/renderer/light state captured at `setup()`.
- * `capture()` reads it off a `SceneLighting`; the caller passes the stored
- * snapshot fields back into the `AtmosphereTint` apply helpers each frame.
- */
 export class LightingSnapshot {
   readonly bg = new THREE.Color();
   exposure = 1.45;
@@ -38,7 +22,6 @@ export class LightingSnapshot {
   readonly fillColor = new THREE.Color();
   fillIntensity = 1;
 
-  /** Read the current lighting state into this snapshot. */
   capture(lighting: SceneLighting): void {
     const bg = lighting.scene.background;
     if (bg instanceof THREE.Color) this.bg.copy(bg);
@@ -55,7 +38,6 @@ export class LightingSnapshot {
   }
 }
 
-/** Original (snapshot) values for one tinted material, captured at setup. */
 export type AtmosphereMaterialEntry<Extra = unknown> = {
   material: THREE.MeshStandardMaterial;
   color: THREE.Color;
@@ -63,11 +45,6 @@ export type AtmosphereMaterialEntry<Extra = unknown> = {
   emissiveIntensity: number;
 } & Extra;
 
-/**
- * Traverse `root`, snapshotting every unique `MeshStandardMaterial` into an
- * entry. `skip(obj)` drops a mesh entirely (ST flippers/garlands/bumpers);
- * `extra(obj)` adds per-map fields (ST `kind`).
- */
 export function collectAtmosphereMaterials<Extra extends object = Record<never, never>>(
   root: THREE.Object3D,
   options: {
@@ -96,12 +73,6 @@ export function collectAtmosphereMaterials<Extra extends object = Record<never, 
   return out;
 }
 
-/**
- * FogExp2 apply/restore lifecycle. `apply()` swaps the map fog onto the scene
- * (restoring the saved fog when `ease <= 0`) and sets its density; `restore()`
- * puts the saved fog back. The caller owns the density formula (ST folds in a
- * `revealLift` factor, Zelda does not).
- */
 export class AtmosphereFog {
   private readonly fog: THREE.FogExp2;
   private savedFog: THREE.Fog | THREE.FogExp2 | null = null;
@@ -110,12 +81,10 @@ export class AtmosphereFog {
     this.fog = new THREE.FogExp2(color, 0);
   }
 
-  /** Capture the scene's current fog so `restore()` can put it back. */
   save(scene: THREE.Scene): void {
     this.savedFog = scene.fog;
   }
 
-  /** Swap in the map fog at `density` (or restore when `ease <= 0`). */
   apply(scene: THREE.Scene, ease: number, density: number): void {
     if (ease <= 0) {
       this.restore(scene);
@@ -125,7 +94,6 @@ export class AtmosphereFog {
     if (scene.fog !== this.fog) scene.fog = this.fog;
   }
 
-  /** Restore the saved fog onto the scene. */
   restore(scene: THREE.Scene): void {
     scene.fog = this.savedFog;
   }

--- a/packages/game-engine/src/infrastructure/AtmosphereTint.ts
+++ b/packages/game-engine/src/infrastructure/AtmosphereTint.ts
@@ -1,21 +1,5 @@
 import * as THREE from 'three';
 
-/**
- * Shared APPLY-side tint helpers for map atmosphere systems (Stranger Things
- * Upside Down, Zelda Sacred Realm). The blend integrator lives in
- * `AtmosphereBlend` (domain); these mutate the actual Three materials/lights.
- *
- * Per-element math:
- *  - color  : copy(orig) -> set(tint) -> lerp(ease*tintK) -> multiplyScalar(1 - ease*darken)
- *  - emissive: copy(orig) -> set(emissive) -> lerp(ease*emissiveK)
- *  - emissiveIntensity: lerp(orig, orig*emissiveMul + emissiveAdd, ease)
- *  - light  : color.copy(orig) -> set(target) -> lerp(ease*colorK) ; intensity lerp
- *
- * The caller owns its snapshot/lighting types and per-map scene/fog/pulse
- * specifics; these helpers only run the common per-element lerps.
- */
-
-/** Original (snapshot) values for one material, captured at setup. */
 export type MaterialTintSnapshot = {
   material: THREE.MeshStandardMaterial;
   color: THREE.Color;
@@ -23,7 +7,6 @@ export type MaterialTintSnapshot = {
   emissiveIntensity: number;
 };
 
-/** Per-material target factors for the tint lerp. */
 export type MaterialTintDescriptor = {
   tint: THREE.ColorRepresentation;
   tintK: number;
@@ -34,13 +17,11 @@ export type MaterialTintDescriptor = {
   emissiveAdd: number;
 };
 
-/** Original (snapshot) values for one light, captured at setup. */
 export type LightTintSnapshot = {
   color: THREE.Color;
   intensity: number;
 };
 
-/** Per-light target factors for the tint lerp. */
 export type LightTintDescriptor = {
   color: THREE.ColorRepresentation;
   colorK: number;
@@ -49,7 +30,6 @@ export type LightTintDescriptor = {
 
 const _scratch = new THREE.Color();
 
-/** Tint one material toward its descriptor by `ease`. */
 export function applyMaterialTint(
   snapshot: MaterialTintSnapshot,
   ease: number,
@@ -72,7 +52,6 @@ export function applyMaterialTint(
   );
 }
 
-/** Tint a light's color + set its intensity toward the descriptor by `ease`. */
 export function applyLightTint(
   light: { color: THREE.Color; intensity: number },
   snapshot: LightTintSnapshot,
@@ -85,7 +64,6 @@ export function applyLightTint(
   light.intensity = THREE.MathUtils.lerp(snapshot.intensity, descriptor.intensity, ease);
 }
 
-/** Lerp one Three.Color from `orig` toward `target` by `ease * k`. */
 export function applyColorTint(
   out: THREE.Color,
   orig: THREE.Color,

--- a/packages/game-engine/src/infrastructure/BallDiagnostics.ts
+++ b/packages/game-engine/src/infrastructure/BallDiagnostics.ts
@@ -35,13 +35,9 @@ export interface BallDiagnosticsSnapshot {
   lastReset: BallResetReason | null;
   lastLost: BallLostReason | null;
   lostCount: number;
-  /** Highest point reached since launch (most negative Z). */
   apexZ: number;
-  /** Ball X at the apex. */
   apexX: number;
-  /** Peak speed since the last launch. */
   peakSpeed: number;
-  /** Total detected crossings of the lane's left wall (sentinel). */
   wallCrossCount: number;
 }
 
@@ -57,7 +53,6 @@ interface DiagBody {
   linvel(): Vec3;
 }
 
-// Single source of truth for labels (reused by the BallDebugOverlay HUD).
 export const RESET_LABELS: Record<BallResetReason, string> = {
   launch: 'Lancement',
   drain: 'Drain (capteur)',
@@ -73,22 +68,10 @@ export const LOST_LABELS: Record<BallLostReason, string> = {
   escaped_out_of_bounds: 'Sortie hors des limites du terrain (X/Z)',
 };
 
-// ── Lane left-wall crossing tracer ─────────────────────────────────────────────
-// The lane's left wall is centered on lane.xMin, thickness lane.wallThickness
-// → inner/outer faces at ±thickness/2 (computed in the constructor). The ball
-// is traced as soon as it enters a wide X band around the wall, and any
-// frame-to-frame crossing (inner→outer or reverse) is reported.
 const WALL_BAND_X_MIN = 0.17;
 const WALL_BAND_X_MAX = 0.23;
 
-/**
- * Tracks the ball every frame and explains why it disappears or leaves the
- * playfield: zone classification, physical escape detection (below floor /
- * out of bounds) and a reset-cause log. Read-only on the Rapier body.
- */
 export class BallDiagnostics {
-  /** Enables console logs (LaneFlight trace, apex, losses, resets).
-   *  Driven by the playfield HUD `[J]` toggle → fully silent in prod. */
   verbose = false;
 
   private readonly lane: MapLayout['shooterLane'];
@@ -98,8 +81,8 @@ export class BallDiagnostics {
 
   constructor(layout: MapLayout) {
     this.lane = layout.shooterLane;
-    this.wallFaceInner = this.lane.xMin - this.lane.wallThickness / 2; // ≈ 0.196
-    this.wallFaceOuter = this.lane.xMin + this.lane.wallThickness / 2; // ≈ 0.216
+    this.wallFaceInner = this.lane.xMin - this.lane.wallThickness / 2;
+    this.wallFaceOuter = this.lane.xMin + this.lane.wallThickness / 2;
     this.laneSepX = bottomOutLaneSepX(layout.spawns.ball.x);
   }
 
@@ -124,30 +107,20 @@ export class BallDiagnostics {
   private apexLogged = false;
   private peakSpeed = 0;
 
-  // ── Launch flight tracer ───────────────────────────────────────────────────
-  // Samples pos/vel during the climb up the lane to see EXACTLY where and how
-  // the ball stops (gradual energy loss vs hard stop against GLB geometry).
-  // Armed on every 'launch' reset, disarmed when the ball leaves the lane
-  // (low X) or falls back down, or after a frame cap to avoid console spam.
   private traceActive = false;
   private traceFrame = 0;
   private traceSampleCount = 0;
   private traceMaxSamples = 90;
-  private traceEverStep = 6; // 1 sample every ~6 frames (~100 ms)
+  private traceEverStep = 6;
   private prevTraceVz = 0;
 
-  // ── Left-wall crossing tracer ────────────────────────────────────────────────
-  // Previous frame's X (NaN = not yet in the band). Detects passing from one
-  // wall face to the other between 2 frames.
   private prevWallX = Number.NaN;
 
-  /** Updates the snapshot and reports a loss (once per episode). */
   update(body: DiagBody, gameState: string): BallLostEvent | null {
     const p = body.translation();
     const v = body.linvel();
     const speed = Math.sqrt(v.x * v.x + v.y * v.y + v.z * v.z);
 
-    // Launch flight tracer (before everything else, to capture the climb).
     this.traceLaneFlight(p, v, speed, gameState);
 
     this.traceWallCross(p, v);
@@ -157,12 +130,10 @@ export class BallDiagnostics {
       this.snapshot = { ...this.snapshot, peakSpeed: speed };
     }
 
-    // Apex = most negative Z since the last launch.
     if (gameState === 'playing' && p.z < this.apexZ) {
       this.apexZ = p.z;
       this.snapshot = { ...this.snapshot, apexZ: p.z, apexX: p.x };
     }
-    // Log the apex once, when the ball starts moving back down the lane.
     if (
       gameState === 'playing' &&
       !this.apexLogged &&
@@ -221,16 +192,10 @@ export class BallDiagnostics {
     return { reason, pos: this.snapshot.pos, vel: this.snapshot.vel, speed };
   }
 
-  /**
-   * Samples the ball trajectory during the launch flight. Logs X/Y/Z + speed
-   * to reveal where and how the ball stops. Also detects the Z reversal
-   * (climb → descent) and the lane exit.
-   */
   private traceLaneFlight(p: Vec3, v: Vec3, speed: number, gameState: string): void {
     if (!this.traceActive || gameState !== 'playing') return;
     this.traceFrame++;
 
-    // Successful lane exit: the ball reached the playfield (low X).
     if (p.x < this.lane.exitX) {
       this.traceActive = false;
       if (this.verbose) {
@@ -243,7 +208,6 @@ export class BallDiagnostics {
       return;
     }
 
-    // Fell back to the bottom of the lane without exiting → failed launch.
     if (p.z > this.lane.failZ && this.traceSampleCount > 3) {
       this.traceActive = false;
       if (this.verbose) {
@@ -257,7 +221,6 @@ export class BallDiagnostics {
       return;
     }
 
-    // Z direction reversal (apex) → explicit marker, bypasses the throttle.
     const reversedZ = this.prevTraceVz < -0.02 && v.z > 0.02;
     this.prevTraceVz = v.z;
 
@@ -276,16 +239,6 @@ export class BallDiagnostics {
     );
   }
 
-  /**
-   * PERMANENT sentinel (independent of `verbose`): traces the ball within the
-   * X band around the lane's left wall and reports any frame-to-frame
-   * crossing (inner ↔ outer face). Cost: 2 comparisons/frame only while the
-   * ball is in the band, zero otherwise. Each crossing →
-   * `console.warn('[WALL CROSS]', …)` + increments the counter shown in the
-   * HUD. `side` tells whether the crossing happens above the wall top
-   * (Z < lane.leftWallTopZ, legitimate exit gap) or below it (spurious pass
-   * through the solid wall).
-   */
   private traceWallCross(p: Vec3, v: Vec3): void {
     const inBand = p.x >= WALL_BAND_X_MIN && p.x <= WALL_BAND_X_MAX;
     if (!inBand) {
@@ -296,7 +249,6 @@ export class BallDiagnostics {
     const prev = this.prevWallX;
     this.prevWallX = p.x;
 
-    // Detailed per-frame trace: verbose only (console spam).
     if (this.verbose) {
       // eslint-disable-next-line no-console
       console.info(
@@ -310,8 +262,6 @@ export class BallDiagnostics {
     const crossedInward = prev > this.wallFaceOuter && p.x < this.wallFaceInner;
     if (!crossedOutward && !crossedInward) return;
 
-    // Crossing detected: snapshot counter ALWAYS incremented (HUD sentinel),
-    // console warn only in `verbose` (fully silent in prod).
     const side = p.z < this.lane.leftWallTopZ ? 'above_top' : 'below_top';
     this.snapshot = {
       ...this.snapshot,
@@ -330,12 +280,10 @@ export class BallDiagnostics {
     }
   }
 
-  /** Remembers the last game event (BUMPER_HIT, DRAIN, ...) for the HUD. */
   noteEvent(type: string): void {
     this.snapshot = { ...this.snapshot, lastEvent: type };
   }
 
-  /** Logs and remembers the cause of a ball reset. */
   noteReset(reason: BallResetReason): void {
     this.snapshot = { ...this.snapshot, lastReset: reason };
     this.lostLatched = false;
@@ -344,7 +292,6 @@ export class BallDiagnostics {
       this.apexLogged = false;
       this.peakSpeed = 0;
       this.snapshot = { ...this.snapshot, apexZ: 0, apexX: 0, peakSpeed: 0 };
-      // (Re)arms the launch flight tracer.
       this.traceActive = true;
       this.traceFrame = 0;
       this.traceSampleCount = 0;

--- a/packages/game-engine/src/infrastructure/BallPhysics.ts
+++ b/packages/game-engine/src/infrastructure/BallPhysics.ts
@@ -26,8 +26,6 @@ export class BallPhysics implements IMapBallPhysics, IBumperEject, IBallPhysics 
   private spawnY: number;
   private spawnZ: number;
 
-  // Render-lerp bounds: positions at the last two physics steps.
-  // Reused objects (mutated in place) — zero allocation in the hot loop.
   private readonly prevPos = { x: 0, y: 0, z: 0 };
   private readonly currPos = { x: 0, y: 0, z: 0 };
   private readonly lerpOut = { x: 0, y: 0, z: 0 };
@@ -57,11 +55,6 @@ export class BallPhysics implements IMapBallPhysics, IBumperEject, IBallPhysics 
     this.resetInterpolation();
   }
 
-  /**
-   * Resets prev = curr = the body's real position. Call after EVERY teleport
-   * (setTranslation): otherwise the next frame would lerp between the old
-   * and new positions → ball rendered as a "streak" across the playfield.
-   */
   private resetInterpolation(): void {
     const p = this.body.translation();
     this.prevPos.x = p.x;
@@ -72,10 +65,6 @@ export class BallPhysics implements IMapBallPhysics, IBumperEject, IBallPhysics 
     this.currPos.z = p.z;
   }
 
-  /**
-   * Call after EACH world.step(): shifts the current state into prev and
-   * captures the new position — provides both bounds of the render lerp.
-   */
   noteStepped(): void {
     this.prevPos.x = this.currPos.x;
     this.prevPos.y = this.currPos.y;
@@ -171,11 +160,6 @@ export class BallPhysics implements IMapBallPhysics, IBumperEject, IBallPhysics 
     mesh.quaternion.set(q.x, q.y, q.z, q.w);
   }
 
-  /**
-   * Interpolated visual sync: position = lerp(prev, curr, alpha) to smooth
-   * 120 Hz rendering over 60 steps/s physics. Quaternion taken as-is — ball
-   * rotation is barely perceptible, no need to slerp.
-   */
   syncToMeshInterpolated(
     mesh: {
       position: { set(x: number, y: number, z: number): void };

--- a/packages/game-engine/src/infrastructure/BallTrail.ts
+++ b/packages/game-engine/src/infrastructure/BallTrail.ts
@@ -1,8 +1,5 @@
 import * as THREE from 'three';
 
-// Ball fire trail — fixed sprite pool (additive planes), zero per-frame
-// allocation, zero lights. Radial texture generated via canvas.
-
 const POOL = 24;
 const PLANE = 0.008;
 const LIFE = 0.3; // s
@@ -17,7 +14,7 @@ const COLOR_FEVER_B = 0x00c8ff;
 interface TrailSprite {
   mesh: THREE.Mesh;
   mat: THREE.MeshBasicMaterial;
-  life: number; // remaining; 0 = free
+  life: number;
 }
 
 function makeRadialTexture(): THREE.CanvasTexture {
@@ -40,7 +37,7 @@ export class BallTrail {
   private texture: THREE.CanvasTexture;
   private emitAccum = 0;
   private feverFlip = 0;
-  private maxActive = POOL; // capped by the QualityGovernor
+  private maxActive = POOL;
 
   constructor() {
     this.texture = makeRadialTexture();
@@ -66,7 +63,6 @@ export class BallTrail {
     scene.add(this.group);
   }
 
-  // Active pool cap (QualityGovernor: 24 → 12 at the lowest tier).
   setMaxSprites(n: number): void {
     this.maxActive = Math.max(0, Math.min(POOL, n));
   }
@@ -88,11 +84,6 @@ export class BallTrail {
     s.mat.opacity = 1;
   }
 
-  /**
-   * @param intensity 0..1 — emission density (0 = trail off).
-   * @param opts alternateWorld (purple tint) / fever (alternating tint).
-   * @param camQuat camera orientation to billboard the planes.
-   */
   update(
     dt: number,
     ballPos: { x: number; y: number; z: number },
@@ -100,7 +91,6 @@ export class BallTrail {
     opts: { alternateWorld: boolean; fever: boolean },
     camQuat: THREE.Quaternion,
   ): void {
-    // Emission proportional to intensity.
     if (intensity > 0) {
       this.emitAccum += intensity * EMIT_RATE * dt;
       while (this.emitAccum >= 1) {
@@ -114,7 +104,6 @@ export class BallTrail {
       }
     }
 
-    // Advance live sprites (scale + alpha decay, +Y drift).
     for (const s of this.sprites) {
       if (s.life <= 0) continue;
       s.life -= dt;
@@ -123,7 +112,7 @@ export class BallTrail {
         s.mat.opacity = 0;
         continue;
       }
-      const t = s.life / LIFE; // 1 → 0
+      const t = s.life / LIFE;
       s.mat.opacity = t;
       s.mesh.scale.setScalar(0.4 + t * 1.1);
       s.mesh.position.y += DRIFT_Y * dt;

--- a/packages/game-engine/src/infrastructure/BlackoutFightPhaseMachine.ts
+++ b/packages/game-engine/src/infrastructure/BlackoutFightPhaseMachine.ts
@@ -1,19 +1,5 @@
 import { easeIn, easeOut, strobeOn } from './CinematicEasing';
 
-/**
- * Pure phase state-machine for "shape B" boss reveals (blackout → reveal →
- * flicker → victory → restore). Owns {phase, elapsed, strobeT, pulseT} and the
- * eleven-assist sub-timer, with NO Three dependency. The fully time-driven
- * sequencing + the regression-prone scalar maths (strobe gating, blackout/reveal
- * eases, flicker shade breathe/blink, victory/restore mixes, assist envelope)
- * live here so the same machine drives Demogorgon (Stranger Things) and
- * Ganondorf (Zelda).
- *
- * Map-specific differences (shade vs flash-only, billboard, eleven assist) are
- * NOT decided here — the renderer reads the descriptor scalars/flags and chooses
- * which Three calls to make.
- */
-
 export type BlackoutFightPhase =
   | 'idle'
   | 'blackout'
@@ -29,31 +15,19 @@ export type BlackoutFightConfig = {
   victory: number;
   strobeHzIntro: number;
   fightFlickerHz: number;
-  /** Hit count required to win (from the boss definition). */
   targetHits: number;
 };
 
-/**
- * Optional eleven-assist (Stranger Things only). Pass null to disable the whole
- * assist sub-machine (Ganondorf).
- */
 export type ElevenAssistConfig = {
-  /** Seconds before the first assist fires (ELEVEN_ASSIST_FIRST). */
   first: number;
-  /** Seconds between subsequent assists (ASSIST_INTERVAL). */
   interval: number;
-  /** Assist animation duration (ELEVEN_ASSIST_ANIM). */
   anim: number;
-  /** Score increment emitted on each assist (ASSIST_SCORE). */
   scoreIncrement: number;
 };
 
-/** Per-frame envelope of the eleven-assist animation. */
 export type ElevenAssistFrame = {
   active: boolean;
-  /** Normalised progress t in [0,1]. */
   t: number;
-  /** Raw assist clock (seconds) — drives the targetGroup.rotation.z wobble. */
   elapsed: number;
   rise: number;
   fade: number;
@@ -63,37 +37,23 @@ export type ElevenAssistFrame = {
 
 export type BlackoutFightDescriptor = {
   phase: BlackoutFightPhase;
-  /** strobeOn(strobeT, strobeHzIntro) — used by blackout/reveal. */
   on: boolean;
-  /** darkMix: 1 except during restore where it eases down to 0. */
   darkMix: number;
-  /** blackout phase: darkMix * easeOut(min(1, elapsed/blackout)). */
   blackoutMix: number;
-  /** reveal phase: clamped progress t = min(1, elapsed/reveal). */
   revealT: number;
-  /** flicker phase: clamped shade scalar. */
   flickerShade: number;
-  /** flicker phase: blink = strobeOn(strobeT, fightFlickerHz). */
   flickerBlink: boolean;
-  /** victory phase: clamped progress t = min(1, elapsed/victory). */
   victoryT: number;
-  /** restore phase: FIGHT_SHADE-scaled hold shade (caller multiplies its own shade). */
   restoreDarkMix: number;
-  /** transition flags (fired once on the frame they occur) */
   enteredReveal: boolean;
   enteredFlicker: boolean;
   finishedVictory: boolean;
   finishedRestore: boolean;
-  /** eleven assist: an assist fired this frame (renderer emits ASSIST + shows fx). */
   assistFired: boolean;
-  /** eleven assist: per-frame animation envelope (null when inactive/disabled). */
   assist: ElevenAssistFrame | null;
-  /** eleven assist: the assist animation just finished this frame (renderer hides fx). */
   assistFinished: boolean;
 };
 
-// Flicker shade constants (Demogorgon formula). Ganondorf gets a flat shade
-// of 0 by zeroing the terms via config — same formula, different inputs.
 export type FlickerShadeConfig = {
   base: number;
   breatheAmp: number;
@@ -134,7 +94,6 @@ export class BlackoutFightPhaseMachine {
     return this.phase === 'victory';
   }
 
-  /** BOSS_REVEAL: enter blackout from idle. Returns true if it transitioned. */
   onReveal(): boolean {
     if (this.phase !== 'idle') return false;
     this.phase = 'blackout';
@@ -147,10 +106,6 @@ export class BlackoutFightPhaseMachine {
     return true;
   }
 
-  /**
-   * BOSS_TARGET_HIT: accepted unless idle/restore/victory. Returns victory=true
-   * when the threshold is reached (renderer begins victory).
-   */
   onHit(hitCount: number): { accepted: boolean; victory: boolean } {
     if (this.phase === 'idle' || this.phase === 'restore' || this.phase === 'victory') {
       return { accepted: false, victory: false };
@@ -163,13 +118,11 @@ export class BlackoutFightPhaseMachine {
   }
 
   private beginVictory(): void {
-    // hideElevenAssist resets the assist sub-state (renderer hides the meshes).
     this.elevenAssistActive = false;
     this.phase = 'victory';
     this.elapsed = 0;
   }
 
-  /** endFight()/reset → idle, clears all clocks + assist state. */
   reset(): void {
     this.phase = 'idle';
     this.elapsed = 0;
@@ -187,13 +140,6 @@ export class BlackoutFightPhaseMachine {
     return clamp(raw, this.flicker.clampMin, this.flicker.clampMax);
   }
 
-  /**
-   * @param opts.suspendAssist true while the game is not in play (ball
-   * drained, game not relaunched). The assist sub-timer is then FROZEN (dt
-   * does not flow): merely "not emitting" would let the counter keep running
-   * down and the assist would fire the instant play resumes (catch-up).
-   * The rest of the fight (strobe, flicker, phases) keeps running normally.
-   */
   tick(dt: number, opts?: { suspendAssist?: boolean }): BlackoutFightDescriptor {
     // pulseT advances every frame — even in idle.
     this.pulseT += dt;
@@ -286,10 +232,8 @@ export class BlackoutFightPhaseMachine {
       return { ...base, phase: 'victory', victoryT, finishedVictory };
     }
 
-    // restore
     const finishedRestore = darkMix <= 0;
     if (finishedRestore) {
-      // resetAtmosphere() in the renderer drives reset(); we report it here.
       return { ...base, phase: 'restore', finishedRestore: true };
     }
     return { ...base, phase: 'restore' };

--- a/packages/game-engine/src/infrastructure/BossActorAnimator.ts
+++ b/packages/game-engine/src/infrastructure/BossActorAnimator.ts
@@ -3,13 +3,9 @@ import * as THREE from 'three';
 export type BossActorAnimState = 'idle' | 'hit' | 'victory';
 
 export type BossActorGlowConfig = {
-  /** Hex color of the glow PointLight created on mount. */
   color: number;
-  /** Light distance (THREE.PointLight 3rd arg). */
   distance: number;
-  /** Light decay (THREE.PointLight 4th arg). */
   decay: number;
-  /** Local Y position of the glow light. */
   y: number;
 };
 
@@ -28,26 +24,15 @@ const HIT_BOOST = 1.4;
 const GLOW_INTENSITY_BASE = 0.42;
 const HIT_SCALE_BOOST = 0.2;
 
-/**
- * Pure pulse intensity multiplier shared by demogorgon/ganondorf target visuals.
- * pulse = (0.82 + sin(t*2.5)*0.12) * (hitFlash>0 ? 1.4 : 1)
- */
 export function bossActorPulse(pulseT: number, hitFlash: number): number {
   const hitBoost = hitFlash > 0 ? HIT_BOOST : 1;
   return (PULSE_BASE + Math.sin(pulseT * PULSE_SPEED) * PULSE_AMP) * hitBoost;
 }
 
-/** Pure anchor scale during a hit flash: 1 + (hitFlash/0.18)*0.2. */
 export function bossActorScale(hitFlash: number): number {
   return 1 + (hitFlash / HIT_FLASH_DURATION) * HIT_SCALE_BOOST;
 }
 
-/**
- * Composed lifecycle helper for the demogorgon/ganondorf "target boss" actors.
- * Owns the idle/hit/victory anim state machine + the glow/scale pulse math.
- * The owning class injects the glow config and feeds in the per-map mixer/actions
- * once its GLTF is fitted. GLTF/material IO stays in the owner.
- */
 export class BossActorAnimator {
   private mixer: THREE.AnimationMixer | null = null;
   private idleAction: THREE.AnimationAction | null = null;
@@ -66,7 +51,6 @@ export class BossActorAnimator {
     return this.glowLight;
   }
 
-  /** Register the per-map mixer + actions, wire the hit→idle finished listener. */
   setActions(actions: BossActorActions): void {
     this.mixer = actions.mixer;
     this.idleAction = actions.idleAction;
@@ -94,7 +78,6 @@ export class BossActorAnimator {
     return this.idleAction;
   }
 
-  /** Attach the glow light to the anchor (idempotent) and start idle. */
   show(anchor: THREE.Object3D): void {
     if (this.glowLight && !this.glowLight.parent) {
       anchor.add(this.glowLight);
@@ -102,7 +85,6 @@ export class BossActorAnimator {
     this.playIdle();
   }
 
-  /** Reset to hidden idle state: scale/rotation reset, glow off + detached. */
   hide(anchor: THREE.Object3D | null): void {
     if (anchor) {
       anchor.scale.setScalar(1);
@@ -147,7 +129,6 @@ export class BossActorAnimator {
     this.idleAction.fadeIn(0.12).play();
   }
 
-  /** Advance mixer + glow/scale pulse. Owner gates on anchor.visible before calling. */
   update(dt: number, anchor: THREE.Object3D): void {
     this.mixer?.update(dt);
 
@@ -160,7 +141,6 @@ export class BossActorAnimator {
     anchor.scale.setScalar(bossActorScale(this.hitFlash));
   }
 
-  /** Clear all anim state. `disposeGlow` matches the per-map dispose() behaviour. */
   reset(disposeGlow: boolean): void {
     if (disposeGlow && this.glowLight) {
       this.glowLight.dispose();

--- a/packages/game-engine/src/infrastructure/BossCollisionHandler.ts
+++ b/packages/game-engine/src/infrastructure/BossCollisionHandler.ts
@@ -4,23 +4,7 @@ import { bossThresholdMet, bossPointsRemaining } from '../domain/BossRegistry';
 import type { GameEventListener } from '../domain/GameEvents';
 import type { BossFightManager } from './BossFightManager';
 
-/**
- * Handles collisions on boss target colliders (roles defined by the map via
- * BossDefinition.colliderRole).
- *
- * Two responsibilities, in order:
- *   1. Locked-hit feedback : when the ball hits a boss target whose reveal
- *      threshold is not yet met, emit BOSS_LOCKED_HIT — throttled to once
- *      every 2s per boss (anti-spam) via the injected clock.
- *   2. Fight collision : delegate to BossFightManager.handleTargetCollision,
- *      which credits BOSS_TARGET_HIT when the fight is armed.
- *
- * canHandle() owns every boss collider role, so this handler must be registered
- * FIRST in the processor: a boss role is always consumed here and never falls
- * through to the generic handlers.
- */
 export class BossCollisionHandler implements CollisionHandler {
-  // Last BOSS_LOCKED_HIT emission per boss, used for the 2s anti-spam throttle.
   private lockedHitLastMs: Partial<Record<BossId, number>> = {};
   private readonly bossByRole = new Map<string, BossDefinition>();
 
@@ -28,12 +12,8 @@ export class BossCollisionHandler implements CollisionHandler {
     private readonly bosses: BossDefinition[],
     private readonly bossFights: BossFightManager,
     private readonly emit: GameEventListener,
-    /** Reads the live alternate-world flag without coupling to the processor. */
     private readonly getAlternateWorldActive: () => boolean,
-    /** Reads the live gate context (score baselines) for threshold checks. */
     private readonly getGateContext: () => BossGateContext,
-    // Injected clock: tests pass a fake to make the anti-spam throttle
-    // deterministic.
     private readonly now: () => number = () => performance.now(),
   ) {
     for (const b of bosses) this.bossByRole.set(b.colliderRole, b);
@@ -46,7 +26,6 @@ export class BossCollisionHandler implements CollisionHandler {
   handle(role: string, gameState: string, started: boolean): void {
     const boss = this.bossByRole.get(role);
 
-    // --- Locked-hit feedback (takes priority over the fight collision) ---
     if (
       boss
       && boss.reveal.requiresAlternateWorld === this.getAlternateWorldActive()
@@ -56,7 +35,6 @@ export class BossCollisionHandler implements CollisionHandler {
     ) {
       const ctx = this.getGateContext();
       if (!bossThresholdMet(boss, ctx)) {
-        // Anti-spam: do not re-emit BOSS_LOCKED_HIT more than once every 2s.
         const now = this.now();
         if (now - (this.lockedHitLastMs[boss.id] ?? 0) >= 2000) {
           this.lockedHitLastMs[boss.id] = now;
@@ -69,15 +47,9 @@ export class BossCollisionHandler implements CollisionHandler {
       }
     }
 
-    // Delegate the fight collision; the role is always a boss role here.
     this.bossFights.handleTargetCollision(role, started, gameState);
   }
 
-  /**
-   * Clears the anti-spam throttle. Without this, after a game/world reset a
-   * re-armed boss would suppress BOSS_LOCKED_HIT for up to 2s. Clears all
-   * bosses when no id is given, otherwise just that boss.
-   */
   resetThrottle(id?: BossId): void {
     if (id === undefined) {
       this.lockedHitLastMs = {};

--- a/packages/game-engine/src/infrastructure/BossFightManager.ts
+++ b/packages/game-engine/src/infrastructure/BossFightManager.ts
@@ -72,7 +72,8 @@ export class BossFightManager {
     return this.states.get(id)?.triggered ?? false;
   }
 
-  // Un seul boss actif à la fois : les cibles des boss se chevauchent physiquement, donc deux boss armés en même temps feraient compter un même coup de balle deux fois (double-comptage injuste).
+  // Only one boss active at a time: boss targets physically overlap, so two
+  // armed bosses would count the same ball hit twice (unfair double-count).
   private anyOtherFightActive(except: BossId): boolean {
     for (const [id, state] of this.states) {
       if (id !== except && state.sensor.fightActive) return true;

--- a/packages/game-engine/src/infrastructure/BossRevealController.ts
+++ b/packages/game-engine/src/infrastructure/BossRevealController.ts
@@ -10,12 +10,6 @@ export interface BossRevealController {
     camera: THREE.Camera,
   ): Promise<void>;
   onGameEvent(event: GameEvent): void;
-  /**
-   * Max number of PointLights THIS reveal adds dynamically to the scene during
-   * its fight (strobe flash, boss glow, target light, assist…). Used to prewarm
-   * shader variants — see
-   * BossRevealOrchestrator.preloadAll / prewarmPointLightProgramVariants.
-   */
   dynamicPointLightCount?(): number;
   endFight(): void;
   update(dt: number): void;

--- a/packages/game-engine/src/infrastructure/BossTargetActor.ts
+++ b/packages/game-engine/src/infrastructure/BossTargetActor.ts
@@ -8,46 +8,25 @@ import { BossActorAnimator, type BossActorActions, type BossActorGlowConfig } fr
 
 const _facingPos = new THREE.Vector3();
 
-/**
- * Resolved per-map animation actions for a boss target actor. The owning map
- * resolves its own clips (raw or subclipped to a Blender frame range) and wires
- * them into mixer actions — that GLTF-clip strategy is the genuine per-map diff.
- */
 export type BossTargetClipResolver = (
   mixer: THREE.AnimationMixer,
   clips: THREE.AnimationClip[],
 ) => Pick<BossActorActions, 'idleAction' | 'hitAction' | 'victoryAction'>;
 
 export type BossTargetActorConfig = {
-  /** Tag for load-error logging, e.g. "Demogorgon". */
   logTag: string;
   modelUrl: string;
-  /** Surface placement target ({x,z} used; y derived from surfaceYAtZ). */
   target: WalkPathPoint;
   footLift: number;
   modelHeight: number;
   floorClearance: number;
   fitFrames: number;
-  /** Billboard yaw offset (radians) applied on top of camera-facing. */
   yaw: number;
   glow: BossActorGlowConfig;
-  /** Map-specific GLTF clip → action wiring (raw vs subclip). */
   resolveClips: BossTargetClipResolver;
-  /**
-   * Whether dispose() also disposes the glow PointLight's GPU resources.
-   * Both maps want this true (the light leaks otherwise).
-   */
   disposeGlowOnDispose: boolean;
 };
 
-/**
- * Composed lifecycle for the "target boss" actors (Demogorgon / Ganondorf).
- * Owns mount/warmup/show/hide/update/dispose, the surface placement, the
- * camera-facing billboard, the GLTF load + skinned-model fit, and the emissive
- * material setup. The animation state machine + glow pulse live in
- * BossActorAnimator (composition). The ONLY per-map variation is injected via
- * config (scalars, glow color, log tag) and the resolveClips function.
- */
 export class BossTargetActor {
   private anchor: THREE.Group | null = null;
   private camera: THREE.Camera | null = null;
@@ -77,7 +56,6 @@ export class BossTargetActor {
     anchor.add(rig);
     this.rig = rig;
 
-    // PointLight added to the scene ONLY during the fight (show/hide).
     this.animator.createGlowLight();
 
     this.loadPromise = this.loadModel();

--- a/packages/game-engine/src/infrastructure/BottomOutCollisionHandler.ts
+++ b/packages/game-engine/src/infrastructure/BottomOutCollisionHandler.ts
@@ -1,14 +1,7 @@
 import type { CollisionHandler } from './CollisionHandler';
 import type { BottomOutBall } from '../use-cases/BottomOutBall';
 
-/**
- * Handles the collision with the playfield floor (role: 'bottom_out').
- *
- * Distinct from drain: bottom_out fires when the ball leaves the playfield
- * without going through the drain channel (out-of-bounds ball).
- * Unlike drain, BottomOutBall respawns the ball without decrementing lives.
- * Execution is deferred via pendingPhysics (mutating Rapier mid-step is forbidden).
- */
+// Execution is deferred via pendingPhysics: mutating Rapier mid-step is forbidden.
 export class BottomOutCollisionHandler implements CollisionHandler {
   constructor(
     private readonly pendingPhysics: Array<() => void>,

--- a/packages/game-engine/src/infrastructure/BumpCollisionHandler.ts
+++ b/packages/game-engine/src/infrastructure/BumpCollisionHandler.ts
@@ -2,21 +2,14 @@ import type { CollisionHandler } from './CollisionHandler';
 import type { BumpHit } from '../use-cases/BumpHit';
 import { BUMP_HIT_COOLDOWN_MS, BUMP_EJECT_SCALE } from '../domain/Ball';
 
-/**
- * Handles collisions with side bumps (roles: 'bump_left', 'bump_right').
- *
- * A per-side cooldown prevents multiple consecutive ejections during a single
- * prolonged contact (Rapier may emit several 'started' events in a row).
- */
+// Per-side cooldown: Rapier may emit several 'started' events in a row for one
+// prolonged contact, which would otherwise trigger multiple ejections.
 export class BumpCollisionHandler implements CollisionHandler {
-  // Timestamp of the last hit per side, used for the anti-spam cooldown.
   private bumpLastHitMs: Record<'left' | 'right', number> = { left: 0, right: 0 };
 
   constructor(
     private readonly pendingPhysics: Array<() => void>,
     private readonly bumpHitUC: BumpHit,
-    // Injected clock: tests pass a controllable fake — no global
-    // monkey-patch needed.
     private readonly now: () => number = () => performance.now(),
   ) {}
 

--- a/packages/game-engine/src/infrastructure/BumperCollisionHandler.ts
+++ b/packages/game-engine/src/infrastructure/BumperCollisionHandler.ts
@@ -2,12 +2,7 @@ import type { CollisionHandler } from './CollisionHandler';
 import type { BumperHit } from '../use-cases/BumperHit';
 import type { MapLayout } from '../domain/MapLayout';
 
-/**
- * Handles collisions with bumpers (role: 'bumper_<index>').
- *
- * Use-case execution is deferred via pendingPhysics to avoid mutating
- * Rapier state from inside a drainCollisionEvents callback (forbidden mid-step).
- */
+// Execution is deferred via pendingPhysics: mutating Rapier mid-step is forbidden.
 export class BumperCollisionHandler implements CollisionHandler {
   constructor(
     private readonly pendingPhysics: Array<() => void>,
@@ -21,7 +16,6 @@ export class BumperCollisionHandler implements CollisionHandler {
 
   handle(role: string, gameState: string, started: boolean): void {
     if (!started || gameState !== 'playing') return;
-    // The bumper index is encoded in the GLB role (e.g. 'bumper_2' → idx 2).
     const idx = parseInt(role.split('_')[1], 10);
     const pos = this.layout.bumpers[idx];
     if (pos) {

--- a/packages/game-engine/src/infrastructure/BumperPartCollector.ts
+++ b/packages/game-engine/src/infrastructure/BumperPartCollector.ts
@@ -7,11 +7,6 @@ import {
   type BumperPoint,
 } from '../domain/BumperVisualMath';
 
-/**
- * Context passed to the `build` callback for each recognized bumper mesh:
- * the mesh, its resolved category (`kind`), the nearest layout bumper index
- * (world position) and its cloned original scale.
- */
 export interface BumperPartContext<K extends string> {
   mesh: THREE.Mesh;
   kind: K;
@@ -19,15 +14,6 @@ export interface BumperPartContext<K extends string> {
   baseScale: THREE.Vector3;
 }
 
-/**
- * Traverses `root` and builds the bumper "parts" list via the shared
- * configurable matcher (`rules`). Common ST/Zelda logic:
- * - `hide`: hides the node (and its descendants) without creating a part.
- * - `part`: on a THREE.Mesh, computes the nearest bumper index + captures
- *   `baseScale`, then delegates the map-specific part construction to `build`.
- *
- * `build` may return `null` to skip.
- */
 export function collectBumperParts<K extends string, P>(
   root: THREE.Object3D,
   bumpers: readonly BumperPoint[],

--- a/packages/game-engine/src/infrastructure/CameraBillboardSprite.ts
+++ b/packages/game-engine/src/infrastructure/CameraBillboardSprite.ts
@@ -46,7 +46,6 @@ export class CameraBillboardSprite {
     this.loadPromise = this.setTextureUrl(config.textureUrl);
   }
 
-  /** Preload a texture without showing it (avoids the flash on swap). */
   preloadTexture(url: string): Promise<void> {
     return this.fetchTexture(url).then(() => undefined);
   }
@@ -91,7 +90,6 @@ export class CameraBillboardSprite {
     }
   }
 
-  /** Switch to a single texture — never two images on the same sprite. */
   setTextureUrl(url: string): Promise<void> {
     if (this.getActiveTextureUrl() === url && this.imageReady) {
       return Promise.resolve();

--- a/packages/game-engine/src/infrastructure/CinematicDirector.ts
+++ b/packages/game-engine/src/infrastructure/CinematicDirector.ts
@@ -6,11 +6,6 @@ export interface CinematicSpec {
   onEnd?: () => void;
 }
 
-/**
- * Cinematics director: generalizes the world-transition pause pattern
- * (clip playing → physics frozen for its duration).
- * The playfield combines `transitionActive || director.shouldFreeze()`.
- */
 export class CinematicDirector {
   private active: CinematicSpec | null = null;
   private startedAt = 0;
@@ -25,27 +20,19 @@ export class CinematicDirector {
     return this.active !== null;
   }
 
-  /** true if physics must be frozen this frame */
   shouldFreeze(): boolean {
     return this.active !== null && this.active.freezePhysics;
   }
 
-  /**
-   * Elapsed time (ms) since the active clip started, or -1 if none.
-   * Lets the playfield drive a feedback (strobe) during the freeze without
-   * duplicating the director's time measurement.
-   */
   activeElapsedMs(now: number = this.now()): number {
     if (!this.active) return -1;
     return now - this.startedAt;
   }
 
-  /** Duration (ms) of the active clip, or -1 if none. */
   activeDurationMs(): number {
     return this.active?.durationMs ?? -1;
   }
 
-  /** plays a clip; once=true → only once per game */
   play(spec: CinematicSpec, opts?: { once?: boolean }): boolean {
     if (opts?.once && this.playedThisGame.has(spec.id)) return false;
     if (opts?.once) this.playedThisGame.add(spec.id);
@@ -55,7 +42,6 @@ export class CinematicDirector {
     return true;
   }
 
-  /** call every frame with performance.now() */
   update(now: number): void {
     if (!this.active) return;
     if (now - this.startedAt >= this.active.durationMs) {
@@ -65,7 +51,6 @@ export class CinematicDirector {
     }
   }
 
-  /** per-game reset (called on resetGame) */
   resetGame(): void {
     this.playedThisGame.clear();
     // Cancel a still-active clip (otherwise shouldFreeze() would stay true

--- a/packages/game-engine/src/infrastructure/CinematicEasing.ts
+++ b/packages/game-engine/src/infrastructure/CinematicEasing.ts
@@ -10,7 +10,6 @@ export function easeInOut(t: number): number {
   return t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
 }
 
-// easeOutBack: slight overshoot then return.
 export function easeOutBack(t: number): number {
   const c1 = 1.70158;
   const c3 = c1 + 1;

--- a/packages/game-engine/src/infrastructure/CinematicFreezeFeedback.ts
+++ b/packages/game-engine/src/infrastructure/CinematicFreezeFeedback.ts
@@ -1,17 +1,9 @@
 import { strobeOn } from './CinematicEasing';
 
 export interface CinematicFreezeFeedbackConfig {
-  /** strobe frequency during the freeze (Hz) */
   hz: number;
-  /** max flash intensity (mix passed to the strobe) */
   maxMix: number;
-  /**
-   * fraction [0..1] of the freeze duration during which the feedback is
-   * active. < 1 → the strobe stops before the clip ends (rest before play
-   * resumes), avoiding a harsh flash right when physics restarts.
-   */
   activeFraction: number;
-  /** fraction [0..1] of the active window spent fading out */
   fadeOutFraction: number;
 }
 
@@ -22,14 +14,6 @@ export interface CinematicFreezeFeedback {
 
 const OFF: CinematicFreezeFeedback = { on: false, mix: 0 };
 
-/**
- * Playfield feedback state (strobed flash) during a cinematic freeze. Makes
- * the freeze read as intentional rather than a dead hang.
- *
- * - outside the freeze (elapsed < 0 or duration <= 0) → OFF
- * - inside the active window → strobe on/off at `hz`, mix fades out
- * - past the active window → OFF (rest before physics resumes)
- */
 export function cinematicFreezeFeedback(
   elapsedMs: number,
   durationMs: number,

--- a/packages/game-engine/src/infrastructure/CinematicPhaseMachine.ts
+++ b/packages/game-engine/src/infrastructure/CinematicPhaseMachine.ts
@@ -1,16 +1,5 @@
 import { easeInOut, easeOut } from './CinematicEasing';
 
-/**
- * Cinematic FSM for the boss camera move (idle → zoomIn → hold → zoomOut →
- * idle). Owns {phase, elapsed} only — NO Three dependency. Given (dt, config) it
- * advances the timeline and returns per-phase blend factors in [0,1] that the
- * caller (PlayfieldCameraDirector) feeds into its vector/distance lerps:
- *
- *  - lookAtT   : panFrom → bossFocus (zoomIn) / bossFocus → baseTarget (zoomOut)
- *  - distanceT : baseDistance → zoomedDistance (zoomIn) / reverse (zoomOut)
- *  - dirT      : baseDir → faceDir blend amount
- */
-
 export type CinematicPhase = 'idle' | 'zoomIn' | 'hold' | 'zoomOut';
 
 export type CinematicPhaseConfig = {

--- a/packages/game-engine/src/infrastructure/ColliderSpecPlanner.ts
+++ b/packages/game-engine/src/infrastructure/ColliderSpecPlanner.ts
@@ -6,19 +6,12 @@ import {
 import type { MapLayout } from '../domain/MapLayout';
 import { surfaceYAtZ, BOTTOM_OUT_Z } from '../domain/PlayfieldGeometry';
 
-// ── ColliderSpec: plain description of a physics collider ────────────────────
-// Captures exactly what the code passes to Rapier (shape, position, rotation,
-// material, sensor, role for the colliderMap) WITHOUT depending on RAPIER.
-// The applier module (PlayfieldColliderFactory) translates a ColliderSpec into
-// createRigidBody/createCollider. The planners below are the bug-prone math
-// part.
-
 export type SpecQuat = { x: number; y: number; z: number; w: number };
 export type SpecVec3 = { x: number; y: number; z: number };
 
 export interface CuboidShape {
   kind: 'cuboid';
-  halfExtents: SpecVec3; // (hx, hy, hz)
+  halfExtents: SpecVec3;
 }
 
 export interface CylinderShape {
@@ -37,21 +30,14 @@ export type ColliderShape = CuboidShape | CylinderShape | BallShape;
 export interface ColliderSpec {
   shape: ColliderShape;
   translation: SpecVec3;
-  /** Rigid body rotation. Absent → no setRotation (identity). */
   rotation?: SpecQuat;
   restitution?: number;
   friction?: number;
   sensor?: boolean;
-  /** Enables Rapier COLLISION_EVENTS. */
   collisionEvents?: boolean;
-  /** Tag registered in colliderMap (handle → role). */
   role?: string;
 }
 
-// ── Analytic playfield geometry (ST values) ──────────────────────────────────
-// PLAYFIELD_*_Z = Z bounds of the analytic floor. Numerically equal to
-// layout.geometry.bounds.topZ / bottomZ, but planPlayfieldFloor() receives no
-// layout → named constants.
 const PLAYFIELD_MIN_Z = -0.552;
 const PLAYFIELD_MAX_Z = 0.418;
 const PLAYFIELD_HALF_X = 0.27; // not a bound (bounds = ±0.265): collider margin
@@ -59,42 +45,34 @@ const PLAYFIELD_FLOOR_HALF_Y = 0.003;
 const PLAYFIELD_FLOOR_RESTITUTION = 0.35;
 const PLAYFIELD_FLOOR_FRICTION = 0.12;
 
-// "Legacy" shooter lane (planLaneFloor) — X bounds. 0.265 = rightX,
-// 0.206 is not a layout bound → kept as-is.
+// 0.206 is not a layout bound → kept literal.
 const LANE_FLOOR_X_MIN = 0.206;
 const LANE_FLOOR_X_MAX = 0.265;
 const LANE_FLOOR_HALF_Y = 0.003;
 const LANE_FLOOR_RESTITUTION = 0.35;
 const LANE_FLOOR_FRICTION = 0.15;
 
-// Analytic walls (planWalls) — ST positions/thicknesses.
 const WALL_HEIGHT = 0.06;
 const WALL_THICKNESS = 0.015;
-const WALL_SIDE_LEFT_X = -0.265; // = bounds.leftX (kept literal: hardcoded ST values)
-const WALL_SIDE_RIGHT_X = 0.265; // = bounds.rightX
+const WALL_SIDE_LEFT_X = -0.265; // = bounds.leftX, kept literal (hardcoded ST values)
+const WALL_SIDE_RIGHT_X = 0.265;
 const WALL_SIDE_HALF_Z = 0.485;
 const WALL_SIDE_Z = -0.067;
-const WALL_BACK_HALF_X = 0.265; // = bounds.rightX
-const WALL_BACK_Z = -0.552; // = bounds.topZ
+const WALL_BACK_HALF_X = 0.265;
+const WALL_BACK_Z = -0.552;
 const WALL_LANE_SEP_HALF_Z = 0.5;
 const WALL_LANE_SEP_Z = -0.05;
 const WALL_RESTITUTION = 0.4;
 const WALL_FRICTION = 0.1;
 
-/** Quaternion of a rotation around the X axis (playfield tilt). */
 function quatAroundX(angle: number): SpecQuat {
   return { x: Math.sin(angle / 2), y: 0, z: 0, w: Math.cos(angle / 2) };
 }
 
-/** Quaternion of a rotation around the Y axis (guide orientation). */
 function quatAroundY(angle: number): SpecQuat {
   return { x: 0, y: Math.sin(angle / 2), z: 0, w: Math.cos(angle / 2) };
 }
 
-/**
- * Main analytic floor (smooth tilted cuboid) — replaces the bumpy GLB
- * trimesh. Z ∈ [-0.552, 0.418], tilt derived from surfaceYAtZ.
- */
 export function planPlayfieldFloor(): ColliderSpec {
   const zMin = PLAYFIELD_MIN_Z;
   const zMax = PLAYFIELD_MAX_Z;
@@ -112,7 +90,6 @@ export function planPlayfieldFloor(): ColliderSpec {
   };
 }
 
-/** Shooter lane floor (smooth strip that shadows the GLB seam). */
 export function planLaneFloor(laneTopZ = 0.03, laneBotZ = 0.42): ColliderSpec {
   const laneMidZ = (laneTopZ + laneBotZ) / 2;
   const laneHalfZ = (laneBotZ - laneTopZ) / 2;
@@ -131,7 +108,6 @@ export function planLaneFloor(laneTopZ = 0.03, laneBotZ = 0.42): ColliderSpec {
   };
 }
 
-/** Analytic playfield walls (sides + back + lane separator). */
 export function planWalls(layout: MapLayout): ColliderSpec[] {
   const HH = WALL_HEIGHT / 2;
   const HT = WALL_THICKNESS / 2;
@@ -152,7 +128,6 @@ export function planWalls(layout: MapLayout): ColliderSpec[] {
   }));
 }
 
-/** Bumpers (cylinders) — role `bumper_${i}`. */
 export function planBumpers(layout: MapLayout): ColliderSpec[] {
   return layout.bumpers.map((pos, i) => ({
     shape: { kind: 'cylinder', halfHeight: 0.02, radius: 0.025 },
@@ -164,7 +139,6 @@ export function planBumpers(layout: MapLayout): ColliderSpec[] {
   }));
 }
 
-/** Left/right slingshot sensors (sensor cuboids). */
 export function planSlingshotSensors(): ColliderSpec[] {
   const slings = [
     { pos: SLINGSHOT_LEFT_CENTER, role: 'slingshot_left' },
@@ -179,7 +153,6 @@ export function planSlingshotSensors(): ColliderSpec[] {
   }));
 }
 
-/** Pop-zone sensors (sensor cuboids) — role `pop_zone_${i}`. */
 export function planPopZoneSensors(layout: MapLayout): ColliderSpec[] {
   return layout.sensors.popZones.map((p, i) => ({
     shape: { kind: 'cuboid', halfExtents: { x: 0.015, y: 0.01, z: 0.015 } },
@@ -190,7 +163,6 @@ export function planPopZoneSensors(layout: MapLayout): ColliderSpec[] {
   }));
 }
 
-/** Boss targets (sensor spheres) — role = boss.colliderRole. */
 export function planBossTargets(layout: MapLayout): ColliderSpec[] {
   return layout.bosses.map((boss) => ({
     shape: { kind: 'ball', radius: 0.034 },
@@ -201,7 +173,6 @@ export function planBossTargets(layout: MapLayout): ColliderSpec[] {
   }));
 }
 
-/** Rocket ramp sensor (sensor cuboid) — role `rocket_ramp`. */
 export function planRocketSensor(layout: MapLayout): ColliderSpec {
   const rocket = layout.sensors.rocket;
   return {
@@ -213,7 +184,6 @@ export function planRocketSensor(layout: MapLayout): ColliderSpec {
   };
 }
 
-/** Drop targets (cuboids) — role = dropTarget.id. */
 export function planDropTargets(layout: MapLayout): ColliderSpec[] {
   return layout.dropTargets.map((dt) => ({
     shape: { kind: 'cuboid', halfExtents: { x: 0.006, y: 0.02, z: 0.015 } },
@@ -225,17 +195,14 @@ export function planDropTargets(layout: MapLayout): ColliderSpec[] {
   }));
 }
 
-/** Bottom-out sensor (full-width sensor cuboid) — role `bottom_out`. */
 export function planBottomOutSensor(layout: MapLayout): ColliderSpec {
   const leftX = layout.geometry.bounds.leftX;
   const rightX = layout.geometry.bounds.rightX;
   const centerX = (leftX + rightX) / 2;
   const halfX = (rightX - leftX) / 2;
-  // +0.03 offset: centers the sensor JUST past the drain line (BOTTOM_OUT_Z)
-  // rather than on it, so it only fires once the ball has crossed.
-  // halfZ 0.06 (0.12-deep band): deliberately thick sensor — a fast-draining
-  // ball could tunnel through a thin band between two physics steps.
-  // These are NOT values to "fix".
+  // +0.03 offset: centers the sensor just past the drain line (BOTTOM_OUT_Z),
+  // so it only fires once the ball has crossed. halfZ 0.06 is deliberately
+  // thick: a fast-draining ball could tunnel through a thin band between steps.
   const sensorZ = BOTTOM_OUT_Z + 0.03;
   return {
     shape: { kind: 'cuboid', halfExtents: { x: halfX, y: 0.03, z: 0.06 } },
@@ -246,7 +213,6 @@ export function planBottomOutSensor(layout: MapLayout): ColliderSpec {
   };
 }
 
-// Scoop hole (saucer) sensor. Optional: only if the map declares it.
 export function planScoopSensor(layout: MapLayout): ColliderSpec[] {
   const scoop = layout.sensors.scoop;
   if (!scoop) return [];
@@ -259,7 +225,6 @@ export function planScoopSensor(layout: MapLayout): ColliderSpec[] {
   }];
 }
 
-/** All sensors (slingshots + pop-zones + rocket + scoop + boss + drop + bottom-out). */
 export function planSensors(layout: MapLayout): ColliderSpec[] {
   return [
     ...planSlingshotSensors(),
@@ -272,9 +237,6 @@ export function planSensors(layout: MapLayout): ColliderSpec[] {
   ];
 }
 
-// ── Shooter lane ─────────────────────────────────────────────────────────────
-
-/** Tilted shooter lane floor. */
 export function planShooterLaneFloor(layout: MapLayout): ColliderSpec {
   const lane = layout.shooterLane;
   const zTop = lane.topZ;
@@ -296,7 +258,6 @@ export function planShooterLaneFloor(layout: MapLayout): ColliderSpec {
   };
 }
 
-/** Tilted lane side wall (follows the playfield tilt, thickness along X). */
 export function planTiltedLaneWall(
   layout: MapLayout,
   x: number,
@@ -321,7 +282,6 @@ export function planTiltedLaneWall(
   };
 }
 
-/** Back wall (safety net at the top of the lane). */
 export function planShooterBackWall(layout: MapLayout): ColliderSpec {
   const lane = layout.shooterLane;
   const z = lane.topZ;
@@ -339,10 +299,6 @@ export function planShooterBackWall(layout: MapLayout): ColliderSpec {
   };
 }
 
-/**
- * Curved guide: quarter circle approximated by N tangent cuboids. The concave
- * normal pushes the climbing ball (-Z) toward the playfield (-X).
- */
 export function planShooterGuide(layout: MapLayout): ColliderSpec[] {
   const lane = layout.shooterLane;
   const C = lane.guideCenter;
@@ -358,7 +314,6 @@ export function planShooterGuide(layout: MapLayout): ColliderSpec[] {
     const z = C.z + R * Math.sin(aMid);
     const y = surfaceYAtZ(z) + lane.wallHeight / 2;
 
-    // Tangent to the arc in the XZ plane → cuboid local +X axis.
     const tx = -Math.sin(aMid);
     const tz = Math.cos(aMid);
     const alpha = Math.atan2(-tz, tx);
@@ -377,7 +332,6 @@ export function planShooterGuide(layout: MapLayout): ColliderSpec[] {
   return specs;
 }
 
-/** Whole shooter lane: floor (optional) + walls + guide + back wall. */
 export function planShooterLane(
   layout: MapLayout,
   options: { includeFloor?: boolean } = {},
@@ -387,9 +341,8 @@ export function planShooterLane(
   if (options.includeFloor !== false) {
     specs.push(planShooterLaneFloor(layout));
   }
-  // Right wall: full height, contains the ball on the +X side up to the top.
   specs.push(planTiltedLaneWall(layout, lane.xMax, lane.topZ, lane.bottomZ));
-  // Left wall: stops before the top → exit opening at the top-left.
+  // Left wall stops before the top (leftWallTopZ) → exit opening at the top-left.
   specs.push(planTiltedLaneWall(layout, lane.xMin + 0.005, lane.leftWallTopZ, lane.bottomZ, 0.01));
   specs.push(...planShooterGuide(layout));
   specs.push(planShooterBackWall(layout));

--- a/packages/game-engine/src/infrastructure/CollisionEventProcessor.ts
+++ b/packages/game-engine/src/infrastructure/CollisionEventProcessor.ts
@@ -109,12 +109,10 @@ export class CollisionEventProcessor {
     });
   }
 
-  /** DEBUG (/debug): reveal via the real state path (boss armed, not a ghost). */
   debugRevealBoss(id: BossId, gameState: string): void {
     this.bossFights.forceReveal(id, gameState);
   }
 
-  /** DEBUG (/debug): credits a hit via the real sensor (real counter/defeat). */
   debugBossTargetHit(id: BossId, gameState: string): void {
     this.bossFights.forceTargetHit(id, gameState);
   }
@@ -144,13 +142,10 @@ export class CollisionEventProcessor {
     // The DRAIN-vs-rescue split (1 before 2) is the load-bearing invariant:
     // a map that rescues on the last ball must see the pre-decrement count.
     private readonly emit: GameEventListener,
-    // Injected clock: tests pass a controllable fake to make the anti-spam
-    // throttles deterministic.
     private readonly now: () => number = () => performance.now(),
   ) {
     this.bossFights = new BossFightManager(emit, layout.bosses, this.now);
 
-    // Kept as properties because they are exposed publicly (reset, state).
     this.dropTargetHandler = new DropTargetCollisionHandler(emit, layout);
     this.portalHandler = new PortalCollisionHandler(emit, () => this.worldState.isActive());
     this.bossHandler = new BossCollisionHandler(
@@ -186,12 +181,9 @@ export class CollisionEventProcessor {
 
   process(eventQueue: RAPIER.EventQueue, gameState: string): void {
     eventQueue.drainCollisionEvents((h1, h2, started) => {
-      // Role resolution: one of the two handles in the pair is the ball.
       const role = this.colliderMap.get(h1) ?? this.colliderMap.get(h2);
       if (!role) return;
 
-      // Dispatch to the registered handler for this role.
-      // BossCollisionHandler is first and consumes every boss collider role.
       const handler = this.handlers.find(h => h.canHandle(role));
       handler?.handle(role, gameState, started);
     });

--- a/packages/game-engine/src/infrastructure/CollisionHandler.ts
+++ b/packages/game-engine/src/infrastructure/CollisionHandler.ts
@@ -1,17 +1,4 @@
-/**
- * Each collider role has its own dedicated handler.
- * Adding a new role means creating a class that implements this interface
- * and registering it in CollisionEventProcessor — without touching the processor.
- */
 export interface CollisionHandler {
-  /** Returns true if this handler is responsible for the given collider role. */
   canHandle(role: string): boolean;
-
-  /**
-   * Processes the collision event.
-   * @param role      - collider role (GLB prefix, e.g. 'bumper_0', 'drain')
-   * @param gameState - current game state ('playing', 'game_over', …)
-   * @param started   - true = contact started, false = contact ended
-   */
   handle(role: string, gameState: string, started: boolean): void;
 }

--- a/packages/game-engine/src/infrastructure/DropTargetCollisionHandler.ts
+++ b/packages/game-engine/src/infrastructure/DropTargetCollisionHandler.ts
@@ -3,20 +3,7 @@ import type { GameEventListener } from '../domain/GameEvents';
 import type { MapLayout } from '../domain/MapLayout';
 import { SCORE_DROP_TARGET, SCORE_DROP_COMPLETE } from '../domain/ScoringConstants';
 
-/**
- * Handles collisions with drop targets (role: 'drop_<id>').
- *
- * Simple per-target state machine:
- *   up (false) → down (true) on first contact.
- *
- * When all targets on the same side are down, emits DROP_TARGET_COMPLETE
- * and resets the side (targets come back up).
- *
- * Note: the 'drop_target' prefix is reserved for visual/GLB colliders
- * (non-interactive); only 'drop_<id>' roles award points.
- */
 export class DropTargetCollisionHandler implements CollisionHandler {
-  // Current state of each drop target: true = down, false = up.
   private dropTargetDown: Record<string, boolean> = {};
 
   constructor(
@@ -29,19 +16,17 @@ export class DropTargetCollisionHandler implements CollisionHandler {
   }
 
   canHandle(role: string): boolean {
-    // Exclude 'drop_target*' (non-interactive GLB colliders).
+    // 'drop_target*' are non-interactive GLB colliders; only 'drop_<id>' scores.
     return role.startsWith('drop_') && !role.startsWith('drop_target');
   }
 
   handle(role: string, gameState: string, started: boolean): void {
     if (!started || gameState !== 'playing') return;
-    // Idempotent: an already-down target awards no further points.
     if (this.dropTargetDown[role]) return;
 
     this.dropTargetDown[role] = true;
     this.emit({ type: 'DROP_TARGET_HIT', targetId: role, scoreIncrement: SCORE_DROP_TARGET });
 
-    // Check whether all targets on the same side are now down.
     const target = this.layout.dropTargets.find((t) => t.id === role);
     if (!target) return;
 
@@ -49,12 +34,10 @@ export class DropTargetCollisionHandler implements CollisionHandler {
     const allDown = sideTargets.every((t) => this.dropTargetDown[t.id]);
     if (!allDown) return;
 
-    // Full combo: award bonus and reset the side.
     this.emit({ type: 'DROP_TARGET_COMPLETE', side: target.side, scoreIncrement: SCORE_DROP_COMPLETE });
     for (const t of sideTargets) this.dropTargetDown[t.id] = false;
   }
 
-  /** Resets all drop targets to the up state (called on drain / bottom_out). */
   resetDropTargets(): void {
     for (const k of Object.keys(this.dropTargetDown)) this.dropTargetDown[k] = false;
     this.emit({ type: 'DROP_TARGET_RESET' });

--- a/packages/game-engine/src/infrastructure/FlipperFlash.ts
+++ b/packages/game-engine/src/infrastructure/FlipperFlash.ts
@@ -6,9 +6,9 @@ export type FlashMat = {
   intensity: number;
 };
 
-export const FLASH_DURATION = 0.08; // retour en 80ms
+export const FLASH_DURATION = 0.08;
 export const FLASH_INTENSITY = 1.2;
-const _flashColor = new THREE.Color(0xfff0e0); // blanc chaud
+const _flashColor = new THREE.Color(0xfff0e0);
 
 export function collectFlashMats(obj: THREE.Object3D): FlashMat[] {
   const out: FlashMat[] = [];

--- a/packages/game-engine/src/infrastructure/FlipperGeometrySplit.ts
+++ b/packages/game-engine/src/infrastructure/FlipperGeometrySplit.ts
@@ -1,38 +1,14 @@
-/**
- * Pure geometry math for splitting a single flipper mesh into a left/right
- * pair at the playfield center plane (X = `planeX`). No THREE.js: operates on
- * plain typed arrays so the partition + remap logic is unit-testable.
- *
- * The caller (FlipperSplitter) reads THREE geometry attributes into these
- * arrays, runs the pure math here, then rebuilds THREE meshes from the result.
- */
-
 export type TriangleSplit = {
-  /** Flat triangle list (vertex indices, 3 per tri) whose centroid X ≤ planeX. */
   leftTris: number[];
-  /** Flat triangle list (vertex indices, 3 per tri) whose centroid X > planeX. */
   rightTris: number[];
 };
 
 export type RemappedGeometry = {
-  /** Compacted vertex positions (x, y, z per vertex), only kept vertices. */
   positions: Float32Array;
-  /** Compacted UVs (u, v per vertex), empty when source had no UVs. */
   uvs: Float32Array;
-  /** Triangle indices remapped to the compacted vertex range. */
   indices: number[];
 };
 
-/**
- * Partition triangles by the X coordinate of their centroid relative to the
- * split plane. A triangle whose centroid X is ≤ planeX goes left, otherwise
- * right — matching the original FlipperSplitter behaviour (boundary inclusive
- * on the left).
- *
- * @param indices flat index list, 3 entries per triangle
- * @param worldX  per-vertex world-space X, indexed by vertex id
- * @param planeX  split plane X (playfield center, usually 0)
- */
 export function partitionTrianglesByPlaneX(
   indices: number[],
   worldX: number[],
@@ -50,17 +26,6 @@ export function partitionTrianglesByPlaneX(
   return { leftTris, rightTris };
 }
 
-/**
- * Rebuild a compacted geometry for a subset of triangles: only the vertices
- * referenced by `tris` are kept, in first-seen order, and the triangle indices
- * are remapped into that compacted range. Positions/UVs are read from the
- * source per-vertex arrays.
- *
- * @param tris      flat triangle list (vertex indices into source arrays)
- * @param positions source local positions (x, y, z per vertex)
- * @param uvs       source UVs (u, v per vertex); pass null/empty when absent
- * @returns compacted positions, uvs, and remapped indices
- */
 export function remapTriangles(
   tris: number[],
   positions: ArrayLike<number>,

--- a/packages/game-engine/src/infrastructure/FlipperHullBody.ts
+++ b/packages/game-engine/src/infrastructure/FlipperHullBody.ts
@@ -9,12 +9,6 @@ export type FlipperHullBodyResult = {
   localPts: THREE.Vector3[];
 };
 
-/**
- * Kinematic body + convex hull collider for a flipper, derived from a
- * THREE.Mesh's world geometry. No scene mutation, no debug mesh created
- * here — returns `localPts`/`hullVertices` so the caller can build its own
- * debug ConvexGeometry.
- */
 export function buildFlipperHullBody(
   world: RAPIER.World,
   flipper: THREE.Mesh,
@@ -30,7 +24,6 @@ export function buildFlipperHullBody(
   const n = posAttr.count;
   const v = new THREE.Vector3();
 
-  // Real geometric center (not the parent group's origin)
   let wSumX = 0,
     wSumY = 0,
     wSumZ = 0;
@@ -43,7 +36,6 @@ export function buildFlipperHullBody(
   const geoCenter = new THREE.Vector3(wSumX / n, wSumY / n, wSumZ / n);
   const localOffset = geoCenter.clone().sub(meshOrigin).applyQuaternion(invWorldQuat);
 
-  // Vertices in body-local space (centered on geoCenter)
   const localPts: THREE.Vector3[] = [];
   const raw: number[] = [];
   for (let i = 0; i < n; i++) {
@@ -75,12 +67,6 @@ export function buildFlipperHullBody(
   return { body, localOffset, hullVertices, localPts };
 }
 
-/**
- * World transform of a flipper offset by its `localOffset` (expressed in the
- * flipper's local space). Offset math shared between the kinematic body sync
- * and the debug wireframes — lives here once. Calls
- * `updateMatrixWorld(true)`.
- */
 export function flipperWorldTransform(
   flipper: THREE.Object3D,
   localOffset: THREE.Vector3,
@@ -95,10 +81,6 @@ export function flipperWorldTransform(
   return { position, quaternion };
 }
 
-/**
- * Pushes a flipper's world transform (via `flipperWorldTransform`) into its
- * kinematic Rapier body. No-op if `body` or `flipper` is null.
- */
 export function syncFlipperBody(
   body: RAPIER.RigidBody | null,
   flipper: THREE.Object3D | null,

--- a/packages/game-engine/src/infrastructure/FlipperSplitter.ts
+++ b/packages/game-engine/src/infrastructure/FlipperSplitter.ts
@@ -36,11 +36,6 @@ function meshCenterX(mesh: THREE.Mesh): number {
   return new THREE.Box3().setFromObject(mesh).getCenter(new THREE.Vector3()).x;
 }
 
-/**
- * Direct resolution: the GLB already exposes two distinct sub-models named
- * `flipper-left` and `flipper-right` (normalized names with a dash).
- * Found directly — no geometric split needed.
- */
 function resolveNamedFlippers(root: THREE.Object3D): PlayfieldFlipperPair | null {
   const leftNode  = findObjectByNormalizedName(root, 'flipper-left',  'flipper_left')  ?? null;
   const rightNode = findObjectByNormalizedName(root, 'flipper-right', 'flipper_right') ?? null;
@@ -63,13 +58,10 @@ function meshSpansPlayfieldCenter(mesh: THREE.Mesh): boolean {
 }
 
 export function resolvePlayfieldFlippers(root: THREE.Object3D): PlayfieldFlipperPair | null {
-  // Case 1: GLB with named flipper-left / flipper-right sub-models (new format).
   const namedPair = resolveNamedFlippers(root);
   if (namedPair) return namedPair;
 
-  // Case 2: legacy fallback — single flipper (flipper.001 / flipper001 /
-  // flipper) split geometrically at the X=0 plane.
-  // Three.js GLTFLoader sanitizes dots → flipper.001 becomes flipper001 in the scene.
+  // Three.js GLTFLoader sanitizes dots → flipper.001 becomes flipper001.
   const group = findObjectByNormalizedName(root, 'flipper.001', 'flipper001', 'flipper') ?? null;
   const meshes: THREE.Mesh[] = [];
   if (group) {
@@ -80,15 +72,8 @@ export function resolvePlayfieldFlippers(root: THREE.Object3D): PlayfieldFlipper
   }
   if (meshes.length === 0) return null;
 
-  // Multi-mesh GLB case: 2+ meshes that EACH span the full playfield width
-  // (base + plastic of the same flipper pair). Split the densest one
-  // geometrically at X=0 to get left/right half-meshes, and hide the others.
   const spanning = meshes.filter(meshSpansPlayfieldCenter);
   if (spanning.length >= 1 && (meshes.length === 1 || spanning.length === meshes.length)) {
-    // Sort by descending vertex count: primary = densest mesh (usually the
-    // main structural layer). The others are split too and attached as
-    // children of the primary half-meshes to preserve the multi-layer look
-    // (e.g. red rubber + white plastic).
     const ordered = [...spanning].sort(
       (a, b) =>
         (b.geometry.attributes.position?.count ?? 0) -
@@ -234,9 +219,7 @@ function hingeLocalPosition(
   const box = new THREE.Box3().setFromObject(flipper);
   const { min, max } = box;
   const inset = (max.x - min.x) * HINGE_INSET_FROM_EDGE;
-  // Pinball convention: hinge at far-X (playfield edge side), tip at center.
-  // LEFT → hinge at min.x (far left). RIGHT → hinge at max.x (far right).
-  // Fine pivot tuning comes from the map layout (pivots).
+  // Pinball convention: hinge at far-X (LEFT → min.x, RIGHT → max.x), tip at center.
   const baseX  = side === 'left' ? min.x + inset : max.x - inset;
   const extraX = side === 'left' ? pivots.leftX : pivots.rightX;
   const hingeWorld = new THREE.Vector3(
@@ -266,10 +249,8 @@ export function attachFlipperAtHinge(
   parent.add(pivot);
   pivot.attach(flipper);
 
-  // Pinball: horizontal swing around an axis perpendicular to the playfield.
-  // Y is close enough to the playfield normal (tilt ~6.5°) for the visual.
-  // The old `detectPivotAxis` measured the Y lift and picked X for a flat
-  // flipper — which gave a vertical tilt instead of a swing.
+  // Horizontal swing around Y: close enough to the playfield normal (tilt ~6.5°)
+  // for the visual, avoiding the vertical tilt an X axis would give.
   pivot.rotation.set(0, 0, 0);
   return { pivot, mesh: flipper, side, axis: 'y' };
 }

--- a/packages/game-engine/src/infrastructure/FlipperZones.ts
+++ b/packages/game-engine/src/infrastructure/FlipperZones.ts
@@ -10,25 +10,12 @@ export type FlipperZone = {
 };
 export type FlipperZones = { left: FlipperZone; right: FlipperZone };
 
-/**
- * Toggle for the zone-derivation log. On by default (a single `console.info`
- * at load). The cabinet can turn it off in prod via
- * `setFlipperZonesLogging(false)` to avoid console noise.
- */
 let flipperZonesLogging = true;
 
 export function setFlipperZonesLogging(enabled: boolean): void {
   flipperZonesLogging = enabled;
 }
 
-/**
- * Derives the flip-guarantee zones from the real bbox of the flipper meshes
- * (rest pose, BEFORE the simulation starts). Avoids frozen X coordinates
- * measured on an old GLB.
- *
- * `margin` expands the bbox on X/Z: the ball counts as touching as soon as
- * its center is within one radius of the edge (margin = BALL_RADIUS).
- */
 export function computeFlipperZones(
   left: THREE.Object3D,
   right: THREE.Object3D,

--- a/packages/game-engine/src/infrastructure/GlowSprite.ts
+++ b/packages/game-engine/src/infrastructure/GlowSprite.ts
@@ -1,9 +1,5 @@
 import * as THREE from 'three';
 
-// Lightweight additive glow (THREE.Sprite → auto billboard, no camera to
-// thread through, 1 draw call, NO light). Replaces decorative PointLights:
-// zero shader cost. Shared radial texture (generated once).
-
 let sharedTexture: THREE.Texture | null = null;
 
 function glowTexture(): THREE.Texture {
@@ -47,7 +43,6 @@ export class GlowSprite {
     this.mat.color.setHex(hex);
   }
 
-  // intensity → opacity; scaleMul modulates size (pulse).
   set(intensity: number, scaleMul = 1): void {
     this.mat.opacity = Math.max(0, Math.min(1, intensity));
     this.sprite.scale.setScalar(this.baseSize * scaleMul);

--- a/packages/game-engine/src/infrastructure/GltfDisplay.ts
+++ b/packages/game-engine/src/infrastructure/GltfDisplay.ts
@@ -45,15 +45,6 @@ function shouldDarkenMapMaterial(mesh: THREE.Mesh): boolean {
   return false;
 }
 
-/**
- * Prepares GLB materials for Three.js PBR rendering.
- * - Fixes texture color spaces (SRGBColorSpace).
- * - Darkens table surfaces per `rendering.colorDarken`.
- * - Boosts `envMapIntensity` based on metalness level and the map config.
- *
- * @param rendering Map rendering config (from manifest.rendering).
- *                  Absent → neutral defaults.
- */
 export function prepareGltfMaterialsForDisplay(
   root: THREE.Object3D,
   rendering?: MapRenderingConfig,
@@ -76,29 +67,22 @@ export function prepareGltfMaterialsForDisplay(
       if (processed.has(material)) continue;
       processed.add(material);
 
-      // Texture color spaces.
       for (const key of TEXTURE_KEYS) {
         const tex = material[key];
         if (tex) tex.colorSpace = THREE.SRGBColorSpace;
       }
 
-      // Selective darkening of playfield surfaces.
       if (shouldDarkenMapMaterial(obj)) {
         material.color.multiplyScalar(colorDarken);
-        // Printed surfaces (floor/plastic/stickers) = diffuse, not mirrors.
-        // High roughness + metalness 0 + near-zero envMapIntensity: even at
-        // grazing angles (fresnel), the floor no longer reflects the
-        // RoomEnvironment panels. Do NOT fall through to the boost below.
+        // Printed surfaces stay diffuse (near-zero envMapIntensity) so the floor
+        // never reflects the RoomEnvironment panels. Do NOT fall through to the
+        // boost below.
         material.roughness = Math.max(material.roughness, 0.85);
         material.metalness = 0;
         material.envMapIntensity = 0.05;
         continue;
       }
 
-      // envMapIntensity by metalness — key to the vivid PBR look.
-      // metalness = 0 → diffuse material (plastic, wood): envBase.
-      // metalness 0.2–0.5 → semi-metal: envSemi.
-      // metalness ≥ 0.5 → pure metal (gold, chrome, gems): envMetallic.
       if (material.metalness >= 0.5) {
         material.envMapIntensity = envMetallic;
       } else if (material.metalness >= 0.2) {
@@ -110,11 +94,6 @@ export function prepareGltfMaterialsForDisplay(
   });
 }
 
-/**
- * Configures the WebGL renderer for correct PBR rendering.
- * @param rendering Map config — toneMappingExposure read from rendering,
- *                  or DEFAULT when absent.
- */
 export function configureGltfRenderer(
   renderer: THREE.WebGLRenderer,
   rendering?: MapRenderingConfig,
@@ -124,10 +103,6 @@ export function configureGltfRenderer(
   renderer.toneMappingExposure = rendering?.toneMappingExposure ?? DEFAULT_TONE_MAPPING_EXPOSURE;
 }
 
-/**
- * Blur factor to pass to `pmrem.fromScene(env, blur)`.
- * 0 = sharp reflections, 0.04 = soft (Three.js default).
- */
 export function getEnvironmentBlur(rendering?: MapRenderingConfig): number {
   return rendering?.environmentBlur ?? DEFAULT_ENVIRONMENT_BLUR;
 }

--- a/packages/game-engine/src/infrastructure/GltfNodeNames.ts
+++ b/packages/game-engine/src/infrastructure/GltfNodeNames.ts
@@ -19,7 +19,6 @@ export function isVisualOnlyGltfName(name: string): boolean {
   return n.startsWith('vis_') || n === 'glass' || n.includes('glass');
 }
 
-/** Ancestry variant: true if self OR any ancestor is visual-only. */
 export function isVisualOnlyGltfAncestry(ancestryNames: string[]): boolean {
   return ancestryNames.some(isVisualOnlyGltfName);
 }
@@ -58,10 +57,6 @@ export function hasNamedAncestor(obj: THREE.Object3D, ...names: string[]): boole
   return false;
 }
 
-/**
- * Variant of isPinballmapGameplayMesh operating on the ancestry name list
- * (self → parents) instead of a THREE.Mesh.
- */
 export function isPinballmapGameplayMeshName(ancestryNames: string[]): boolean {
   return ancestryNames.some((name) => normalizeGltfName(name) === 'pinballmap');
 }
@@ -70,16 +65,10 @@ export function isPinballmapGameplayMesh(mesh: THREE.Mesh): boolean {
   return hasNamedAncestor(mesh, 'Pinballmap');
 }
 
-/**
- * Variant of isFlipperGltfMesh operating on the ancestry name list
- * (self → parents). Stops at the 'pinballmap' boundary.
- */
 export function isFlipperGltfMeshName(ancestryNames: string[]): boolean {
   for (const name of ancestryNames) {
     const n = normalizeGltfName(name);
     if (n === 'pinballmap') return false;
-    // Old convention: single "flipper" or "flipper.001" node
-    // New convention: separate "flipper-left" / "flipper-right" sub-models
     if (
       n === 'flipper' ||
       n.startsWith('flipper.') ||
@@ -106,11 +95,6 @@ function isRailNodeName(normalized: string): boolean {
   return /^circle\.\d+$/.test(normalized) || /^plane\.\d+$/.test(normalized);
 }
 
-/**
- * Variant of isPinballmapRailMesh operating on the ancestry name list
- * (self → parents). Self is a rail if it matches circle.NNN / plane.NNN;
- * otherwise walk up the parents until the 'pinballmap' boundary.
- */
 export function isPinballmapRailMeshName(ancestryNames: string[]): boolean {
   const self = normalizeGltfName(ancestryNames[0] ?? '');
   if (isRailNodeName(self)) return true;
@@ -154,7 +138,6 @@ export const PINBALLMAP_NONPHYSICAL_FLOOR_MESHES = new Set([
   'mesh0',
 ]);
 
-/** Name-based variant of isPinballmapNonPhysicalFloorMesh (self name). */
 export function isPinballmapNonPhysicalFloorMeshName(selfName: string): boolean {
   const n = normalizeGltfName(selfName);
   const c = canonicalGltfName(selfName);
@@ -168,12 +151,8 @@ export function isPinballmapNonPhysicalFloorMesh(mesh: THREE.Mesh): boolean {
   return isPinballmapNonPhysicalFloorMeshName(mesh.name);
 }
 
-/**
- * GLB switch sensors (visual, non-gameplay sensor zones).
- * Single source shared by the 3 pipelines: trimesh (HIDDEN_NODES),
- * colliders (EXCLUDED_NODES) and rendering (VISUALLY_HIDDEN_NODES).
- * Both underscore and space variants are matched.
- */
+// Single source shared by 3 pipelines: trimesh (HIDDEN_NODES), colliders
+// (EXCLUDED_NODES) and rendering (VISUALLY_HIDDEN_NODES).
 export const SWITCH_SENSOR_NODES = new Set([
   'switch_slingshot', 'switch slingshot',
   'switch_left_pop_bumper_zone',  'switch left pop bumper zone',
@@ -184,15 +163,8 @@ export const SWITCH_SENSOR_NODES = new Set([
   'switch_out',     'switch out',
 ]);
 
-/**
- * GLB nodes present in the model that must stay invisible in game
- * (plate, switch sensors…).
- * No collision either — these nodes are already in PlayfieldTrimeshBuilder's
- * EXCLUDED_NODES.
- */
 const VISUALLY_HIDDEN_NODES = new Set(['plate', ...SWITCH_SENSOR_NODES]);
 
-/** Hides the decorative / non-gameplay GLB meshes (plate, switches). */
 export function hidePinballmapDecorNodes(root: THREE.Object3D): void {
   root.traverse((obj) => {
     if (!(obj instanceof THREE.Mesh)) return;

--- a/packages/game-engine/src/infrastructure/LauncherLaneBounds.ts
+++ b/packages/game-engine/src/infrastructure/LauncherLaneBounds.ts
@@ -9,7 +9,6 @@ const LAUNCHER_LANE_MESH_NAMES = new Set([
   'separator_right',
 ]);
 
-/** Shooter-lane Z bounds from the GLB (fallback = legacy constants). */
 export function computeLauncherLaneZBounds(playfieldRoot: THREE.Object3D): {
   minZ: number;
   maxZ: number;

--- a/packages/game-engine/src/infrastructure/LayoutResolver.ts
+++ b/packages/game-engine/src/infrastructure/LayoutResolver.ts
@@ -2,18 +2,8 @@ import * as THREE from 'three';
 import { MeshRoleResolver } from './MeshRoleResolver';
 import type { MapLayout, MapPoint3 } from '../domain/MapLayout';
 
-// Derives gameplay element positions from the conventioned GLB meshes
-// (world Box3 center) instead of hardcoded constants. Goal: a single source
-// of truth (the GLB), no drift on Blender re-export.
-//
-// Current GLB coverage: bumpers (bumper_<n>) + drop targets (target_<id>).
-// Sensors / portal / drain / boss targets have NO mesh → they stay explicit
-// literals in the map layout (deliberate hybrid).
-
 export interface DerivedLayout {
-  /** World Box3 center of the bumper_<n> mesh, indexed by (n-1). */
   bumpers: (MapPoint3 | null)[];
-  /** World Box3 center of the target_<id> mesh, key = `drop_<id>`. */
   dropTargets: Record<string, MapPoint3>;
 }
 
@@ -38,7 +28,6 @@ function distMm(a: MapPoint3, b: MapPoint3): number {
 }
 
 export class LayoutResolver {
-  /** Traverses the GLB and derives the positions of the supported roles. */
   static derive(playfieldRoot: THREE.Object3D, resolver: MeshRoleResolver): DerivedLayout {
     playfieldRoot.updateMatrixWorld(true);
     const bumpers: (MapPoint3 | null)[] = [];
@@ -58,11 +47,6 @@ export class LayoutResolver {
     return { bumpers, dropTargets };
   }
 
-  /**
-   * Derives and logs the delta (mm) against the constant layout. Mutates
-   * nothing. `[LayoutResolver] <id> derived={…} constant={…} delta=<mm>`;
-   * marks OK/⚠ against the tolerance.
-   */
   static deriveAndCompare(
     playfieldRoot: THREE.Object3D,
     resolver: MeshRoleResolver,
@@ -92,12 +76,8 @@ export class LayoutResolver {
     return derived;
   }
 
-  /**
-   * Returns a copy of the layout with drop target positions replaced by the
-   * GLB-derived ones (source of truth). Bumpers are NOT derived (Box3 center
-   * ≠ tuned collider point, deltas out of tolerance) → they keep their
-   * literals. A drop target without a mesh keeps its literal (fallback).
-   */
+  // Bumpers are NOT derived (Box3 center ≠ tuned collider point, deltas out of
+  // tolerance) → they keep their literals; a drop target without a mesh too.
   static withDerivedDropTargets(layout: MapLayout, derived: DerivedLayout): MapLayout {
     return {
       ...layout,

--- a/packages/game-engine/src/infrastructure/MeshRoleResolver.ts
+++ b/packages/game-engine/src/infrastructure/MeshRoleResolver.ts
@@ -1,18 +1,3 @@
-// Resolves a mesh's physical role from its name, by prefix convention. A map
-// provides a GLB named to these conventions; an optional `meshAliases`
-// (manifest) first translates legacy names before matching.
-//
-// Conventions (prefix → role):
-//   vis_        decor, zero physics
-//   floor_      play surface → trimesh + slope derivation
-//   wall_       solid trimesh
-//   flipper_    flipper_left / flipper_right
-//   bumper_<n>  analytic collider + visual
-//   slingshot_  slingshot_left / slingshot_right
-//   target_<id> drop target
-//   sensor_<id> trigger zone (no solid)
-//   lane_       shooter lane
-
 export type MeshRole =
   | 'vis'
   | 'floor'
@@ -26,7 +11,6 @@ export type MeshRole =
 
 export interface ResolvedRole {
   role: MeshRole;
-  /** Suffix after the prefix (e.g. bumper_1 → '1', flipper_left → 'left'). */
   id: string;
 }
 
@@ -43,26 +27,22 @@ const PREFIXES: ReadonlyArray<readonly [string, MeshRole]> = [
   ['lane_', 'lane'],
 ];
 
-/** Normalizes a GLB name: lowercase, separators (space/dot/dash) → underscore. */
 export function normalizeMeshName(name: string): string {
   return name.toLowerCase().replace(/[\s.-]+/g, '_');
 }
 
 export class MeshRoleResolver {
   private readonly aliases: Record<string, string>;
-  // Unresolved names (no role, no vis_) — aggregated into a single warn.
   private readonly unresolved = new Set<string>();
   private warned = false;
 
   constructor(aliases: Record<string, string> = {}) {
-    // Normalize alias keys to match regardless of the GLB casing.
     this.aliases = {};
     for (const [from, to] of Object.entries(aliases)) {
       this.aliases[normalizeMeshName(from)] = normalizeMeshName(to);
     }
   }
 
-  /** Matches a single name (alias + prefix), side-effect free. */
   private match(name: string): ResolvedRole | null {
     const norm = normalizeMeshName(name);
     const canonical = this.aliases[norm] ?? norm;
@@ -74,36 +54,27 @@ export class MeshRoleResolver {
     return null;
   }
 
-  /** Mesh role + id, or null if unrecognized (recorded for the aggregated warn). */
   resolve(meshName: string): ResolvedRole | null {
     const r = this.match(meshName);
     if (!r) this.unresolved.add(meshName);
     return r;
   }
 
-  /**
-   * Resolves by walking up the hierarchy: names from the mesh toward the
-   * root, first recognized prefix wins (most specific first). Lets a parent
-   * GROUP be prefixed once for all its children — primitives coming from a
-   * per-material split (e.g. `Circle.018` → `Mesh_8/9/10`) inherit the
-   * parent's role. A named child can override its group.
-   */
+  // Most specific first: a parent group prefixed once is inherited by children
+  // (per-material split primitives), and a named child can override its group.
   resolveFromAncestry(namesFromSelfToRoot: string[]): ResolvedRole | null {
     for (const name of namesFromSelfToRoot) {
       const r = this.match(name);
       if (r) return r;
     }
-    // No ancestor resolved → record the most specific name (the mesh).
     if (namesFromSelfToRoot.length > 0) this.unresolved.add(namesFromSelfToRoot[0]);
     return null;
   }
 
-  /** Aggregated list of meshes with no role (vis_ excluded). */
   getUnresolved(): string[] {
     return [...this.unresolved];
   }
 
-  /** Emits a single summary console.warn if some meshes are unresolved. */
   warnUnresolvedOnce(): void {
     if (this.warned || this.unresolved.size === 0) return;
     this.warned = true;

--- a/packages/game-engine/src/infrastructure/PhysicsWorld.ts
+++ b/packages/game-engine/src/infrastructure/PhysicsWorld.ts
@@ -1,24 +1,20 @@
 import * as RAPIER from "@dimforge/rapier3d-compat";
 import type { IPhysicsWorld } from '../domain/IPhysicsWorld';
 
-/** Hooks for the per-frame physics step cycle (see PhysicsWorld.update). */
 export interface PhysicsUpdateHooks {
   /**
-   * Called BEFORE each world.step(). Kinematic body targets (flippers) must
-   * be set here: Rapier infers a kinematic body's velocity from the
-   * target/pose gap at step time. Setting the target at RENDER rate made the
-   * flipper sweep a double arc per step at 120 Hz (tunneling — Rapier does
-   * not CCD kinematic motion) and a zero arc every other step at 60 Hz.
-   * One target per step = constant arc.
+   * Kinematic body targets (flippers) must be set here, before world.step():
+   * Rapier infers a kinematic body's velocity from the target/pose gap at step
+   * time. Setting the target at RENDER rate made the flipper sweep a double arc
+   * per step at 120 Hz (tunneling — Rapier does not CCD kinematic motion) and a
+   * zero arc every other step at 60 Hz. One target per step = constant arc.
    */
   onBeforeStep?: () => void;
   /**
-   * Called after EACH world.step() — drains collision events per step.
-   * Required with multi-step: Rapier does not keep events across steps, so
-   * draining once per frame would lose collisions from intermediate steps.
+   * Called after EACH world.step(). Rapier does not keep events across steps,
+   * so draining once per frame would lose collisions from intermediate steps.
    */
   onStep?: () => void;
-  /** Called once per frame, after all steps (including 0 steps). */
   onAfterSteps?: () => void;
 }
 
@@ -54,14 +50,8 @@ export class PhysicsWorld implements IPhysicsWorld {
   private static readonly MAX_STEPS_PER_FRAME = 5;
   private accumulator = 0;
   private timeScale = 1;
-  /** true after a Rapier WASM panic (unreachable / unsafe aliasing). */
   private crashed = false;
 
-  /**
-   * Time scale (slow-mo). 1 = normal, 1/3 = slowed. Implemented by scaling
-   * the accumulator → fewer real steps, so the ball appears to slow down
-   * without touching the fixed Rapier timestep.
-   */
   setTimeScale(scale: number): void {
     this.timeScale = scale;
   }
@@ -82,11 +72,7 @@ export class PhysicsWorld implements IPhysicsWorld {
     return new PhysicsWorld(world);
   }
 
-  /**
-   * Step planning logic. Caps the backlog at
-   * MAX_STEPS_PER_FRAME × STEP_INTERVAL before draining, which protects
-   * against the spiral-of-death while still allowing catch-up.
-   */
+  // Caps the backlog before draining to protect against the spiral-of-death.
   static planSteps(accumulator: number): { steps: number; remainder: number } {
     const maxBacklog = PhysicsWorld.MAX_STEPS_PER_FRAME * PhysicsWorld.STEP_INTERVAL;
     let acc = Math.min(accumulator, maxBacklog);
@@ -98,34 +84,19 @@ export class PhysicsWorld implements IPhysicsWorld {
     return { steps, remainder: acc };
   }
 
-  /** true if the Rapier world panicked and can no longer be used. */
   get isAlive(): boolean {
     return !this.crashed;
   }
 
-  /**
-   * Fraction of the way toward the next physics step, used to interpolate
-   * rendering between two physics states (smooth ball at 120 Hz while
-   * physics stays at 60 steps/s). Purely visual — does not affect the
-   * simulation.
-   */
   get interpolationAlpha(): number {
     return PhysicsWorld.interpolationAlphaFor(this.accumulator);
   }
 
-  /** accumulator/STEP_INTERVAL clamped to [0,1]. */
   static interpolationAlphaFor(accumulator: number): number {
     const a = accumulator / PhysicsWorld.STEP_INTERVAL;
     return a < 0 ? 0 : a > 1 ? 1 : a;
   }
 
-  /**
-   * @param dt Seconds elapsed since the last frame (capped at 0.05 in the
-   *           render loop — protects against tab freezes).
-   * @param hooks Per-step cycle: onBeforeStep (kinematic targets) →
-   *           world.step() → onStep (event drain), then onAfterSteps once
-   *           the frame is drained. See PhysicsUpdateHooks for the WHY.
-   */
   update(dt: number, hooks?: PhysicsUpdateHooks): void {
     this.accumulator += dt * this.timeScale;
     const { steps, remainder } = PhysicsWorld.planSteps(this.accumulator);
@@ -135,9 +106,8 @@ export class PhysicsWorld implements IPhysicsWorld {
       try {
         this.world.step(this.eventQueue);
       } catch (e) {
-        // Rapier WASM panic (unreachable / unsafe aliasing). Mark the world
-        // as dead so later calls do not cascade into errors. The user must
-        // reload the page to get a healthy world back.
+        // Mark the world dead on a Rapier WASM panic so later calls do not
+        // cascade into errors; the page must be reloaded to recover.
         this.crashed = true;
         console.error('[Rapier] world.step() panic — physics halted:', e);
         return;

--- a/packages/game-engine/src/infrastructure/PlayfieldCameraFit.ts
+++ b/packages/game-engine/src/infrastructure/PlayfieldCameraFit.ts
@@ -26,14 +26,10 @@ export const PLAYFIELD_PORTRAIT_HALF_WIDTH =
 export const PLAYFIELD_PORTRAIT_LOOK_Z_BIAS = 0;
 export const PLAYFIELD_PORTRAIT_LOOK_Y_BIAS = 0;
 
-// Module-level shared scratch: avoids allocating in the hot framing loop
-// (bisection ~30 iterations × N corners, per resize/refit).
-// Safe because all usage is SYNCHRONOUS, non-recursive and await-free:
-// single-threaded JS guarantees a scratch is written then fully consumed
-// before the next writer. `_clipMatrix` is returned by withCameraAt then read
-// immediately (only one live matrix at a time); `_ndcPoint`/`_camPosScratch`
-// are distinct objects, no aliasing. Making them locals would reintroduce
-// per-frame allocations — a regression, not a cleanup.
+// Module-level scratch, safe because all usage is synchronous, non-recursive
+// and await-free (each scratch is written then fully consumed before the next
+// writer). Making them locals would reintroduce per-frame allocations in the
+// hot framing loop — a regression, not a cleanup.
 const _clipMatrix = new THREE.Matrix4();
 const _ndcPoint = new THREE.Vector4();
 const _camPosScratch = new THREE.Vector3();
@@ -73,11 +69,6 @@ export type PlayfieldCameraFitOptions = {
   viewMode?: PlayfieldViewMode;
   debugTuning?: PlayfieldCameraDebugTuning | null;
 };
-
-// ── Per-mode public API: full delegation to the strategy table ────────────────
-// No switch/if on the mode here. All mode-specific knowledge lives in
-// PLAYFIELD_VIEW_MODE_STRATEGIES (defined below). Adding a view mode = adding
-// ONE table entry, without touching these functions or refit/fit.
 
 export function playfieldViewDirForMode(viewMode: PlayfieldViewMode): THREE.Vector3 {
   return PLAYFIELD_VIEW_MODE_STRATEGIES[viewMode].viewDir();
@@ -434,34 +425,16 @@ export function boundingBoxPortraitFrame(playfieldRoot: THREE.Object3D): THREE.B
   return boundingBoxPlayfieldWallFootprint(0.01);
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// VIEW-MODE STRATEGIES
-//
-// Each camera mode (`legacy`, `portrait-fill`, …) is described by ONE object
-// implementing the same interface. The generic code below (fit / refit) only
-// READS this table: it knows no mode names.
-//
-// ADDING A MODE = adding an entry to PLAYFIELD_VIEW_MODE_STRATEGIES. The
-// `Record<PlayfieldViewMode, …>` makes TypeScript require the entry at
-// compile time.
-// ─────────────────────────────────────────────────────────────────────────────
-
 interface PlayfieldViewModeStrategy {
-  /** Eye→target direction (fresh, normalized vector). */
   viewDir(debugTuning?: PlayfieldCameraDebugTuning | null): THREE.Vector3;
-  /** Camera "up" vector (shared constant — caller clones if needed). */
   cameraUp(): THREE.Vector3;
-  /** Mode-specific framing bounding box. */
   frameBox(playfieldRoot: THREE.Object3D): THREE.Box3;
-  /** Computes the look-at point, writes it into `out` and returns it. */
   computeTarget(
     frameBox: THREE.Box3,
     out: THREE.Vector3,
     debugTuning?: PlayfieldCameraDebugTuning | null,
   ): THREE.Vector3;
-  /** Fills the corners used for the distance computation. */
   fillCorners(frameBox: THREE.Box3, corners: THREE.Vector3[]): void;
-  /** Positions the camera; returns the distance (perspective) or half-width (ortho). */
   fit(
     camera: PlayfieldCamera,
     fit: PlayfieldCamFit,
@@ -471,13 +444,10 @@ interface PlayfieldViewModeStrategy {
   ): number;
 }
 
-// Box-center target (legacy mode: classic tilted camera).
 function legacyCameraTarget(frameBox: THREE.Box3, out: THREE.Vector3): THREE.Vector3 {
   return frameBox.getCenter(out);
 }
 
-// Portrait-specific target: XZ center laid on the surface, with optional
-// debug biases (pulls the look-at toward the surface / bottom of the frame).
 function portraitCameraTarget(
   frameBox: THREE.Box3,
   out: THREE.Vector3,

--- a/packages/game-engine/src/infrastructure/PlayfieldCinematicStrobe.ts
+++ b/packages/game-engine/src/infrastructure/PlayfieldCinematicStrobe.ts
@@ -11,7 +11,6 @@ export type PlayfieldCinematicStrobeConfig = {
   flashDecay?: number;
 };
 
-/** Optional decor port: drives lights/visuals in time with the strobe. */
 export interface DecorLights {
   setStrobe(active: boolean, on: boolean, normalWhenOn?: boolean): void;
 }
@@ -23,7 +22,6 @@ export class PlayfieldCinematicStrobe {
   private decor: DecorLights[] = [];
   private flashIntensity = 2.4;
 
-  // The PointLight is IN the scene only while it flashes (perf).
   private setFlash(intensity: number): void {
     if (!this.flashLight) return;
     this.flashLight.intensity = intensity;
@@ -55,7 +53,7 @@ export class PlayfieldCinematicStrobe {
       config.flashDecay ?? 2,
     );
     this.flashLight.position.copy(config.flashPosition);
-    this.flashRoot = root; // add/remove on demand
+    this.flashRoot = root;
   }
 
   apply(on: boolean, fullMap: boolean, mix: number): void {
@@ -67,7 +65,6 @@ export class PlayfieldCinematicStrobe {
     for (const d of this.decor) d.setStrobe(active, on, fullMap);
   }
 
-  /** Flash without shade overlay — for maps that don't want a black veil. */
   applyFlashOnly(on: boolean, mix: number): void {
     this.shade.setOpacity(0);
     this.setFlash(on ? this.flashIntensity * mix : 0);

--- a/packages/game-engine/src/infrastructure/PlayfieldColliderFactory.ts
+++ b/packages/game-engine/src/infrastructure/PlayfieldColliderFactory.ts
@@ -19,11 +19,6 @@ export type AnalyticalColliderOptions = {
   bumpers?: boolean;
 };
 
-/**
- * Thin applier: translates a ColliderSpec (see ColliderSpecPlanner) into
- * Rapier createRigidBody/createCollider calls. All the math (translation /
- * halfExtents / quaternion / restitution / sensor) lives in the planner.
- */
 function applyColliderSpec(
   world: RAPIER.World,
   spec: ColliderSpec,
@@ -102,11 +97,7 @@ export class PlayfieldColliderFactory {
     PlayfieldColliderFactory.createSensors(world, layout, colliderMap);
   }
 
-  /**
-   * Analytic colliders for a conventioned map (role-driven GLB): smooth
-   * floor + bumpers + sensors + shooter lane. Walls come from the wall_
-   * trimeshes (PlayfieldTrimeshBuilder.buildRoleDriven), not from here.
-   */
+  // Walls come from the wall_ trimeshes (PlayfieldTrimeshBuilder), not from here.
   static createForMap(
     world: RAPIER.World,
     layout: MapLayout,
@@ -123,27 +114,17 @@ export class PlayfieldColliderFactory {
     layout: MapLayout,
     colliderMap: Map<number, string>,
   ): void {
-    // Smooth analytic floor (tilted cuboid) replacing the bumpy GLB trimesh
-    // (Mesh_0, excluded in PlayfieldTrimeshBuilder). A box primitive has no
-    // facets → the ball glides without snagging on the trimesh's internal
-    // edges (Rapier "ghost collisions") that used to slow it down.
+    // Smooth analytic floor replaces the bumpy GLB trimesh (Mesh_0, excluded in
+    // PlayfieldTrimeshBuilder): a box has no facets, so the ball glides without
+    // snagging on the trimesh's internal edges (Rapier "ghost collisions").
     PlayfieldColliderFactory.createPlayfieldFloor(world);
     PlayfieldColliderFactory.createBumpers(world, layout, colliderMap);
     PlayfieldColliderFactory.createSensors(world, layout, colliderMap);
-    // Analytic floor ENABLED: the GLB playfield is split into 2 trimeshes
-    // with a seam at Z≈-0.286 right in the lane (+ a ~3mm lip on Circle.001).
-    // The smooth strip shadows the seam → reliable launch.
+    // Analytic lane floor shadows the GLB seam (2 trimeshes meeting at Z≈-0.286
+    // + ~3mm lip on Circle.001) that otherwise deviates the climbing ball.
     PlayfieldColliderFactory.createShooterLane(world, layout, { includeFloor: true });
   }
 
-  /**
-   * Analytic shooter lane: walls + guide (+ optional floor).
-   * When the GLB floor is multi-mesh, the analytic floor is REQUIRED: the
-   * GLB playfield is split into 2 trimeshes (Mesh_1 / Circle.001) with a
-   * seam + ~3mm lip at Z≈-0.286 right in the lane → the climbing ball
-   * deviated. The smooth strip (createShooterLaneFloor) shadows the seam.
-   * includeFloor: true.
-   */
   static createShooterLane(
     world: RAPIER.World,
     layout: MapLayout,

--- a/packages/game-engine/src/infrastructure/PlayfieldTrimeshBuilder.ts
+++ b/packages/game-engine/src/infrastructure/PlayfieldTrimeshBuilder.ts
@@ -24,8 +24,6 @@ import {
   reverseWoundIndices,
 } from './PlayfieldTrimeshRules';
 
-// Per-mesh material tuning (= manifest.elements). Passed raw to avoid
-// coupling game-engine to shared-types.
 export type MeshElements = Record<string, Record<string, number | string>>;
 
 function ancestryNames(obj: THREE.Object3D): string[] {
@@ -49,9 +47,7 @@ const COLLISION_SOLIDS = new Set([
 ]);
 
 const COLLISION_ANALYTIC = new Set([
-  // Old convention (single node split geometrically)
   'flipper', 'flipper_buttons', 'flipper_left_split', 'flipper_right_split',
-  // New convention (named sub-models in the GLB)
   'flipper-left', 'flipper-right', 'flipper_left', 'flipper_right',
   'pop_bumper', 'pop_bumper_left', 'pop_bumper_right',
 ]);
@@ -84,18 +80,11 @@ const TRIMESH_DEDICATED = new Set([
   ...TRIMESH_MISC,
 ]);
 
-/**
- * Scene-root meshes (outside the known GLB hierarchy) that must receive a
- * trimesh collider. Typically small guide plates added to smooth a wall
- * where the ball used to get stuck.
- * Normalized names (lowercase, spaces → underscores).
- */
 const STANDALONE_WALL_MESHES = new Set([
   'mesh1.0',   // guide plate smoothing the upper-left wall
   'fix-start', // launch guide: smooths the shooter lane wall at launch
 ]);
 
-// Switch sensors: single source in GltfNodeNames (shared with rendering).
 const HIDDEN_NODES = new Set(SWITCH_SENSOR_NODES);
 
 const EXCLUDED_NODES = new Set([
@@ -119,19 +108,16 @@ const PINBALLMAP_TRIMESH_FRICTION = 0.12;
  */
 const RAIL_SUBMESH_MIN_PHYS_DIM = 0.025; // 25 mm
 
-// Pinballmap meshes that must bounce hard ("bump" surfaces).
-// Normalized names: lowercase, spaces → underscores (dashes stay).
 const PINBALLMAP_HIGH_BOUNCE = new Set([
   'bump-right',
   'bump-left',
 ]);
-// Moderate restitution: the BumpHit sensor provides the main active impulse.
+// Only moderate restitution: the BumpHit sensor provides the main impulse.
 const PINBALLMAP_HIGH_BOUNCE_RESTITUTION = 0.40;
 const PINBALLMAP_HIGH_BOUNCE_FRICTION    = 0.05;
 
-// Full-playfield molded walls: single-sided trimesh (doubleSided=true would
-// create ghost faces that eject the ball through the wall). Normals point
-// toward the playfield interior (verified in Blender).
+// Single-sided trimesh: doubleSided would create ghost faces that eject the
+// ball through the wall. Normals point to the interior (verified in Blender).
 const PINBALLMAP_SINGLE_SIDED_WALL = 'mesh_1';
 
 const PLASTIC_GROUPS = new Set([
@@ -142,10 +128,6 @@ function meshMatchesSet(mesh: THREE.Mesh, names: Set<string>): boolean {
   return ancestryMatchesSet(ancestryNames(mesh), names);
 }
 
-/**
- * Skip decision for a mesh, from its ancestry name list (self → parents)
- * and the collOnly flag.
- */
 export function isSkipped(ancestryNames: string[], collOnly: boolean): boolean {
   const selfNorm = normalizeGltfName(ancestryNames[0] ?? '');
 
@@ -180,14 +162,6 @@ function isSkippedMesh(node: THREE.Object3D, collOnly: boolean): boolean {
   return isSkipped(ancestryNames(node), collOnly);
 }
 
-/**
- * Classifies a Pinballmap mesh (trimesh routing) from its ancestry name list
- * (self → parents) and its AABB dimensions.
- *
- * Guard order is load-bearing:
- * not-gameplay / flipper / analytic / non-physical-floor → 'skip';
- * then bump (tag = self name with '-'→'_'), rail (dimension filter), wall.
- */
 export type PinballmapMeshClass =
   | { kind: 'skip' }
   | { kind: 'bump'; tag: string; restitution: number; friction: number; doubleSided: boolean }
@@ -198,6 +172,7 @@ export function classifyPinballmapMesh(
   ancestry: string[],
   aabbDims: [number, number, number] | null,
 ): PinballmapMeshClass {
+  // Guard order is load-bearing: skip guards before bump/rail/wall routing.
   if (!isPinballmapGameplayMeshName(ancestry)) return { kind: 'skip' };
   if (isFlipperGltfMeshName(ancestry)) return { kind: 'skip' };
   if (ancestryMatchesSet(ancestry, COLLISION_ANALYTIC)) return { kind: 'skip' };
@@ -283,16 +258,6 @@ function laplacianSmooth(
 }
 
 export class PlayfieldTrimeshBuilder {
-  /**
-   * Role-driven build (conventioned GLB). Each mesh is classified by its
-   * role (MeshRoleResolver, via the hierarchy):
-   *  - wall_ / lane_ → solid trimesh (material from elements[name])
-   *  - floor_        → trimesh, UNLESS elements.physics === 'analytic'
-   *  - flipper_/bumper_/slingshot_/target_/sensor_/vis_ → ignored here
-   *    (handled analytically by PlayfieldColliderFactory, or no physics).
-   * Meshes sharing a conventioned name (e.g. wall_top = Mesh_2/3/4) are
-   * merged into a single collider.
-   */
   static buildRoleDriven(
     playfieldRoot: THREE.Object3D,
     world: RAPIER.World,
@@ -368,11 +333,8 @@ export class PlayfieldTrimeshBuilder {
   ): void {
     playfieldRoot.traverse((child) => {
       if (!(child instanceof THREE.Mesh)) return;
-      // Fast skip before geometry extraction (guards that need no AABB).
       if (!isPinballmapGameplayMesh(child)) return;
 
-      // The AABB is only needed for the rail dimension filter; extract world
-      // geometry once and reuse it for the collider.
       const geo = extractWorldGeometry(child);
       geo.computeBoundingBox();
       const bb = geo.boundingBox;
@@ -384,14 +346,12 @@ export class PlayfieldTrimeshBuilder {
       if (cls.kind === 'skip') return;
 
       if (cls.kind === 'rail') {
-        // Trimesh only (see createRailColliders). Reuses the extracted geometry.
         PlayfieldTrimeshBuilder.createRailColliders(world, child, cls.restitution, cls.friction, geo);
         return;
       }
 
-      // "bump" surfaces: the trimesh IS both the bounce surface and the
-      // detection surface. Enable COLLISION_EVENTS + register in colliderMap.
-      // Walls: plain trimesh, doubleSided except Mesh_1 (single-sided).
+      // 'bump' surfaces are both the bounce and detection surface: register in
+      // colliderMap with COLLISION_EVENTS so BumpHit can fire.
       const col = PlayfieldTrimeshBuilder.createTrimeshCollider(
         world,
         [geo],
@@ -407,12 +367,6 @@ export class PlayfieldTrimeshBuilder {
     });
   }
 
-  /**
-   * Trimesh colliders for the standalone meshes in STANDALONE_WALL_MESHES
-   * (scene-root nodes outside the Pinballmap hierarchy).
-   * Double-sided + no smoothing: these meshes are already thin and planar,
-   * Laplacian smoothing would deform them.
-   */
   private static buildStandaloneWalls(playfieldRoot: THREE.Object3D, world: RAPIER.World): void {
     playfieldRoot.traverse((child) => {
       if (!(child instanceof THREE.Mesh)) return;

--- a/packages/game-engine/src/infrastructure/PlayfieldTrimeshRules.ts
+++ b/packages/game-engine/src/infrastructure/PlayfieldTrimeshRules.ts
@@ -1,11 +1,6 @@
 import { canonicalGltfName, normalizeGltfName } from './GltfNodeNames';
 import type { MeshElements } from './PlayfieldTrimeshBuilder';
 
-/**
- * True if any ancestor name (self included, most specific to root) belongs
- * to `names`, comparing both the normalized form and the canonical form
- * (vis_/coll_/pf_ prefixes stripped).
- */
 export function ancestryMatchesSet(ancestryNames: string[], names: Set<string>): boolean {
   for (const raw of ancestryNames) {
     const n = normalizeGltfName(raw);
@@ -26,11 +21,6 @@ function elemNum(v: number | string | undefined, def: number): number {
   return typeof v === 'number' ? v : def;
 }
 
-/**
- * Resolves a trimesh group's material params from `elements[key]`, applying
- * defaults. `role` decides the smoothing default (floor smoothed, wall/lane
- * raw).
- */
 export function resolveMaterialParams(
   el: MeshElements[string] | undefined,
   role: string,
@@ -50,13 +40,6 @@ export interface GeometryTuple {
   index: ArrayLike<number> | null;
 }
 
-/**
- * Laplacian smoothing over interleaved xyz positions of an already-welded
- * geometry. Each vertex is pulled toward the barycenter of its neighbors
- * (triangle edges) by `factor`, over `iterations` passes.
- * Returns a new Float32Array; the input is not mutated. Isolated vertices
- * (count 0) are left unchanged.
- */
 export function laplacianSmoothPositions(
   positions: Float32Array,
   index: ArrayLike<number>,
@@ -98,11 +81,6 @@ export function laplacianSmoothPositions(
   return out;
 }
 
-/**
- * Index of a double-sided geometry: concatenates the original index with a
- * reverse-wound copy (back-faces). For each triangle (i, i+1, i+2) the back
- * face is (i+2, i+1, i). Returns a new array; the input is not mutated.
- */
 export function reverseWoundIndices(index: ArrayLike<number>): number[] {
   const n = index.length;
   const doubled = new Array<number>(n * 2);
@@ -115,11 +93,6 @@ export function reverseWoundIndices(index: ArrayLike<number>): number[] {
   return doubled;
 }
 
-/**
- * Merges several geometries (interleaved xyz positions + optional index) into
- * a single verts/indices pair, offsetting indices per group. Without an
- * index, vertices are indexed sequentially.
- */
 export function mergeGeometryTuples(geos: GeometryTuple[]): { verts: number[]; indices: number[] } {
   const verts: number[] = [];
   const indices: number[] = [];

--- a/packages/game-engine/src/infrastructure/PopZoneCollisionHandler.ts
+++ b/packages/game-engine/src/infrastructure/PopZoneCollisionHandler.ts
@@ -2,13 +2,6 @@ import type { GameEventListener } from '../domain/GameEvents';
 import { SCORE_POP_ZONE } from '../domain/ScoringConstants';
 import type { CollisionHandler } from './CollisionHandler';
 
-/**
- * Handles collisions with pop zones (role: 'pop_zone_<id>').
- *
- * Pop zones are passive scoring areas (no physics impulse).
- * The full role string is forwarded in the event so the map can
- * distinguish between multiple distinct zones.
- */
 export class PopZoneCollisionHandler implements CollisionHandler {
   constructor(
     private readonly emit: GameEventListener,

--- a/packages/game-engine/src/infrastructure/PortalCollisionHandler.ts
+++ b/packages/game-engine/src/infrastructure/PortalCollisionHandler.ts
@@ -2,34 +2,20 @@ import type { CollisionHandler } from './CollisionHandler';
 import type { GameEventListener } from '../domain/GameEvents';
 import { RETURN_PORTAL_ENTER_SCORE, PORTAL_ENTER_SCORE } from '../domain/Ball';
 
-/**
- * Handles the collision with the portal entrance (role: 'portal_enter').
- *
- * Two-flag state machine:
- *   - portalOpen      : the portal is physically open (activated by the map)
- *   - portalTriggered : already crossed during this opening (prevents double-fire)
- *
- * The emitted event depends on the current world:
- *   - normal world    → PORTAL_ENTER (transition to alternate world)
- *   - alternate world → RETURN_PORTAL_ENTER (return to normal world)
- */
 export class PortalCollisionHandler implements CollisionHandler {
   private portalOpen = false;
   private portalTriggered = false;
 
   constructor(
     private readonly emit: GameEventListener,
-    /** Injected getter to read alternate-world state without direct coupling. */
     private readonly getAlternateWorldActive: () => boolean,
   ) {}
 
-  /** Opens or closes the portal. Closing also resets the triggered flag. */
   setPortalOpen(open: boolean): void {
     this.portalOpen = open;
     if (!open) this.portalTriggered = false;
   }
 
-  /** Resets the triggered flag (e.g. after a full world cycle). */
   resetPortalTrigger(): void {
     this.portalTriggered = false;
   }
@@ -40,7 +26,6 @@ export class PortalCollisionHandler implements CollisionHandler {
 
   handle(role: string, gameState: string, started: boolean): void {
     if (!started || gameState !== 'playing') return;
-    // Ignore if the portal is closed or has already been crossed this opening.
     if (!this.portalOpen || this.portalTriggered) return;
 
     this.portalTriggered = true;

--- a/packages/game-engine/src/infrastructure/QualityGovernor.ts
+++ b/packages/game-engine/src/infrastructure/QualityGovernor.ts
@@ -1,7 +1,3 @@
-// Adaptive quality governor: monitors frame time and steps tiers down/up
-// (pixelRatio + trail/spores flags) with hysteresis.
-// Cabinet diagnostics: console log on every tier change.
-
 export interface QualityTier {
   dpr: number;
   trailMax: number;
@@ -13,8 +9,6 @@ const TIERS: QualityTier[] = [
   { dpr: 1.25, trailMax: 24, sporesOn: true },
   { dpr: 1.0, trailMax: 24, sporesOn: true },
   { dpr: 1.0, trailMax: 12, sporesOn: false },
-  // Low-resolution tiers: under heavy load the governor drops down to
-  // dpr 0.7 — nearly indistinguishable on the cabinet screen, big fill-rate win.
   { dpr: 0.85, trailMax: 12, sporesOn: false },
   { dpr: 0.7, trailMax: 8, sporesOn: false },
 ];
@@ -39,7 +33,6 @@ export class QualityGovernor {
     return TIERS[this.index];
   }
 
-  /** Call every frame with the frame time in ms. */
   frame(ms: number): void {
     this.clock += ms;
     if (this.samples.length < WINDOW) this.samples.push(ms);

--- a/packages/game-engine/src/infrastructure/RocketRampCollisionHandler.ts
+++ b/packages/game-engine/src/infrastructure/RocketRampCollisionHandler.ts
@@ -2,12 +2,7 @@ import type { GameEventListener } from '../domain/GameEvents';
 import { SCORE_RAMP } from '../domain/ScoringConstants';
 import type { CollisionHandler } from './CollisionHandler';
 
-/**
- * Handles the collision with the rocket ramp (role: 'rocket_ramp').
- *
- * Emits RAMP_HIT on each contact start. No cooldown is needed because
- * the ramp geometry generates only one 'started' event per pass.
- */
+// No cooldown needed: the ramp geometry generates one 'started' event per pass.
 export class RocketRampCollisionHandler implements CollisionHandler {
   constructor(
     private readonly emit: GameEventListener,

--- a/packages/game-engine/src/infrastructure/ScoopCollisionHandler.ts
+++ b/packages/game-engine/src/infrastructure/ScoopCollisionHandler.ts
@@ -2,14 +2,8 @@ import type { GameEventListener } from '../domain/GameEvents';
 import { SCORE_SCOOP } from '../domain/ScoringConstants';
 import type { CollisionHandler } from './CollisionHandler';
 
-/**
- * Handles the ball entering the scoop / saucer hole (role: 'scoop').
- *
- * Passive detection only: emits SCOOP_ENTER once on contact start. The capture
- * sequence (hold the ball, grant rewards + timed multiplier, then eject) is
- * owned by the map module, which reacts to SCOOP_ENTER and drives the ball via
- * update(dt). This handler only scores and notifies.
- */
+// Only emits SCOOP_ENTER; the capture sequence (hold, reward, eject) is owned
+// by the map module reacting to that event.
 export class ScoopCollisionHandler implements CollisionHandler {
   constructor(
     private readonly emit: GameEventListener,

--- a/packages/game-engine/src/infrastructure/ScreenShake.ts
+++ b/packages/game-engine/src/infrastructure/ScreenShake.ts
@@ -1,8 +1,3 @@
-// Screen shake — energy stacked by events, exponential decay.
-// World-unit offset applied to the camera (transform-only, no new light).
-// Direction is smoothed (interpolated between targets) to avoid the
-// high-frequency noise of a per-frame Math.random.
-
 const MAX_AMPLITUDE = 0.004 // world units
 const DECAY_PER_S = 6
 const RETARGET_MIN = 0.03
@@ -26,7 +21,6 @@ export class ScreenShake {
   update(dt: number): ShakeOffset {
     this.energy = Math.max(0, this.energy - this.energy * DECAY_PER_S * dt)
 
-    // Retarget direction occasionally (not every frame).
     this.retargetT -= dt
     if (this.retargetT <= 0) {
       const a = Math.random() * Math.PI * 2
@@ -35,7 +29,6 @@ export class ScreenShake {
       this.retargetT = RETARGET_MIN + Math.random() * RETARGET_VAR
     }
 
-    // Smooth toward the target.
     const k = Math.min(1, dt * 30)
     this.cur.x += (this.target.x - this.cur.x) * k
     this.cur.y += (this.target.y - this.cur.y) * k

--- a/packages/game-engine/src/infrastructure/ShakeBasis.ts
+++ b/packages/game-engine/src/infrastructure/ShakeBasis.ts
@@ -1,13 +1,5 @@
 import * as THREE from 'three';
 
-/**
- * Snapshot of the camera + playfield-root transforms taken before a tremor,
- * restored once the shake ends. Shared by the Stranger Things
- * UpsideDownTransition and the Zelda ZeldaTransition.
- *
- * No map import here (game-engine never imports a map): the THREE objects are
- * injected by the caller. `capture`/`restore` are null-safe.
- */
 export class ShakeBasis {
   readonly camPos = new THREE.Vector3();
   readonly rootPos = new THREE.Vector3();

--- a/packages/game-engine/src/infrastructure/ShooterLaneGate.ts
+++ b/packages/game-engine/src/infrastructure/ShooterLaneGate.ts
@@ -4,8 +4,6 @@ import { surfaceYAtZ } from '../domain/PlayfieldGeometry';
 
 type LaneConfig = MapLayout['shooterLane'];
 
-// Lane-closing wall: placed just right of the lane's left edge, thin (the goal
-// is to plug the opening, not to bounce the ball).
 const GATE_X_INSET = 0.005;
 const GATE_THICKNESS = 0.01;
 

--- a/packages/game-engine/src/infrastructure/SkinnedModelFit.ts
+++ b/packages/game-engine/src/infrastructure/SkinnedModelFit.ts
@@ -81,9 +81,8 @@ function measureSkinnedVertexBounds(
     const hasSkin = obj.geometry.attributes.skinIndex && obj.geometry.attributes.skinWeight;
     if (!pos) return;
     obj.skeleton.update();
-    // Decimate: an axis-aligned bbox needs only a few hundred samples. A full
-    // per-vertex skin pass (applyBoneTransform + 2 matrix transforms each) on a
-    // 10k+ vert model is a needless load-time CPU spike, ×2 boss models.
+    // Decimate: a bbox needs only a few hundred samples; a full per-vertex skin
+    // pass on a 10k+ vert model is a needless load-time CPU spike.
     const step = Math.max(1, Math.floor(pos.count / 800));
     for (let i = 0; i < pos.count; i += step) {
       _v.fromBufferAttribute(pos, i);

--- a/packages/game-engine/src/infrastructure/SlingshotCollisionHandler.ts
+++ b/packages/game-engine/src/infrastructure/SlingshotCollisionHandler.ts
@@ -2,12 +2,8 @@ import type { GameEventListener } from '../domain/GameEvents';
 import { SCORE_SLINGSHOT } from '../domain/ScoringConstants';
 import type { CollisionHandler } from './CollisionHandler';
 
-/**
- * Handles collisions with slingshots (roles: 'slingshot_left', 'slingshot_right').
- *
- * Emits SLINGSHOT_HIT with the side that was hit. The rebound impulse is applied
- * directly by Rapier via the collider; this handler only scores and notifies.
- */
+// The rebound impulse is applied directly by Rapier via the collider; this
+// handler only scores and notifies.
 export class SlingshotCollisionHandler implements CollisionHandler {
   constructor(
     private readonly emit: GameEventListener,

--- a/packages/game-engine/src/infrastructure/SporeField.ts
+++ b/packages/game-engine/src/infrastructure/SporeField.ts
@@ -1,11 +1,3 @@
-/**
- * Pure spore-particle field shared by map atmosphere systems (Stranger Things
- * Upside Down). Owns particle seeding (anchor/base/angle/radius/speed/drift from
- * index) and per-frame position math (angle/radius/lift/wander -> x,y,z). NO
- * Three/BufferGeometry dependency — the map class builds the THREE.Points geometry
- * by reading positions written here.
- */
-
 export type SporeParticle = {
   anchorX: number;
   anchorZ: number;
@@ -20,7 +12,6 @@ function lerp(a: number, b: number, t: number): number {
   return a + (b - a) * t;
 }
 
-/** Seed a single particle from its index and the total count. */
 export function seedSpore(i: number, count: number): SporeParticle {
   return {
     anchorX: lerp(-0.22, 0.22, (i * 0.37) % 1),
@@ -33,17 +24,12 @@ export function seedSpore(i: number, count: number): SporeParticle {
   };
 }
 
-/** Seed `count` particles. */
 export function seedSpores(count: number): SporeParticle[] {
   const spores: SporeParticle[] = [];
   for (let i = 0; i < count; i++) spores.push(seedSpore(i, count));
   return spores;
 }
 
-/**
- * Advance one particle's angle by `speed * dt` (mutates `spore.angle`) and return
- * its world position for the given `pulseT`.
- */
 export function stepSpore(
   spore: SporeParticle,
   dt: number,
@@ -60,10 +46,6 @@ export function stepSpore(
   };
 }
 
-/**
- * Advance all spores and write their positions into the flat `out` array
- * (out[i*3], out[i*3+1], out[i*3+2]). Returns nothing — caller flags the geometry.
- */
 export function stepSporeField(
   spores: SporeParticle[],
   dt: number,

--- a/packages/game-engine/src/infrastructure/TransitionTimeline.ts
+++ b/packages/game-engine/src/infrastructure/TransitionTimeline.ts
@@ -1,45 +1,24 @@
 import { easeIn, easeOut, strobeOn } from './CinematicEasing';
 
-/**
- * Phase clock for world-transition cinematics (Upside Down / Sacred Realm).
- * Owns {phase, elapsed, strobeT} and the regression-prone scalar maths (strobe
- * gating, blackout/reveal/restore eases, shade + billboard opacity mixes) with
- * NO Three dependency. Drives the same machine for the Stranger Things
- * UpsideDownTransition (blackout → reveal → hold → restore → tremor) and the
- * Zelda ZeldaTransition (blackout → restore → tremor — reveal/hold skipped).
- *
- * Map-specific IO (camera/billboard/ball, which strobe call to make) lives in
- * the renderer: it reads the descriptor scalars/flags and chooses the Three
- * calls. The tremor offset maths live in `tremorOffset`.
- */
-
 export type TransitionPhase = 'idle' | 'blackout' | 'reveal' | 'hold' | 'restore' | 'tremor';
 
 export type TransitionTimelineConfig = {
   blackout: number;
-  /** Reveal + hold durations (Stranger Things). Set both to 0 to skip them (Zelda). */
   reveal: number;
   hold: number;
   restore: number;
   tremor: number;
   strobeHz: number;
-  /** Whether the reveal/hold phases run. false → blackout goes straight to restore (Zelda). */
   hasReveal: boolean;
 };
 
 export type TransitionDescriptor = {
   phase: TransitionPhase;
-  /** strobeOn(strobeT, strobeHz). */
   on: boolean;
-  /** blackout phase: easeOut(min(1, elapsed/blackout)). */
   blackoutMix: number;
-  /** reveal phase: clamped progress t = min(1, elapsed/reveal). */
   revealT: number;
-  /** restore phase: darkMix = 1 - easeIn(min(1, elapsed/restore)). */
   darkMix: number;
-  /** true once the active phase is blackout/reveal/hold/restore (drives billboard sync). */
   active: boolean;
-  /** transition flags (fired once on the frame they occur). */
   enteredReveal: boolean;
   enteredHold: boolean;
   enteredRestore: boolean;
@@ -62,7 +41,6 @@ export class TransitionTimeline {
     return this.elapsed;
   }
 
-  /** Enter blackout from idle. Returns true if it transitioned. */
   begin(): boolean {
     if (this.phase !== 'idle') return false;
     this.phase = 'blackout';
@@ -132,7 +110,6 @@ export class TransitionTimeline {
       return { ...base, phase: 'restore', on, darkMix };
     }
 
-    // tremor
     if (this.elapsed >= this.config.tremor) {
       return { ...base, phase: 'tremor', active: false, finished: true };
     }
@@ -156,13 +133,6 @@ export class TransitionTimeline {
   }
 }
 
-/**
- * Camera/playfield tremor offset for world transitions.
- *
- * Shared by UpsideDownTransition (rampDuration 0.45, amp 0.0032) and
- * ZeldaTransition (rampDuration 0.3, amp 0.003). Caller adds these offsets
- * to the captured base camera position / playfield rotation.
- */
 export type TremorOffset = {
   camX: number;
   camY: number;

--- a/packages/game-engine/src/infrastructure/WalkBossPulse.ts
+++ b/packages/game-engine/src/infrastructure/WalkBossPulse.ts
@@ -4,29 +4,17 @@ const PULSE_AMP = 0.14;
 const PULSE_BASE = 0.82;
 const HIT_BOOST = 1.5;
 
-/** Duration (seconds) of the hit flash used by the walk-boss actors. */
 export const WALK_BOSS_HIT_FLASH_DURATION = HIT_FLASH_DURATION;
 
-/** Hit flash intensity applied on a normal hit. */
 export const WALK_BOSS_HIT_FLASH = 0.18;
 
-/** Hit flash intensity applied on the victory/dead finisher. */
 export const WALK_BOSS_FINISHER_FLASH = 0.28;
 
-/**
- * Glow pulse multiplier shared by the walk-boss target visuals
- * (Vecna / Dark Link): pulse = (0.82 + sin(t*2.2)*0.14) * (hitFlash>0 ? 1.5 : 1).
- * NB: distinct from BossActorAnimator's static-boss pulse (2.5 / 0.12 / 1.4).
- */
 export function walkBossPulse(pulseT: number, hitFlash: number): number {
   const hitBoost = hitFlash > 0 ? HIT_BOOST : 1;
   return (PULSE_BASE + Math.sin(pulseT * PULSE_SPEED) * PULSE_AMP) * hitBoost;
 }
 
-/**
- * Anchor scale during a hit flash: 1 + (hitFlash/0.18)*scaleBoost.
- * scaleBoost is per-boss (Vecna 0.12, Dark Link 0.10).
- */
 export function walkBossScale(hitFlash: number, scaleBoost: number): number {
   return 1 + (hitFlash / HIT_FLASH_DURATION) * scaleBoost;
 }

--- a/packages/game-engine/src/infrastructure/WalkBossTargetActor.ts
+++ b/packages/game-engine/src/infrastructure/WalkBossTargetActor.ts
@@ -19,14 +19,11 @@ import {
 
 type AnimState = 'walk' | 'fight' | 'hit' | 'finisher';
 
-/** Mixer + actions resolved by the owning map from its own GLTF clips. */
 export type WalkBossActions = {
   mixer: THREE.AnimationMixer;
   walkAction: THREE.AnimationAction | null;
-  /** Idle/settled pose action. May reuse the walk clip (Vecna). */
   fightIdleAction: THREE.AnimationAction | null;
   hitAction: THREE.AnimationAction | null;
-  /** Victory (ST) or dead (Zelda) finisher. */
   finisherAction: THREE.AnimationAction | null;
 };
 
@@ -48,15 +45,9 @@ export type WalkBossGlowConfig = {
   intensityBase: number;
 };
 
-/**
- * How the fight idle pose is held once the walk-in settles.
- *  - 'reuse-walk-frozen' (Vecna): play once + clamp + pause on a frozen pose.
- *  - 'loop-idle' (Dark Link): loop the idle clip forever.
- */
 export type WalkBossFightIdleMode = 'reuse-walk-frozen' | 'loop-idle';
 
 export type WalkBossTargetActorConfig = {
-  /** Tag for load/clip warn+error logging, e.g. "Vecna". */
   logTag: string;
   modelUrl: string;
   spawn: WalkPathPoint;
@@ -64,7 +55,6 @@ export type WalkBossTargetActorConfig = {
   footLift: number;
   modelHeight: number;
   floorClearance: number;
-  /** Optional fixed bind height (Vecna uses it; Dark Link omits). */
   bindHeight?: number;
   fitFrames: number;
   yaw: number;
@@ -73,7 +63,6 @@ export type WalkBossTargetActorConfig = {
   walkFadeOut: number;
   emissive: WalkBossEmissiveConfig;
   glow: WalkBossGlowConfig;
-  /** Anchor scale boost at peak hit flash (Vecna 0.12, Dark Link 0.10). */
   hitScaleBoost: number;
   fightIdleMode: WalkBossFightIdleMode;
   resolveClips: WalkBossClipResolver;
@@ -81,13 +70,6 @@ export type WalkBossTargetActorConfig = {
 
 const _facingPos = new THREE.Vector3();
 
-/**
- * Composed lifecycle for the "walk-in target boss" actors (Vecna / Dark Link):
- * spawn → walk along the tilted playfield → settle facing the camera → fight
- * idle, with hit flashes and a victory/dead finisher. The only per-map
- * variation is injected via config (constants, emissive/glow, fight-idle mode,
- * scale boost) and the resolveClips function (raw vs subclipped GLTF clips).
- */
 export class WalkBossTargetActor {
   private anchor: THREE.Group | null = null;
   private camera: THREE.Camera | null = null;
@@ -281,7 +263,6 @@ export class WalkBossTargetActor {
     this.hitAction.crossFadeFrom(this.fightIdleAction, 0.08, true).play();
   }
 
-  /** Play the finisher (victory for ST, dead for Zelda). */
   playFinisher(): void {
     if (!this.mixer || !this.finisherAction) {
       this.enterFightIdle();

--- a/packages/game-engine/src/infrastructure/WalkFightPhaseMachine.ts
+++ b/packages/game-engine/src/infrastructure/WalkFightPhaseMachine.ts
@@ -1,37 +1,17 @@
-/**
- * Phase state-machine for "shape A" boss reveals (walk → settle → fight →
- * victory). Owns {phase, elapsed} and the sequencing/timer logic, with NO Three
- * dependency. Map-specific scalars (fight flicker shade/flashMix, victory
- * duration, target hit count) are passed in via config so the same machine
- * drives Vecna (Stranger Things) and Dark Link (Zelda).
- *
- * Walk/settle exit is gated by the renderer's visual (path completion / settle
- * completion booleans) because that timing lives in Three-side animation; the
- * machine consumes those booleans but owns the phase transitions.
- */
-
 export type WalkFightPhase = 'idle' | 'walk' | 'settle' | 'fight' | 'victory';
 
 export type WalkFightConfig = {
-  /** Victory phase duration in seconds (Vecna/DarkLink: 0.65). */
   victoryDuration: number;
-  /** Constant shade passed to applyFightFlicker during the fight phase. */
   fightFlickerShade: number;
-  /** Constant flashMix passed to applyFightFlicker during the fight phase. */
   fightFlickerFlashMix: number;
-  /** Hit count required to win (from the boss definition). */
   targetHits: number;
 };
 
-/** Per-frame inputs sampled from the renderer's visual (Three-side timing). */
 export type WalkFightTickInput = {
-  /** vecnaVisual.isWalkPathComplete() — gates walk → settle. */
   walkPathComplete: boolean;
-  /** result of vecnaVisual.updateSettle(dt) — gates settle → fight. */
   settleComplete: boolean;
 };
 
-/** What the strobe should do this frame. The renderer translates this. */
 export type WalkFightStrobeOp =
   | { kind: 'stop' }
   | { kind: 'fightFlicker'; shade: number; flashMix: number }
@@ -39,15 +19,10 @@ export type WalkFightStrobeOp =
 
 export type WalkFightDescriptor = {
   phase: WalkFightPhase;
-  /** Whether the machine just transitioned into walk this tick. */
   enteredWalk: boolean;
-  /** Whether the machine just transitioned into settle this tick. */
   enteredSettle: boolean;
-  /** Whether the machine just transitioned into fight this tick. */
   enteredFight: boolean;
-  /** Whether the victory phase just finished this tick (→ hide boss). */
   finishedVictory: boolean;
-  /** The strobe operation to apply this frame. */
   strobe: WalkFightStrobeOp;
 };
 
@@ -65,12 +40,10 @@ export class WalkFightPhaseMachine {
     return this.elapsed;
   }
 
-  /** Gameplay is frozen during the cinematic walk/settle phases. */
   isGameplayFrozen(): boolean {
     return this.phase === 'walk' || this.phase === 'settle';
   }
 
-  /** BOSS_REVEAL received: enter walk (only from idle). */
   onReveal(): boolean {
     if (this.phase !== 'idle') return false;
     this.phase = 'walk';
@@ -78,11 +51,6 @@ export class WalkFightPhaseMachine {
     return true;
   }
 
-  /**
-   * BOSS_TARGET_HIT received while fighting. Returns true if this hit reaches
-   * the victory threshold (renderer then plays victory). Returns false if the
-   * hit lands outside the fight phase or below the threshold.
-   */
   onHit(hitCount: number): { accepted: boolean; victory: boolean } {
     if (this.phase !== 'fight') return { accepted: false, victory: false };
     if (hitCount >= this.config.targetHits) {
@@ -97,7 +65,6 @@ export class WalkFightPhaseMachine {
     this.elapsed = 0;
   }
 
-  /** endFight()/reset: back to idle. */
   reset(): void {
     this.phase = 'idle';
     this.elapsed = 0;
@@ -149,7 +116,6 @@ export class WalkFightPhaseMachine {
       };
     }
 
-    // victory
     const mix = Math.max(0, 1 - this.elapsed / this.config.victoryDuration);
     const finished = this.elapsed >= this.config.victoryDuration;
     return {

--- a/packages/game-engine/src/infrastructure/WalkPathProgress.ts
+++ b/packages/game-engine/src/infrastructure/WalkPathProgress.ts
@@ -21,12 +21,6 @@ function lerp(a: number, b: number, t: number): number {
   return a + (b - a) * t;
 }
 
-/**
- * Boss walk progression: spawn → target along the tilted playfield.
- *  - progressAt(elapsed) = min(1, elapsed / duration)
- *  - positionAt(t) lerps x/z spawn→target, y = surfaceYAtZ(z) + footLift,
- *    t clamped to [0, 1].
- */
 export class WalkPathProgress {
   constructor(
     private readonly spawn: WalkPathPoint,
@@ -47,10 +41,6 @@ export class WalkPathProgress {
   }
 }
 
-/**
- * Static boss placement on the tilted playfield: same formula as
- * WalkPathProgress.positionAt(1) — { x, y: surfaceYAtZ(z) + footLift, z }.
- */
 export function surfacePoint(
   target: WalkPathPoint,
   footLift: number,
@@ -59,10 +49,6 @@ export function surfacePoint(
   return { x: target.x, y: surfaceYAtZ(target.z) + footLift, z: target.z };
 }
 
-/**
- * Model yaw to face the camera (Y-axis billboard):
- * atan2(camX - anchorX, camZ - anchorZ) + yaw.
- */
 export function cameraFacingYaw(
   anchorPos: WalkPathPoint,
   camPos: WalkPathPoint,
@@ -73,10 +59,6 @@ export function cameraFacingYaw(
   return Math.atan2(dx, dz) + yaw;
 }
 
-/**
- * Model yaw to face the walk direction (spawn → target):
- * atan2(targetX - spawnX, targetZ - spawnZ) + yaw.
- */
 export function pathFacingYaw(
   spawn: WalkPathPoint,
   target: WalkPathPoint,

--- a/packages/game-engine/src/use-cases/BallFrameCorrections.ts
+++ b/packages/game-engine/src/use-cases/BallFrameCorrections.ts
@@ -9,12 +9,6 @@ export interface BallBodyState {
   angvel: Vec3;
 }
 
-/**
- * Locks the ball at the spawn while idle (including during plunger charge):
- * otherwise gravity/tilt makes it slide against the right wall (friction →
- * slower launch). Pure: the caller reads spawn from the layout and applies
- * translation/linvel/angvel to the body.
- */
 export function computeIdleSpawnLock(spawn: { x: number; y: number; z: number }): BallBodyState {
   const z = spawn.z;
   return {
@@ -24,16 +18,6 @@ export function computeIdleSpawnLock(spawn: { x: number; y: number; z: number })
   };
 }
 
-/**
- * Shooter lane lateral lock: during the climb (straight right part of the
- * lane, before the exit opening), X is pinned to the spawn line and lateral
- * velocity is cancelled → perfectly straight launch, independent of GLB
- * geometry. The ball is released once it reaches the exit zone
- * (Z <= lane.leftWallTopZ) so it enters the playfield naturally.
- *
- * Returns the state to apply while in the straight part, the 'close' signal
- * once past exitX (the caller closes the gate), or null when nothing to do.
- */
 export function computeLaneStraightLock(
   pos: Vec3,
   linvel: Vec3,
@@ -53,14 +37,8 @@ export function computeLaneStraightLock(
   return null;
 }
 
-/**
- * Speed clamp. Both rules read the SAME initial velocity (the second does not
- * see the result of the first):
- *   1. if total speed exceeds BALL_MAX_SPEED → scale x/y/z.
- *   2. if INITIAL y > 1.25 → overwrite with { x, y: 0.35, z } using the
- *      INITIAL x/z, fully replacing the result of step 1.
- * Returns the final linvel to apply, or null when no correction is needed.
- */
+// Both rules read the SAME initial velocity; the y > 1.25 rule fully replaces
+// (not composes with) the speed-scale result.
 export function computeSpeedClamp(vel: Vec3): Vec3 | null {
   let out: Vec3 | null = null;
   const speed = Math.sqrt(vel.x ** 2 + vel.y ** 2 + vel.z ** 2);

--- a/packages/game-engine/src/use-cases/BottomOutBall.ts
+++ b/packages/game-engine/src/use-cases/BottomOutBall.ts
@@ -9,26 +9,14 @@ export class BottomOutBall {
     private readonly emit: GameEventListener,
   ) {}
 
-  /**
-   * Re-arms the use-case for the next play episode.
-   *
-   * CONTRACT: the latch is set by `execute()` (sensor/geometric-zone debounce)
-   * and MUST be lifted when a new ball enters play, otherwise bottom-out stays
-   * dead for the whole session. Two callers cover this contract:
-   *  - the `BALL_LAUNCHED` path (normal relaunch),
-   *  - `noteRespawn()`, called on every physical ball respawn, including game
-   *    reset paths that never go through a launch — guarantees no path can
-   *    leave the latch stuck.
-   */
+  // The latch is set by execute() and MUST be lifted when a new ball enters
+  // play, or bottom-out stays dead for the whole session.
   resetLatch(): void {
     this.latched = false;
   }
 
-  /**
-   * Call whenever a new ball is (re)placed at the spawn, whatever the path
-   * (launch OR game reset). Auto re-arms the latch: safety net so bottom-out
-   * never dies because a reset path forgot an explicit `resetLatch()`.
-   */
+  // Call on every ball respawn (launch OR game reset): safety net so no reset
+  // path can leave the latch stuck.
   noteRespawn(): void {
     this.latched = false;
   }

--- a/packages/game-engine/src/use-cases/DetectBottomOut.ts
+++ b/packages/game-engine/src/use-cases/DetectBottomOut.ts
@@ -1,10 +1,9 @@
 import { isInBottomOutZone } from '../domain/PlayfieldGeometry';
 
 export class DetectBottomOut {
-  // Covers the full playfield width (up to WALL_RIGHT_X = 0.265). No shooter
-  // lane cutoff: the ball must still drain if it drifts to x > laneSepX before
-  // reaching z = BOTTOM_OUT_Z.
+  // Full playfield width, no shooter-lane cutoff: the ball must still drain if
+  // it drifts to x > laneSepX before reaching z = BOTTOM_OUT_Z.
   check(pos: { x: number; z: number }): boolean {
-    return isInBottomOutZone(pos.x, pos.z); // default rightX = WALL_RIGHT_X
+    return isInBottomOutZone(pos.x, pos.z);
   }
 }

--- a/packages/game-engine/src/use-cases/DetectFlipperHit.ts
+++ b/packages/game-engine/src/use-cases/DetectFlipperHit.ts
@@ -1,3 +1,1 @@
-// Kept for compatibility but no longer used. Flippers are now driven by a
-// Rapier revolute joint (dynamic body + motor).
 export {};

--- a/packages/game-engine/src/use-cases/DrainBall.ts
+++ b/packages/game-engine/src/use-cases/DrainBall.ts
@@ -9,21 +9,12 @@ export class DrainBall {
     private readonly emit: GameEventListener,
   ) {}
 
-  /**
-   * Re-arms the use-case. Call when a new ball enters play (`BALL_LAUNCHED`
-   * path), symmetric to `BottomOutBall.resetLatch`.
-   */
   resetLatch(): void {
     this.latched = false;
   }
 
-  /**
-   * Emits DRAIN and resets the ball to spawn. The visual delay is handled by
-   * the interface layer. Debounce latch: the drain sensor (Rapier) can fire
-   * `execute()` on 2 consecutive frames before the spawn reset takes effect →
-   * without this guard, double DRAIN / double life loss. The latch is lifted
-   * by `resetLatch()` when the ball is (re)launched.
-   */
+  // Debounce latch: the drain sensor can fire on 2 consecutive frames before
+  // the spawn reset takes effect; without this guard, double DRAIN / life loss.
   execute(): void {
     if (this.latched) return;
     this.latched = true;

--- a/packages/game-engine/src/use-cases/FlipperLaunchAssist.ts
+++ b/packages/game-engine/src/use-cases/FlipperLaunchAssist.ts
@@ -18,16 +18,6 @@ export interface FlipperLaunchAssistResult {
   linvel: Vec3;
 }
 
-/**
- * Flipper launch guarantee. Pure: no Rapier dependency — the caller reads
- * pos/vel from the body + derives angVel, applies the returned linvel and
- * triggers the flash. Returns null when no correction applies.
- *
- * Triggers when the ball is in the flipper zone AND the upswing angular
- * velocity exceeds FLIPPER_MIN_LAUNCH_ANGVEL AND vz is above
- * FLIPPER_MIN_LAUNCH_VZ: attenuate vx, clamp vz to FLIPPER_MIN_LAUNCH_VZ,
- * keep vy → guaranteed launch up the table.
- */
 export function computeFlipperLaunchAssist(
   input: FlipperLaunchAssistInput,
 ): FlipperLaunchAssistResult | null {

--- a/packages/game-engine/src/use-cases/SnapBallToSurface.ts
+++ b/packages/game-engine/src/use-cases/SnapBallToSurface.ts
@@ -10,23 +10,12 @@ import { ballCenterOnSurface } from '../domain/PlayfieldGeometry';
 type Vec3 = { x: number; y: number; z: number };
 
 export interface SurfaceSnapResult {
-  /** Position to rest the ball at (always present when the snap triggers). */
   translation: Vec3;
-  /** Corrected velocity — present only when an upward Y was cancelled. */
   linvel?: Vec3;
 }
 
-/**
- * Decides whether the ball must be snapped back onto the tilted surface.
- * Pure: no Rapier dependency — the caller reads pos/vel from the body and
- * applies the result. Returns null when no snap is needed.
- *
- * Rules:
- * - active only inside the playfield, outside the straight shooter lane;
- * - triggers when the ball lifts more than SURFACE_SNAP_THRESHOLD;
- * - cancels only POSITIVE Y velocity (lift-off) — negative Y is gravity
- *   bringing the ball back, never blocked. XZ untouched → game speed kept.
- */
+// Cancels only POSITIVE Y velocity (lift-off); negative Y is gravity bringing
+// the ball back and must never be blocked. XZ is untouched to keep game speed.
 export function computeSurfaceSnap(
   pos: Vec3,
   vel: Vec3,

--- a/packages/maps/backglass.ts
+++ b/packages/maps/backglass.ts
@@ -1,10 +1,8 @@
 import * as strangerthings from '@pinball/map-strangerthings/backglass'
 import * as zelda from '@pinball/map-zelda/backglass'
 
-// Registry backglass surface. Separate entrypoint from the core index: only
-// the backglass pulls this module (React + map art), never the playfield.
-// BackglassContent = ST reference shape (both maps expose the same
-// interface). TODO: extract an explicit shared interface.
+// TODO: extract an explicit shared BackglassContent interface (both maps
+// currently conform to the ST reference shape).
 export type BackglassContent = typeof strangerthings
 
 const BY_ID: Record<string, BackglassContent> = {
@@ -12,8 +10,6 @@ const BY_ID: Record<string, BackglassContent> = {
   zelda: zelda as unknown as BackglassContent,
 }
 
-// Resolves a map's backglass content by id (null = no dedicated backglass,
-// the app then shows the generic engine / NO SIGNAL).
 export function getBackglassContent(id: string): BackglassContent | null {
   return BY_ID[id] ?? null
 }

--- a/packages/maps/dmd.ts
+++ b/packages/maps/dmd.ts
@@ -2,14 +2,11 @@ import type { DmdMapContent } from '@pinball/dmd-core'
 import { dmdContent as strangerthings } from '@pinball/map-strangerthings/dmd'
 import { dmdContent as zelda } from '@pinball/map-zelda/dmd'
 
-// Registry DMD surface. Lightweight entrypoint separate from the core index:
-// no game-engine/three pulled into the DMD bundle.
 const BY_ID: Record<string, DmdMapContent> = {
   strangerthings,
   zelda,
 }
 
-// Resolves a map's DMD content by id (null = generic engine only).
 export function getDmdContent(id: string): DmdMapContent | null {
   return BY_ID[id] ?? null
 }

--- a/packages/maps/index.ts
+++ b/packages/maps/index.ts
@@ -11,17 +11,11 @@ import {
   createModule as zeldaCreateModule,
 } from '@pinball/map-zelda'
 
-// layout + module (game-engine types) cannot live on MapPackage
-// (shared-types does not depend on game-engine). The registry — which does
-// depend on game-engine — assembles them into this enriched type.
 export interface ResolvedMap extends MapPackage {
   layout: MapLayout
-  /** Lazy behavior-module factory (absent → no custom behavior). */
   module?: () => MapModule
 }
 
-// Maps composition root: the ONLY file in the repo that imports
-// @pinball/map-* packages. Apps resolve a map by id via getMapPackage.
 export function getMapPackage(id: string): ResolvedMap | null {
   switch (id) {
     case 'strangerthings':
@@ -33,13 +27,11 @@ export function getMapPackage(id: string): ResolvedMap | null {
   }
 }
 
-/** Lightweight metadata for the map selector (no layout, no module). */
 export interface MapMeta {
   id: string
   name: string
   tagline: string
   accentColor: string
-  /** Public URL of the preview video (looped inside the card). */
   previewVideo?: string
 }
 

--- a/packages/maps/strangerthings/backglass/DemogorgonTakeover.tsx
+++ b/packages/maps/strangerthings/backglass/DemogorgonTakeover.tsx
@@ -1,7 +1,5 @@
 import { cx } from './artStyles'
-// Inlined VHS wrapper (scanlines + tracking band). Structural classes (vhs*,
-// tk-center, glitch-text) are app-global; ST classes (tk-demogorgon, demo-*)
-// are scoped via art.module.css.
+
 export default function DemogorgonTakeover() {
   return (
     <div className={cx('vhs', 'tk-demogorgon')}>

--- a/packages/maps/strangerthings/backglass/JoyceWall.tsx
+++ b/packages/maps/strangerthings/backglass/JoyceWall.tsx
@@ -6,7 +6,6 @@ const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('')
 const ROW1 = ALPHABET.slice(0, 13)
 const ROW2 = ALPHABET.slice(13)
 
-// Varied garland colors (Joyce's wall style)
 const GARLAND = [
   '#ff3b30', '#ffcc00', '#34c759', '#00c7ff', '#bf5af2',
   '#ff9f0a', '#ff2d92', '#5e5ce6', '#30d158', '#ff6b3b',
@@ -17,7 +16,7 @@ const colorFor = (i: number) => GARLAND[i % GARLAND.length]
 
 interface JoyceWallProps {
   message: string | null
-  messageId?: number // change → re-enqueue even if the text is identical
+  messageId?: number // bump to re-enqueue even when the text is identical
   reactor?: Reactor
 }
 
@@ -29,7 +28,6 @@ export default function JoyceWall({ message, messageId, reactor }: JoyceWallProp
   const timersRef = useRef<Set<number>>(new Set())
   const hitCursorRef = useRef(0)
 
-  // Set + auto-prune: on a 24/7 cabinet the array grew without end.
   const later = (fn: () => void, ms: number) => {
     const id = window.setTimeout(() => {
       timersRef.current.delete(id)
@@ -38,7 +36,6 @@ export default function JoyceWall({ message, messageId, reactor }: JoyceWallProp
     timersRef.current.add(id)
   }
 
-  // Direct DOM mutation of a bulb (0 React re-render)
   const applyGlow = (idx: number, g: number) => {
     const bulb = bulbRefs.current[idx]
     const letter = letterRefs.current[idx]
@@ -59,7 +56,6 @@ export default function JoyceWall({ message, messageId, reactor }: JoyceWallProp
     }, holdMs)
   }
 
-  // ----- Message queue (letter-by-letter spelling) -----
   const enqueue = (text: string) => {
     queueRef.current.push(text)
     if (!busyRef.current) runNext()
@@ -79,8 +75,8 @@ export default function JoyceWall({ message, messageId, reactor }: JoyceWallProp
     letters.forEach((c, i) => {
       const idx = c.charCodeAt(0) - 65
       later(() => {
-        applyGlow(idx, 1) // strong flash
-        later(() => applyGlow(idx, 0.45), 220) // then dimly lit
+        applyGlow(idx, 1)
+        later(() => applyGlow(idx, 0.45), 220)
       }, i * STEP)
     })
     const total = letters.length * STEP
@@ -90,7 +86,6 @@ export default function JoyceWall({ message, messageId, reactor }: JoyceWallProp
     }, total + 2000)
   }
 
-  // ----- Ambient flicker (frequency modulated by heat) -----
   useEffect(() => {
     let alive = true
     let timer = 0
@@ -101,7 +96,6 @@ export default function JoyceWall({ message, messageId, reactor }: JoyceWallProp
         flickerBulb(idx, 0.5, 170)
       }
       const heat = reactor?.getHeat() ?? 0
-      // calm: 1–3s; blazing: ~200–400ms
       const base = 1000 + Math.random() * 2000
       const delay = base * (1 - heat * 0.85)
       timer = window.setTimeout(tick, Math.max(180, delay))
@@ -114,13 +108,11 @@ export default function JoyceWall({ message, messageId, reactor }: JoyceWallProp
     // eslint-disable-next-line
   }, [reactor])
 
-  // ----- Messages via props (takeover hook) -----
   useEffect(() => {
     if (message) enqueue(message)
     // eslint-disable-next-line
   }, [messageId, message])
 
-  // ----- In-game reactions -----
   useEffect(() => {
     if (!reactor) return
     const off = reactor.on((r) => {
@@ -133,13 +125,11 @@ export default function JoyceWall({ message, messageId, reactor }: JoyceWallProp
         flickerBulb(idx, 0.4 + r.intensity * 0.6, 160)
       } else if (r.kind === 'combo') {
         if (busyRef.current) return
-        // chase light: wave sweeping the garland, speed ∝ combo
         const step = Math.max(28, 110 - r.combo * 6)
         for (let i = 0; i < 26; i++) {
           later(() => flickerBulb(i, 0.85, 140), i * step)
         }
       } else if (r.kind === 'lifeLost') {
-        // bulbs turn off one by one then the ambience resumes
         busyRef.current = true
         for (let i = 0; i < 26; i++) applyGlow(i, 0.4)
         for (let i = 0; i < 26; i++) {

--- a/packages/maps/strangerthings/backglass/SideArt.tsx
+++ b/packages/maps/strangerthings/backglass/SideArt.tsx
@@ -3,10 +3,8 @@ import { useEffect, useRef } from 'react'
 import type { Reactor } from './reactor'
 
 interface SideArtProps {
-  // Generic API (normal / alternate world): the app does not know about the
-  // Upside Down. The ST rendering is internal to the map.
   mood: 'normal' | 'alternate'
-  agitation: number // 0..1 — animation speed/amplitude
+  agitation: number
   reactor?: Reactor
 }
 
@@ -20,12 +18,12 @@ export default function SideArt({ mood, agitation, reactor }: SideArtProps) {
       if (r.kind === 'event' && r.label === 'RAMP' && beamRef.current) {
         const el = beamRef.current
         el.classList.remove(cx('ramp-beam-on'))
-        void el.offsetWidth // reflow → restarts the animation
+        void el.offsetWidth // force reflow to restart the CSS animation
         el.classList.add(cx('ramp-beam-on'))
       }
     })
   }, [reactor])
-  const swayDur = 6 - agitation * 4 // more agitated = faster
+  const swayDur = 6 - agitation * 4
   const glow = upside ? '#b14dff' : '#ff2d2d'
   const amp = 2 + agitation * 6
 
@@ -55,7 +53,6 @@ export default function SideArt({ mood, agitation, reactor }: SideArtProps) {
 
         <rect x="0" y="0" width="320" height="660" fill="url(#demoGrad)" />
 
-        {/* Demogorgon silhouette — body + petal head */}
         <g
           className={cx('demo-body')}
           fill="#050505"
@@ -65,7 +62,6 @@ export default function SideArt({ mood, agitation, reactor }: SideArtProps) {
         >
           <path d="M160 250 C120 300 120 470 150 600 L170 600 C200 470 200 300 160 250 Z" />
           <ellipse cx="160" cy="235" rx="42" ry="54" />
-          {/* flower head: open petals */}
           {Array.from({ length: 6 }).map((_, i) => {
             const a = (Math.PI * (i - 2.5)) / 5
             const x = 160 + Math.cos(a - Math.PI / 2) * 60
@@ -79,12 +75,10 @@ export default function SideArt({ mood, agitation, reactor }: SideArtProps) {
               />
             )
           })}
-          {/* thin arms */}
           <path d="M150 290 C100 320 70 400 80 470" fill="none" strokeWidth="6" />
           <path d="M170 290 C220 320 250 400 240 470" fill="none" strokeWidth="6" />
         </g>
 
-        {/* Animated vines (slow sway) */}
         {[40, 110, 200, 280].map((x, i) => (
           <path
             key={x}

--- a/packages/maps/strangerthings/backglass/artStyles.ts
+++ b/packages/maps/strangerthings/backglass/artStyles.ts
@@ -1,8 +1,4 @@
 import styles from './art.module.css'
 
-// Resolves a class name: scoped if defined in art.module.css (ST content),
-// otherwise returned as-is (global structural app class: tk-center,
-// glitch-text, vhs*, tk-confetti…). Importing this module also loads the ST
-// content CSS.
 export const cx = (...names: string[]): string =>
   names.map((n) => styles[n] ?? n).join(' ')

--- a/packages/maps/strangerthings/backglass/css-modules.d.ts
+++ b/packages/maps/strangerthings/backglass/css-modules.d.ts
@@ -1,5 +1,3 @@
-// CSS Modules declaration for the map package tsc (the app has its own via
-// next-env.d.ts; the package must provide one itself).
 declare module '*.module.css' {
   const classes: Record<string, string>
   export default classes

--- a/packages/maps/strangerthings/backglass/index.ts
+++ b/packages/maps/strangerthings/backglass/index.ts
@@ -1,6 +1,4 @@
-// Stranger Things backglass art components. CSS classes stay in the app's
-// globals.css (TODO: extract the ST theme). The Reactor type is structural
-// (see reactor.ts).
+// TODO: extract the ST theme out of the app's globals.css
 export { default as JoyceWall } from './JoyceWall'
 export { default as SideArt } from './SideArt'
 export { default as DemogorgonTakeover } from './DemogorgonTakeover'
@@ -11,7 +9,5 @@ export { backglassTheme, backglassThemeAlternate } from './theme'
 export type { ThemeTokens } from './theme'
 import { manifest } from '../manifest'
 import type { ClipTimings } from '@pinball/shared-types'
-// Lightweight manifest data exposed to the backglass (no heavy getMapPackage).
 export const counterLabels: Record<string, string> = manifest.counterLabels ?? {}
-// Clip timings (manifest.clips) — backglass takeover durations.
 export const clips: Record<string, ClipTimings> = manifest.clips ?? {}

--- a/packages/maps/strangerthings/backglass/reactor.ts
+++ b/packages/maps/strangerthings/backglass/reactor.ts
@@ -1,6 +1,5 @@
-// Structural type of the backglass in-game reactor (defined app-side in
-// useIngameReactor). Duplicated here so the map's ST components don't
-// depend on the app; structurally identical → assignable.
+// Must stay structurally identical to the app-side useIngameReactor type;
+// the map cannot import the app, so assignability relies on structural match.
 export type Reaction =
   | { kind: 'gameStart'; player: string }
   | { kind: 'hit'; intensity: number }

--- a/packages/maps/strangerthings/backglass/takeover.tsx
+++ b/packages/maps/strangerthings/backglass/takeover.tsx
@@ -4,9 +4,6 @@ import type { GameOver } from '@pinball/shared-types'
 import SideArt from './SideArt'
 import DemogorgonTakeover from './DemogorgonTakeover'
 
-// VhsGlitch lives app-side (generic, CSS classes in its globals). We inject it
-// instead of importing the app (dependency direction maps → core, never
-// maps → app).
 type VhsComponent = ComponentType<{ children: ReactNode; className?: string }>
 
 export interface MapTakeoverContext {
@@ -14,9 +11,6 @@ export interface MapTakeoverContext {
   Vhs: VhsComponent
 }
 
-// Rocket takeover shared by all score milestones (5k/15k/30k/big).
-// Rocket crossing the screen bottom-to-top + milestone label. Cross-screen
-// rocket motif (playfield garlands + DMD).
 function rocketTakeover(Vhs: VhsComponent, label: string): ReactNode {
   return (
     <Vhs className={cx('tk-cine-rocket')}>
@@ -28,11 +22,6 @@ function rocketTakeover(Vhs: VhsComponent, label: string): ReactNode {
   )
 }
 
-// Map-specific takeover visual for a clip (or an event-scene key).
-// Returns null if the clip has no ST takeover → the core handles hall_of_fame +
-// the generic fallback. ST styles in ./art.module.css (co-located); generic
-// structural classes (tk-center/kicker/score, glitch-text, tk-confetti…) in the
-// app's globals.
 export function renderMapTakeover(clip: string, ctx: MapTakeoverContext): ReactNode | null {
   const { payload, Vhs } = ctx
   switch (clip) {
@@ -76,9 +65,6 @@ export function renderMapTakeover(clip: string, ctx: MapTakeoverContext): ReactN
         </Vhs>
       )
 
-    // All score milestones share the rocket takeover (cross-screen rocket motif
-    // with the playfield + DMD). The label varies per milestone; milestone_big
-    // shows the final score.
     case 'milestone_5k':
       return rocketTakeover(Vhs, '5 000')
     case 'milestone_15k':
@@ -107,7 +93,6 @@ export function renderMapTakeover(clip: string, ctx: MapTakeoverContext): ReactN
         </Vhs>
       )
 
-    // Scene triggered by a server event (cf. eventTakeovers).
     case 'event_demogorgon_slain':
       return <DemogorgonTakeover />
 
@@ -116,22 +101,16 @@ export function renderMapTakeover(clip: string, ctx: MapTakeoverContext): ReactN
   }
 }
 
-// Per-clip dispatch side effects: joyce / gold wave / fever / takeover.
-// Data-drives the useBackglassTakeover hook switch (once ST-hardcoded).
-// Absent from the table → generic takeover via clipShowMs.
 export interface ClipBehavior {
   joyce?: string | ((value?: number) => string)
   goldWave?: boolean
   fever?: boolean
-  takeoverMs?: number // explicit takeover duration
-  noTakeover?: boolean // joyce/wave only, no takeover
-  holdsHallFlip?: boolean // delays the hall of fame 3D flip during the clip
+  takeoverMs?: number
+  noTakeover?: boolean
+  holdsHallFlip?: boolean
 }
 
 export const clipBehavior: Record<string, ClipBehavior> = {
-  // Milestones: all push the rocket takeover (cross-screen rocket motif).
-  // goldWave/joyce kept for 5k/15k; takeoverMs = visible window per milestone
-  // (aligned with manifest clips.showMs).
   milestone_5k: { goldWave: true, takeoverMs: 4_000 },
   milestone_15k: { goldWave: true, joyce: 'BIEN', takeoverMs: 8_000 },
   hetic_letter: { joyce: (v) => 'HETIC'[(v ?? 1) - 1] ?? 'H', noTakeover: true },
@@ -143,7 +122,6 @@ export const clipBehavior: Record<string, ClipBehavior> = {
   portal_swallow: { holdsHallFlip: true },
 }
 
-// Takeover triggered by a server event (dmd:display mode EVENT, by label).
 export interface EventTakeover {
   clipKey: string
   durationMs: number

--- a/packages/maps/strangerthings/backglass/theme.ts
+++ b/packages/maps/strangerthings/backglass/theme.ts
@@ -1,10 +1,5 @@
-// Map backglass theme tokens (CSS custom properties). The app sets them as
-// inline style on the root container (see apps/backglass pages/index).
-// The app's structural CSS + the map's ST modules consume these var().
-// A map without a theme → the app keeps its neutral defaults (no hardcoded ST).
 export type ThemeTokens = Record<`--${string}`, string>
 
-// Normal palette (real world).
 export const backglassTheme: ThemeTokens = {
   '--foreground': '#ede4d3',
   '--glow': '#ff2d2d',
@@ -17,8 +12,6 @@ export const backglassTheme: ThemeTokens = {
   '--fever-b': '#00c7ff',
 }
 
-// Alternate world (Upside Down) overrides — merged over the base when
-// alternateWorld is active.
 export const backglassThemeAlternate: ThemeTokens = {
   '--glow': '#b14dff',
   '--vignette': '#1a0640',

--- a/packages/maps/strangerthings/bosses.ts
+++ b/packages/maps/strangerthings/bosses.ts
@@ -7,9 +7,6 @@ import {
 } from './cameraCinematics'
 import { mapAsset } from './manifest'
 
-// Stranger Things boss definitions. The engine contains no boss content:
-// it receives these definitions injected (layout.bosses) and operates on
-// them via generic helpers.
 export const bossDefinitions: BossDefinition[] = [
   {
     id: 'demogorgon',
@@ -44,7 +41,7 @@ export const bossDefinitions: BossDefinition[] = [
     revealSoundUrl: mapAsset('audio/spawnDG.mp3'),
     revealSoundVolume: 100,
     keepMusicUntilBossReveal: 'vecna',
-    // Eleven assists during the fight (DemogorgonReveal emits ASSIST id 'eleven').
+    // id must match the ASSIST id emitted by DemogorgonReveal.
     assist: { id: 'eleven' },
     targetMeshTheme: {
       ring: {
@@ -112,7 +109,6 @@ export const bossDefinitions: BossDefinition[] = [
     latePhaseSoundUrl: mapAsset('audio/win-music.mp3'),
     latePhaseSoundVolume: 100,
     latePhaseHitThreshold: 7,
-    // win-music keeps playing during the portal return cinematic (Vecna end photo).
     keepMusicUntilReturnPortal: true,
     targetMeshTheme: {
       ring: {
@@ -144,7 +140,6 @@ export const bossDefinitions: BossDefinition[] = [
   },
 ]
 
-// Map-side registry over THIS map's definitions.
 const byId: Record<string, BossDefinition> = Object.fromEntries(
   bossDefinitions.map((b) => [b.id, b]),
 )

--- a/packages/maps/strangerthings/dmd/attract.ts
+++ b/packages/maps/strangerthings/dmd/attract.ts
@@ -3,10 +3,6 @@ import { GRID_W, GRID_H } from '@pinball/dmd-core'
 import { DOT } from '@pinball/dmd-core'
 import { applyGlitch } from '@pinball/dmd-core'
 
-// Attract mode: PURE clock-driven state machine. No persistent state —
-// everything derives from clockMs, so it survives re-renders and Socket.io
-// reconnections.
-
 const MARQUEE_TEXT = 'DEFY THE DEMOGORGON * ENTER THE UPSIDE DOWN'
 const MARQUEE_SPEED = 22 // dots/s
 const MARQUEE_SCALE = 3
@@ -82,13 +78,11 @@ export function attractFrame(grid: Uint8Array, display: { player: string }, cloc
       break
   }
 
-  // Transition: decaying glitch over the first 250 ms of each phase.
   if (tLocal < TRANSITION_MS) {
     applyGlitch(grid, GRID_W, GRID_H, (TRANSITION_MS - tLocal) / TRANSITION_MS)
   }
 }
 
-// Phase 'title' — typewriter 'PINBALL' / 'HETIC' scale 2, then pulse.
 function phaseTitle(grid: Uint8Array, tLocal: number): void {
   const w1 = 'PINBALL'
   const w2 = 'HETIC'
@@ -119,28 +113,24 @@ function cursor2x2(grid: Uint8Array, x: number, y: number): void {
   for (let i = 0; i < 2; i++) for (let j = 0; j < 2; j++) plot(grid, x + i, y + j, DOT.marquee)
 }
 
-// Phase 'marquee' — scale-3 text enters right, exits left, fully readable
-// (the phase lasts exactly one pass).
 function phaseMarquee(grid: Uint8Array, tLocal: number): void {
   const x = GRID_W - (tLocal / 1000) * MARQUEE_SPEED
   drawText(grid, GRID_W, Math.round(x), 5, MARQUEE_TEXT, FONT_5X7, DOT.marquee, 1, MARQUEE_SCALE)
 }
 
-// Phase 'coin' — coin dropping into a slot + 'INSERT COIN' blink.
 function phaseCoin(grid: Uint8Array, tLocal: number): void {
-  // Fixed slot (14×2 rect) below the coin.
   for (let dx = 0; dx < 14; dx++) {
     plot(grid, 2 + dx, 15, DOT.event)
     plot(grid, 2 + dx, 16, DOT.event)
   }
 
-  const dropCycle = 1100 // ~700ms fall + 400ms pause → ~4 drops / 5s
+  const dropCycle = 1100
   const ct = tLocal % dropCycle
   if (ct < 660) {
     const topY = -9 + (ct / 700) * 17
     drawCoin(grid, 5, topY, false)
   } else if (ct < 700) {
-    drawCoin(grid, 4, 8, true) // squash on contact
+    drawCoin(grid, 4, 8, true)
   }
 
   if (blinkOn(tLocal, 600, 400)) {
@@ -149,7 +139,6 @@ function phaseCoin(grid: Uint8Array, tLocal: number): void {
   }
 }
 
-// Dot-art coin: 9×9 ring + vertical bar (₵-like), or squashed 11×7.
 function drawCoin(grid: Uint8Array, cx: number, cy: number, squashed: boolean): void {
   if (squashed) {
     for (let dy = 0; dy < 7; dy++) {
@@ -168,8 +157,6 @@ function drawCoin(grid: Uint8Array, cx: number, cy: number, squashed: boolean): 
   for (let dy = 2; dy <= 6; dy++) plot(grid, cx + 4, cy + dy, DOT.event)
 }
 
-// Phase 'rules' — tutorial: targets → HETIC row letter by letter →
-// FEVER X5 → the nest (boss unlock). 4 sub-phases over 12s.
 function phaseRules(grid: Uint8Array, tLocal: number): void {
   if (tLocal < 2500) {
     drawCentered(grid, 'COMPLETE', 4, DOT.score, 2)
@@ -192,7 +179,6 @@ function phaseRules(grid: Uint8Array, tLocal: number): void {
     }
     return
   }
-  // The nest: 3000 pts opens it, then where to hit. 2 screens of 2s.
   if (tLocal < 10000) {
     drawCentered(grid, '3000 PTS', 4, DOT.event, fitScale('3000 PTS', 2))
     drawCentered(grid, 'LE NID S OUVRE', 18, DOT.event, fitScale('LE NID S OUVRE', 2))
@@ -202,7 +188,6 @@ function phaseRules(grid: Uint8Array, tLocal: number): void {
   drawCentered(grid, 'ENTRE LES BUMPERS', 18, DOT.heticOn, fitScale('ENTRE LES BUMPERS', 2))
 }
 
-// Phase 'ready' — player name + 'START !' blink.
 function phaseReady(grid: Uint8Array, tLocal: number, player: string): void {
   const name = player && player !== '—' ? player : 'PLAYER'
   const ns = fitScale(name, 2)

--- a/packages/maps/strangerthings/dmd/demogorgonHero.ts
+++ b/packages/maps/strangerthings/dmd/demogorgonHero.ts
@@ -1,7 +1,3 @@
-// Demogorgon hero frame, generated from the official artwork via
-// tools/ascii-quantize.py (5-level palette quantization .:#@!, 52×24).
-// Animations (revealRadial, dissolve) derive procedurally from this single
-// frame — see AsciiClipPlayer.
 export const DEMOGORGON_HERO = `
 ........................:...........................
 .......................#@#..........................

--- a/packages/maps/strangerthings/dmd/handlers.ts
+++ b/packages/maps/strangerthings/dmd/handlers.ts
@@ -19,7 +19,6 @@ import {
 import { DEMOGORGON_HERO } from './demogorgonHero'
 import { RAW_CLIPS } from './rawClips'
 
-// Per-clip palettes (char → DMD palette index resolution).
 const RED = { ':': DOT.heticOff, '#': DOT.lives, '@': DOT.gameOver, '!': DOT.event }
 const VIOLET = { ':': DOT.heticOff, '#': DOT.multi, '@': DOT.rain, '!': DOT.event }
 
@@ -28,7 +27,6 @@ const CLIPS: Record<'portal_swallow' | 'last_chance', ParsedClip> = {
   last_chance: parseClip(RAW_CLIPS.last_chance, RED),
 }
 
-// Static demogorgon hero frame + procedural palettes.
 const HERO_FRAME: string[] = trimFrame(DEMOGORGON_HERO.replace(/\r/g, '').split('\n'))
 const HERO_MAP = { ':': DOT.heticOff, '#': DOT.lives, '@': DOT.gameOver, '!': DOT.event }
 const HERO_MAP_PULSE = { ':': DOT.heticOff, '#': DOT.lives, '@': DOT.event, '!': DOT.gameOver }
@@ -90,13 +88,6 @@ function clipHeticComplete(grid: Uint8Array, ms: number): void {
   }
 }
 
-// Rocket liftoff (DMD) — consistent with the playfield (garlands) and the
-// backglass (cine-rocket). Two phases: ascent (rocket climbing) then spark
-// burst + milestone label. Ascent lasts ~40% of the clip.
-//
-// Pure: rocket y at time ms over an ascent window launchMs, from bottom
-// (GRID_H - 1) to top (topY). Returns topY once the ascent is done
-// (ms >= launchMs). Testable without a grid.
 export function rocketLaunchY(ms: number, launchMs: number, topY = 3): number {
   const p = Math.max(0, Math.min(1, ms / launchMs))
   return (GRID_H - 1) + p * (topY - (GRID_H - 1))
@@ -106,7 +97,6 @@ function clipMilestoneRocket(grid: Uint8Array, value: number, ms: number): void 
   const cx = Math.floor(GRID_W / 2)
   const launchMs = 1600
   if (ms < launchMs) {
-    // Ascent: rocket body + exhaust flame below.
     const y = Math.round(rocketLaunchY(ms, launchMs))
     plot(grid, cx, y, DOT.score)
     plot(grid, cx, y + 1, DOT.event)
@@ -115,7 +105,6 @@ function clipMilestoneRocket(grid: Uint8Array, value: number, ms: number): void 
     plot(grid, cx, y + 3, DOT.gameOver)
     return
   }
-  // Spark burst at apogee + milestone label (deterministic).
   const et = Math.min(1, (ms - launchMs) / 1400)
   for (let i = 0; i < 22; i++) {
     const a = seeded(i) * Math.PI * 2
@@ -127,10 +116,7 @@ function clipMilestoneRocket(grid: Uint8Array, value: number, ms: number): void 
   drawCentered(grid, fmtNum(value), 22, FONT_5X7, DOT.score, 1, 1)
 }
 
-// Stranger Things cinematic handlers (injected into the DMD engine).
 export const cinematicHandlers: Record<string, ClipHandler> = {
-  // Score milestones: all render the same rocket liftoff (cross-screen
-  // rocket consistency). The milestone value comes from ctx.value.
   milestone_5k: (grid, clockMs, ctx) => clipMilestoneRocket(grid, ctx.value || 5000, clockMs),
   milestone_15k: (grid, clockMs, ctx) => clipMilestoneRocket(grid, ctx.value || 15000, clockMs),
   milestone_30k: (grid, clockMs, ctx) => clipMilestoneRocket(grid, ctx.value || 30000, clockMs),

--- a/packages/maps/strangerthings/dmd/index.ts
+++ b/packages/maps/strangerthings/dmd/index.ts
@@ -4,7 +4,6 @@ import { scoreOverlay, feverBanner } from './overlays'
 import { attractFrame } from './attract'
 import { PALETTE_UPSIDE_DOWN } from './palette'
 
-// Stranger Things DMD content injected into the @pinball/dmd-core engine.
 export const dmdContent: DmdMapContent = {
   paletteAlternateWorld: PALETTE_UPSIDE_DOWN,
   cinematicHandlers,

--- a/packages/maps/strangerthings/dmd/overlays.ts
+++ b/packages/maps/strangerthings/dmd/overlays.ts
@@ -12,7 +12,6 @@ import {
 } from '@pinball/dmd-core'
 import { mapStateNumber } from '@pinball/shared-types'
 
-// HETIC overlay (right row) drawn over SCORE mode.
 export const scoreOverlay: ScoreOverlay = (grid, display) => {
   const hetic = mapStateNumber(display.mapState, 'hetic')
   const letters = 'HETIC'
@@ -24,7 +23,6 @@ export const scoreOverlay: ScoreOverlay = (grid, display) => {
   }
 }
 
-// ST FEVER banner: top/bottom chase + big score + "FEVER X5".
 export const feverBanner: FeverBanner = (grid, score, clockMs) => {
   drawChenillard(grid, clockMs, 0)
   drawChenillard(grid, -clockMs, GRID_H - 1)

--- a/packages/maps/strangerthings/dmd/palette.ts
+++ b/packages/maps/strangerthings/dmd/palette.ts
@@ -1,6 +1,5 @@
 import type { DotColor } from '@pinball/dmd-core'
 
-// Alternate world palette (violet/magenta) — applied when display.alternateWorld.
 export const PALETTE_UPSIDE_DOWN: Record<DotColor, string> = {
   score: '#C26BF0',
   lives: '#FF2255',

--- a/packages/maps/strangerthings/dmd/rawClips.ts
+++ b/packages/maps/strangerthings/dmd/rawClips.ts
@@ -5,10 +5,8 @@
 //   ===                 → frame separator
 // Character mapping (resolved per clip via charMap in AsciiClipPlayer):
 //   '.' or ' ' = off; ':' = dim; '#' = mid; '@' = full; '!' = accent
-// Template literals (no raw import) — simplicity first.
 
 export const RAW_CLIPS = {
-  // Spiral growing from the center, swallowing the screen.
   portal_swallow: `
 # fps: 3
             @
@@ -50,7 +48,6 @@ export const RAW_CLIPS = {
  @@@@@@@@@@@@@@@@@@
 `,
 
-  // A giant circle pulsing twice.
   last_chance: `
 # fps: 5
        :##:
@@ -78,7 +75,6 @@ export const RAW_CLIPS = {
      :#@@@@#:
 `,
 
-  // Starry frame (the score rolls over it at clip end — handled by the layout).
   hall_of_fame: `
 # fps: 2
  !  :  !  :  !  :  !  :  !

--- a/packages/maps/strangerthings/index.ts
+++ b/packages/maps/strangerthings/index.ts
@@ -4,9 +4,6 @@ import { manifest } from './manifest'
 export { layout } from './layout'
 export { createModule } from './module'
 
-// Stranger Things map package. DMD content is exposed via the
-// '@pinball/map-strangerthings/dmd' subpath (kept out of the main index to
-// avoid bloating the playfield bundle).
 export const mapPackage: MapPackage = {
   manifest,
   hasModule: true,

--- a/packages/maps/strangerthings/layout.ts
+++ b/packages/maps/strangerthings/layout.ts
@@ -48,21 +48,15 @@ import {
   UPSIDE_DOWN_HINT_MS,
 } from './systems/UpsideDownConstants'
 
-// ST layout. Transitional step: MapLayout is assembled from existing
-// game-engine constants (referenced, not copied → no drift). Ownership flip
-// (literals here, constants removed from game-engine) happens consumer by
-// consumer.
 export const layout: MapLayout = {
-  // Bumpers: literals (tuned collider). The Box3 center of bumper_* meshes
-  // deviates 11-15 mm (mushroom cap) → not derivable. TODO(blender): add
-  // bumper_anchor_1/2/3 (empty at the collider point) to derive eventually.
+  // Literals, not derivable: bumper_* Box3 centers deviate 11-15 mm (mushroom
+  // cap). TODO(blender): add bumper_anchor_1/2/3 empties at the collider point.
   bumpers: [
     { x: -0.020586, y: 1.0482, z: -0.1967 },
     { x: -0.097406, y: 1.0621, z: -0.30509 },
     { x: 0.059483, y: 1.0621, z: -0.30509 },
   ],
-  // Drop targets: positions derived from the GLB at runtime (LayoutResolver,
-  // target_* meshes). Literals below = fallback (≤ 0.7 mm off the derived).
+  // Fallback only: LayoutResolver derives these from target_* meshes at runtime.
   dropTargets: [
     { id: 'drop_left_1', x: -0.209, y: 1.022, z: -0.019, side: 'left' },
     { id: 'drop_left_2', x: -0.205, y: 1.026, z: -0.049, side: 'left' },
@@ -71,8 +65,7 @@ export const layout: MapLayout = {
     { id: 'drop_right_3', x: 0.137, y: 1.032, z: -0.114, side: 'right' },
   ],
   // TODO(blender): derive from the GLB once sensor_* meshes exist
-  // (sensor_pop_1/2/3, sensor_rocket, sensor_demogorgon). Explicit literals
-  // until then — no mesh in the current GLB.
+  // (sensor_pop_1/2/3, sensor_rocket, sensor_demogorgon). Literals until then.
   sensors: {
     popZones: [
       { x: -0.0225, y: 1.057, z: -0.448 },
@@ -80,27 +73,21 @@ export const layout: MapLayout = {
       { x: 0.042, y: 1.056, z: -0.438 },
     ],
     rocket: { x: 0.193, y: 1.021, z: -0.13 },
-    // Scoop hole (saucer): capture → +life/+points/×2(5s) → kick. Position to
-    // refine at smoke test (H key = collider wireframes).
     scoop: { x: 0.192, y: 1.028, z: -0.061 },
     bossReveal: { x: -0.0195, y: 1.0575, z: -0.269 },
-    // sensor_portal (sensor Ø 1.7 cm) — literal until the mesh exists.
+    // TODO: literal until sensor_portal mesh (Ø 1.7 cm) exists in the GLB.
     portal: { x: -0.000751, y: 1.015191, z: -0.064818 },
   },
-  // Spawns: analytic (no mesh expected — outside lane/hinge).
   spawns: {
     ball: { x: 0.2355, y: 1.01, z: 0.161 },
     alternateWorld: { x: -0.0225, z: -0.48 },
     alternateWorldImpulse: { x: 0, y: 0, z: 0.055 },
-    // Normal-world return → the ball EXITS THE PORTAL (= sensors.portal) with
-    // a push toward the flippers. Not the shooter lane: while `playing` the
-    // plunger does not charge (idle only) and the lane gate is closed
-    // → ball trapped. No re-trigger: the portal is closed after the cycle
-    // (portalOpen=false until a boss reopens it).
+    // Must be the portal position (= sensors.portal), not the shooter lane:
+    // while `playing` the plunger stays idle and the lane gate is closed, so a
+    // ball returned to the lane would be trapped.
     normalReturn: { x: -0.000751, z: -0.064818 },
     normalReturnImpulse: { x: 0, y: 0, z: 0.055 },
   },
-  // Shooter lane: analytic geometry (no mesh). Map literals.
   shooterLane: {
     xMin: 0.206,
     xMax: 0.265,
@@ -120,7 +107,6 @@ export const layout: MapLayout = {
     guideAngleStart: Math.PI * 1.5,
     guideAngleEnd: Math.PI * 2,
   },
-  // Fine flipper pivot tuning (offset from the bbox edge).
   flipperPivots: {
     leftX: 0.02,
     rightX: -0.02,
@@ -129,7 +115,6 @@ export const layout: MapLayout = {
   },
   bosses: bossDefinitions,
   geometry: {
-    // surfaceYAtZ(z) = 1.068 - ((z + 0.552) / 0.970) * 0.110
     coefficients: { base: 1.068, zOffset: 0.552, zSpan: 0.97, yDrop: 0.11 },
     bounds: { leftX: WALL_LEFT_X, rightX: WALL_RIGHT_X, topZ: WALL_TOP_Z, bottomZ: WALL_BOTTOM_Z },
     shade: {

--- a/packages/maps/strangerthings/manifest.ts
+++ b/packages/maps/strangerthings/manifest.ts
@@ -1,25 +1,16 @@
 import { mapAssetUrl, type MapManifest } from '@pinball/shared-types'
 
-// Map id + asset resolution helper (public URL /maps/<id>/…).
-// ONLY source of the id literal in the package (assets synced from
-// packages/maps/strangerthings/assets/).
 export const MAP_ID = 'strangerthings'
 export const mapAsset = (rel: string) => mapAssetUrl(MAP_ID, rel)
 
-// Stranger Things map manifest. Values come from game-engine constants
-// (ScoringConstants, BossRegistry, FlipperConstants) and useGameState.
-// Later phases: the engine will read these from the manifest (injection)
-// instead of hardcoded constants.
 export const manifest: MapManifest = {
   id: MAP_ID,
   name: 'Stranger Things',
   version: 1,
   attractTagline: 'Hawkins National Laboratory',
-  // CSS tokens consumed by the playfield overlay (outro). A map without
-  // theme → overlay keeps its neutral defaults.
   theme: {
     '--glow': '#ff2d2d',
-    '--glow-alt': '#b14dff', // upside down world
+    '--glow-alt': '#b14dff',
     '--st-font': "'Times New Roman', Georgia, serif",
     '--vignette': '#2a0606',
     '--foreground': '#ede4d3',
@@ -30,7 +21,6 @@ export const manifest: MapManifest = {
     replayLabel: 'START — Rejouer',
     qrLogo: mapAsset('playfield/demogorgon.png'),
   },
-  // Cinematic families (generic overlay fallback). Not listed → 'other'.
   clipFamilies: {
     demogorgon_rises: 'boss',
     demogorgon_slain: 'boss',
@@ -43,83 +33,68 @@ export const manifest: MapManifest = {
     milestone_30k: 'milestone',
     milestone_big: 'milestone',
   },
-  // Assets preloaded by the playfield page (public URL /maps/<id>/…).
   preload: [
     mapAsset('playfield/demogorgon.glb'),
     mapAsset('playfield/demogorgon.png'),
     mapAsset('playfield/fin_combat_vecna.png'),
-    // Vecna GLB (~28 MB): fetch starts at page load (link rel=preload)
-    // instead of waiting for module mount — otherwise it delays boss preload.
+    // Vecna GLB (~28 MB): preload early (rel=preload), else it delays boss preload.
     mapAsset('playfield/vecna.glb'),
   ],
-  // Map event sounds (played via ctx.playSound(id)).
   sounds: {
     upside_down_appear: { url: mapAsset('audio/apparitionUpsideDown.mp3'), volume: 280 },
   },
-  // Counter labels (backglass recap).
   counterLabels: { demogorgons: 'DEMOGORGONS', portals: 'PORTAILS', hetic: 'HETIC' },
-  // mapState keys editable by the debug tool (dev).
   debugMapState: { numbers: ['hetic'], flags: ['fever'] },
-  // Clip timings: showMs / freezeMs / takeoverMs.
   clips: {
-    demogorgon_rises: { showMs: 10_000, freezeMs: 6_000 }, // 6s freeze + 4s celebration
+    demogorgon_rises: { showMs: 10_000, freezeMs: 6_000 },
     portal_swallow: { showMs: 4_000, freezeMs: 4_000 },
     demogorgon_slain: { showMs: 15_000, freezeMs: 2_600 },
     last_chance: { showMs: 2_000, freezeMs: 0 },
     hall_of_fame: { showMs: 25_000, freezeMs: 0 },
+    // Milestones + letters keep freezeMs: 0 on purpose — the playfield is the
+    // watched screen, so a DMD/backglass clip must not freeze the ball.
     milestone_5k: { showMs: 4_000, freezeMs: 0 },
-    // Milestones + letters: NO physics freeze. The playfield is the watched
-    // screen — don't freeze the ball for a DMD/backglass clip. The clip still
-    // plays (showMs), the ball keeps rolling; the playfield cue
-    // (garland sweep + shake) stays non-blocking.
     milestone_15k: { showMs: 8_000, freezeMs: 0 },
     milestone_30k: { showMs: 13_000, freezeMs: 0 },
     milestone_big: { showMs: 15_000, freezeMs: 0 },
     hetic_letter: { showMs: 5_000, freezeMs: 0 },
-    hetic_complete: { showMs: 40_000, freezeMs: 10_000, takeoverMs: 10_000 }, // 10s cinematic + 30s fever
+    hetic_complete: { showMs: 40_000, freezeMs: 10_000, takeoverMs: 10_000 },
     skill_shot: { showMs: 5_000, freezeMs: 2_000 },
   },
   glb: mapAsset('playfield/newStrangerthings.glb'),
-  // Points per role (ScoringConstants.ts + boss values from BossRegistry).
   scoring: {
-    bumper: 1000, // SCORE_BUMPER
-    bump: 30, // SCORE_BUMP
-    slingshot: 10, // SCORE_SLINGSHOT
-    popZone: 50, // SCORE_POP_ZONE
-    ramp: 200, // SCORE_RAMP
-    dropTarget: 75, // SCORE_DROP_TARGET
-    dropComplete: 500, // SCORE_DROP_COMPLETE
-    demogorgonReveal: 150, // BOSS_REGISTRY.demogorgon.reveal.scoreIncrement
-    demogorgonTarget: 250, // BOSS_REGISTRY.demogorgon.scoreTargetHit
-    vecnaReveal: 200, // BOSS_REGISTRY.vecna.reveal.scoreIncrement
-    vecnaTarget: 300, // BOSS_REGISTRY.vecna.scoreTargetHit
+    bumper: 1000,
+    bump: 30,
+    slingshot: 10,
+    popZone: 50,
+    ramp: 200,
+    dropTarget: 75,
+    dropComplete: 500,
+    demogorgonReveal: 150,
+    demogorgonTarget: 250,
+    vecnaReveal: 200,
+    vecnaTarget: 300,
   },
   rules: {
-    lives: 3, // INITIAL_LIVES
-    multiplierThresholds: [5, 10, 20, 40], // MULTIPLIER_THRESHOLDS
-    milestones: [5_000, 15_000, 30_000], // MILESTONES
-    milestoneRepeatEvery: 25_000, // MILESTONE_REPEAT_EVERY
-    comboDecayMs: 2_000, // COMBO_DECAY_MS
+    lives: 3,
+    multiplierThresholds: [5, 10, 20, 40],
+    milestones: [5_000, 15_000, 30_000],
+    milestoneRepeatEvery: 25_000,
+    comboDecayMs: 2_000,
   },
-  // Per-mesh material tuning (key = conventioned name). Default for
-  // unlisted wall_ meshes: restitution 0.35, friction 0.15, double-sided,
-  // Laplacian smoothing.
-  //   physics:'analytic' → no trimesh (the smooth analytic floor handles it)
-  //   singleSided:1      → single-sided trimesh (normals facing inward)
-  //   doubleSided:0/1    → forces double-sided
-  //   smooth:0/1         → Laplacian smoothing
+  // Unlisted wall_ meshes default to restitution 0.35, friction 0.15,
+  // double-sided, Laplacian smoothing.
   elements: {
-    floor_main: { physics: 'analytic' }, // ex-Mesh_0: smooth analytic floor
-    wall_main: { singleSided: 1, restitution: 0.35, friction: 0.12 }, // ex-Mesh_1
-    wall_slingshot: { restitution: 0, friction: 0.1 }, // ex no-bounce (Cylinder.008)
-    wall_bottom: { restitution: 0, friction: 0.1 }, // ex no-bounce (Plane.008)
-    wall_top: { restitution: 0.3, friction: 0.1 }, // plastic (Circle.001)
-    wall_under_top: { restitution: 0.35, friction: 0.12 }, // rail (Circle.034)
-    wall_middle_left: { restitution: 0.3, friction: 0.1 }, // plastic (Circle.011)
-    wall_middle_right: { restitution: 0.3, friction: 0.1 }, // plastic (Circle.018)
-    wall_guide_lane: { restitution: 0.2, friction: 0.15, smooth: 0 }, // ex-Fix-Start
+    floor_main: { physics: 'analytic' },
+    wall_main: { singleSided: 1, restitution: 0.35, friction: 0.12 },
+    wall_slingshot: { restitution: 0, friction: 0.1 },
+    wall_bottom: { restitution: 0, friction: 0.1 },
+    wall_top: { restitution: 0.3, friction: 0.1 },
+    wall_under_top: { restitution: 0.35, friction: 0.12 },
+    wall_middle_left: { restitution: 0.3, friction: 0.1 },
+    wall_middle_right: { restitution: 0.3, friction: 0.1 },
+    wall_guide_lane: { restitution: 0.2, friction: 0.15, smooth: 0 },
   },
-  // ST terms tracked by the anti-leak grep guard.
   forbiddenInCore: [
     'demogorgon',
     'vecna',
@@ -130,9 +105,8 @@ export const manifest: MapManifest = {
     'eleven',
     'hawkins',
   ],
-  // ─── Three.js rendering — original ST lighting ──────────────────────────
-  // hemi and fill at intensity 0: kept for UpsideDownAtmosphere which
-  // revives them (it overwrites intensities via the light refs).
+  // hemi and fill are intentionally at intensity 0: UpsideDownAtmosphere
+  // revives them by overwriting the intensities via the light refs.
   rendering: {
     useEnvironment: false,
     toneMappingExposure: 1.12,
@@ -144,11 +118,8 @@ export const manifest: MapManifest = {
     lights: {
       ambient: { color: 0xffffff, intensity: 0.25 },
       hemi:    { sky: 0xffffff, ground: 0x111111, intensity: 0 },
-      // Opposed dual side suns (tuned by eye): no specular highlight along
-      // the camera axis, floor lit from both sides.
       dir:     { color: 0xffffff, intensity: 2.54, x: 1.08,  y: 1.5,  z: 0.27 },
       dir2:    { color: 0xffffff, intensity: 5.05, x: -1.21, y: 1.5,  z: 0.55 },
-      // Backlight: metal rim toward the camera (tuned by eye).
       rim:     { color: 0xffffff, intensity: 1.1,  x: 0,     y: 1.3,  z: -1.2 },
       fill:    { color: 0xffffff, intensity: 0,    x: 0,     y: 1,    z: -1   },
     },

--- a/packages/maps/strangerthings/module/index.ts
+++ b/packages/maps/strangerthings/module/index.ts
@@ -28,23 +28,14 @@ import { createLastLifeRescue } from './lastLifeRescue'
 import { playMilestoneCinematic } from './milestoneCinematic'
 import { createScoopCapture } from './scoopCapture'
 
-// Stranger Things behavior module. Owns all its systems in closure; exposes
-// only the MapModule contract (no bridge to the playfield component).
 export function createModule(): MapModule {
   let ctxRef: MapContext | null = null
-  // ST counters (feed mapState + GameStats.counters).
   let demogorgons = 0
   let portals = 0
   let hetic = 0
-  // Nest: armed-since timestamp (ms) + late hint already fired, per boss.
   const armedAt: Record<string, number> = {}
   const hintFired = new Set<string>()
-  // Boss id list (static after setup) — hoisted to avoid an array allocation
-  // on every update tick (nest late hint).
   let bossIds: readonly string[] = []
-  // Timescale-restore timers after a boss defeat (~200 ms). Tracked per
-  // bossId to avoid leaks (cancelled on reset/dispose, never stacked).
-  // See createBossDefeatTimers (game-engine).
   const bossDefeatTimers = createBossDefeatTimers()
   let garlands: GarlandLights | null = null
   let bumperVisuals: BumperVisuals | null = null
@@ -56,26 +47,18 @@ export function createModule(): MapModule {
   let demogorgonReveal: DemogorgonReveal | null = null
   let vecnaReveal: VecnaReveal | null = null
   const lastLifeRescue = createLastLifeRescue()
-  // Scoop hole (saucer): capture → hold → kick state machine.
   const scoop = createScoopCapture()
 
-  // ── onGameEvent handlers (closures over ST state/systems) ────────────────
   function onMilestone(ctx: MapContext, e: GameEvent): void {
     if (e.type !== 'MILESTONE') return
-    // Score milestone: rocket cinematic + garland liftoff (rising orange
-    // sweep, matching the DMD/backglass rocket) + shake.
     playMilestoneCinematic(ctx, e.threshold, () => garlands?.rocketBurst())
   }
 
   function onScoop(_ctx: MapContext, e: GameEvent): void {
     if (e.type !== 'SCOOP_ENTER') return
-    // Sensor contact only ARMS. Capture (and rewards) happens only if the
-    // ball SETTLES in the zone (dwell, see scoopCapture.ts) — a ball just
-    // passing through the lane exits with no effect.
     scoop.arm()
   }
 
-  // Rewards + juice at capture instant (phase 'capture', one frame).
   function grantScoopRewards(ctx: MapContext): void {
     ctx.addScore(SCORE_SCOOP, 'SCOOP')
     ctx.addLife()
@@ -87,7 +70,6 @@ export function createModule(): MapModule {
 
   function onPortalTransitionEnd(ctx: MapContext, e: GameEvent): void {
     if (e.type !== 'PORTAL_TRANSITION_END') return
-    // Upside Down entry confirmed: portal active + core baseline + UD nest.
     portal?.reset()
     portal?.setUpsideDownActive(true)
     ctx.resetPortalTrigger()
@@ -96,20 +78,17 @@ export function createModule(): MapModule {
   }
 
   function onGameOverDrain(ctx: MapContext, e: GameEvent): void {
-    // Game over on drain: end all boss fights.
     if (isGameOverDrain(e, ctx.gameState())) bossReveals?.endAllFights()
   }
 
   function onBossArmed(ctx: MapContext, e: GameEvent): void {
     if (e.type !== 'BOSS_ARMED') return
-    // Nest wakes up: DMD banner + hint timestamp (shared) + celebrate + shake.
     handleBossArmed(ctx, e, armedAt, performance.now())
     garlands?.celebrate()
     ctx.screenShake(0.3)
   }
 
   function onDemogorgon(ctx: MapContext, e: GameEvent): void {
-    // Demogorgon boss cinematics (reveal + victory).
     if (e.type === 'BOSS_REVEAL' && e.bossId === 'demogorgon') {
       ctx.playCinematic('demogorgon_rises', { once: true })
     }
@@ -129,7 +108,6 @@ export function createModule(): MapModule {
   }
 
   function onBossDefeatedCounter(ctx: MapContext, e: GameEvent): void {
-    // ST demogorgons counter → mapState.
     if (e.type !== 'BOSS_TARGET_HIT') return
     const boss = ctx.layout.bosses.find((b) => b.id === e.bossId)
     if (boss && isBossTargetDefeated(boss.targetHits, e.hitCount)) {
@@ -208,8 +186,6 @@ export function createModule(): MapModule {
   }
 
   function reconcileNestMarkers(ctx: MapContext): void {
-    // Nest marker reconciliation after each event: triggered → revealed;
-    // else threshold reached → armed; else locked. Idempotent.
     if (!nestMarker) return
     const gate = ctx.bossGateContext()
     nestMarker.setUpsideDown(gate.alternateWorldActive)
@@ -270,8 +246,8 @@ export function createModule(): MapModule {
           ctx.emitGameEvent({ type: 'BOSS_FIGHT_END', bossId: 'demogorgon' });
         },
         onTargetReady: () => ctx.setBossTargetArmed('demogorgon', true),
-        // Eleven assist gate: outside 'playing' (drain, waiting for relaunch)
-        // the sub-timer is suspended — otherwise +100 pts loops without playing.
+        // Gate the assist sub-timer to 'playing'; otherwise +100 pts loops
+        // while the ball is drained and waiting for relaunch.
         isPlaying: () => ctx.gameState() === 'playing',
       })
       demogorgonReveal.setEmit(ctx.emitGameEvent)
@@ -349,9 +325,8 @@ export function createModule(): MapModule {
       portal?.update(dt)
       bossReveals?.update(dt)
       nestMarker?.update(dt)
-      transition?.update(dt) // no-op when inactive (guarded internally)
+      transition?.update(dt)
 
-      // Nest late hint: armed > 45 s without reveal → DMD banner once.
       const ctx = ctxRef
       if (ctx && nestMarker) {
         const marker = nestMarker
@@ -364,9 +339,7 @@ export function createModule(): MapModule {
         }
       }
 
-      // Scoop: dwell (ball settled in zone?) → capture → hold → kick.
-      // NOTE: uses ctx.ball.body (raw RigidBody) — to be replaced by
-      // holdAt/kick helpers.
+      // TODO: uses ctx.ball.body (raw RigidBody) — replace with holdAt/kick helpers.
       const scoopPos = ctx?.layout.sensors.scoop
       if (ctx?.ball && scoopPos) {
         const bp = ctx.ball.body.translation()
@@ -381,15 +354,11 @@ export function createModule(): MapModule {
         if (phase === 'capture') {
           grantScoopRewards(ctx)
         } else if (phase === 'hold') {
-          // Physics is frozen during hold (shouldFreezePhysics) → just center
-          // the ball in the hole, at rest. resetStuck is defensive.
           ctx.ball.body.setTranslation({ x: scoopPos.x, y: scoopPos.y, z: scoopPos.z }, true)
           ctx.ball.body.setLinvel({ x: 0, y: 0, z: 0 }, true)
           ctx.ball.body.setAngvel({ x: 0, y: 0, z: 0 }, true)
           ctx.resetStuck()
         } else if (phase === 'eject') {
-          // Teleport-eject: place the ball at the exit point (absolute,
-          // resting on the surface) with a direct exit velocity (see ScoopConfig).
           const p = scoop.config.ejectPos
           ctx.ball.body.setTranslation(
             { x: p.x, y: ballCenterOnSurface(p.z), z: p.z },
@@ -404,9 +373,7 @@ export function createModule(): MapModule {
       return (
         (transition?.isActive() ?? false) ||
         (bossReveals?.isGameplayFrozen() ?? false) ||
-        // Scoop hold: freeze → ball motionless in the hole (no gravity or
-        // surface-snap/stuck-detector fighting it) until the kick.
-        // (NOT during 'armed': the ball must be able to roll/settle.)
+        // Only during 'hold', not 'armed' — an armed ball must still roll/settle.
         scoop.isHolding()
       )
     },
@@ -420,18 +387,9 @@ export function createModule(): MapModule {
     setSporesEnabled(enabled: boolean): void {
       atmosphere?.setSporesEnabled(enabled)
     },
-    // ── Contract of the three reset hooks (disjoint responsibilities) ─────────
-    // releaseWorld: "soft" exit from the alternate world MID-game (normal
-    //   return via portal). Disables Upside Down + atmosphere and ends the
-    //   Vecna fight, without touching the portal object or counters.
-    //   Triggered by `releaseAlternateWorld` (PinballPlayfield).
-    // resetWorld: WORLD/PORTAL/FIGHTS teardown on restart from game_over.
-    //   Does NOT touch counters or nest (that is onGameReset's job).
-    // onGameReset: LOGICAL game reset — counters, rescue, nest hints,
-    //   mapState. Does NOT touch world/portal/atmosphere (resetWorld's job).
-    // resetWorld and onGameReset are both called on game_over restart
-    // (via distinct PinballPlayfield paths) and cover disjoint targets:
-    // no duplicated effect between them.
+    // resetWorld and onGameReset both fire on game_over restart and MUST stay
+    // disjoint: resetWorld owns world/portal/fights, onGameReset owns
+    // counters/rescue/nest/mapState. Overlap = double or missed reset.
     releaseWorld(): void {
       portal?.setUpsideDownActive(false)
       atmosphere?.reset()

--- a/packages/maps/strangerthings/module/lastLifeRescue.ts
+++ b/packages/maps/strangerthings/module/lastLifeRescue.ts
@@ -11,18 +11,7 @@ export type RescueStatus = {
 export type LastLifeRescue = {
   reset(): void
   onGameEvent(ctx: MapContext, e: GameEvent): void
-  /**
-   * Called BEFORE the life decrement (handleDrain) on a DRAIN/BOTTOM_OUT,
-   * with the PRE-decrement life count (explicit, without reading
-   * `ctx.lives()`). Does TWO things on that explicit count:
-   *   1. Rescue: if armed and the goal is reached on the last life
-   *      (`livesBeforeDrain === 1`), grants a life here — before the
-   *      decrement hits 0, so game over is avoided.
-   *   2. Arming: based on lives remaining AFTER this drain
-   *      (`livesBeforeDrain + (life granted ? 1 : 0) - 1`), arms the rescue
-   *      if the player enters their last life (1 left), else disarms it.
-   * Returns true if a life was granted (successful rescue).
-   */
+  // Must run BEFORE the life decrement, with the pre-decrement count.
   onPreDrain(ctx: MapContext, livesBeforeDrain: number): boolean
   isArmed(): boolean
   status(ctx: MapContext): RescueStatus
@@ -56,9 +45,7 @@ export function createLastLifeRescue(): LastLifeRescue {
       : LAST_LIFE_RESCUE_POINTS,
   })
 
-  // Rescue attempt: if armed and the goal is reached on the last life,
-  // grant the life now (before handleDrain hits 0) → game over avoided.
-  // Returns true if a life was granted.
+  // Grants the life before handleDrain decrements to 0, so game over is avoided.
   const tryRescue = (ctx: MapContext, livesBeforeDrain: number): boolean => {
     if (!active) return false
     if (livesBeforeDrain !== 1) return false
@@ -68,14 +55,10 @@ export function createLastLifeRescue(): LastLifeRescue {
     return true
   }
 
-  // Before the decrement: rescue attempt first, then arming decided on the
-  // EXPLICIT post-drain life count — without reading ctx.lives()
-  // (so no dependence on handleDrain's decrement ordering).
+  // Arming decides on the explicit post-drain count, never ctx.lives(), to
+  // avoid any dependence on handleDrain's decrement ordering.
   const onPreDrain = (ctx: MapContext, livesBeforeDrain: number): boolean => {
     const rescued = tryRescue(ctx, livesBeforeDrain)
-    // Lives left after this drain (handleDrain will remove 1; the rescue may
-    // have added 1 just before). 1 left = player enters their last life
-    // → arm + count; otherwise disarm.
     const livesAfterDrain = livesBeforeDrain + (rescued ? 1 : 0) - 1
     if (livesAfterDrain === 1) {
       if (!active) arm(ctx)
@@ -86,8 +69,7 @@ export function createLastLifeRescue(): LastLifeRescue {
   }
 
   const onGameEvent = (ctx: MapContext, e: GameEvent) => {
-    // Arming/disarming on DRAIN/BOTTOM_OUT is handled in onPreDrain
-    // (explicit life count). Ignore those events here.
+    // DRAIN/BOTTOM_OUT arming is owned by onPreDrain; skip them here.
     if (e.type === 'DRAIN' || e.type === 'BOTTOM_OUT') return
 
     if (ctx.lives() !== 1) {

--- a/packages/maps/strangerthings/module/milestoneCinematic.ts
+++ b/packages/maps/strangerthings/module/milestoneCinematic.ts
@@ -1,17 +1,10 @@
 import { selectMilestoneClip } from '@pinball/game-engine'
 
-// Subset of MapContext needed by the milestone cinematic. Allows testing
-// playMilestoneCinematic with a fake ctx (spies) without a full MapContext.
 export interface MilestoneContext {
   playCinematic(clipId: string, opts?: { value?: number }): void
   screenShake(amount: number): void
 }
 
-// Score milestone (MILESTONE) effect: plays the selected clip's cinematic
-// (clip selection shared with Zelda via selectMilestoneClip), fires the ST
-// playfield cue (optional, absent outside setup) then a screen shake. The
-// playfield cue (garland rocket liftoff) is ST-specific and injected by the
-// caller.
 export function playMilestoneCinematic(
   ctx: MilestoneContext,
   threshold: number,

--- a/packages/maps/strangerthings/module/scoopCapture.ts
+++ b/packages/maps/strangerthings/module/scoopCapture.ts
@@ -1,39 +1,20 @@
-// Scoop hole (saucer) mechanic: arms on contact, captures ONLY a settled
-// ball (dwell), then rewards → hold → kick (teleport-eject).
-// Pure state machine (time in ms), testable without Three/Rapier.
-//
-// Why the dwell: the sensor sits at rolling-ball height in a pass-through
-// lane (rocket ramp). Without dwell, any ball merely CROSSING the zone
-// triggered capture (freeze + teleport mid-play = unrealistic "impulses").
-// A real saucer only captures a ball that settles into it.
+// The dwell requirement is load-bearing: the sensor sits at rolling-ball
+// height in a pass-through lane, so without it any ball crossing the zone
+// would trigger a capture.
 
 export interface ScoopConfig {
-  /** continuous in-zone time before capture (ms) */
   armDwellMs: number;
-  /** radius (m) around the sensor the ball must stay within to capture */
-  captureRadius: number;
-  /** speed (m/s) below which the ball counts as "settled" */
-  settleSpeed: number;
-  /** capture duration before eject (ms) — time for the anim */
+  captureRadius: number; // metres
+  settleSpeed: number; // m/s
   holdMs: number;
-  /** multiplier value granted */
   multiplier: number;
-  /** multiplier duration (ms) */
   multiplierMs: number;
-  /**
-   * Teleport-eject (pinball standard): on eject the ball is PLACED at
-   * `ejectPos` (absolute, resting on the surface via ballCenterOnSurface)
-   * with a direct exit velocity. No impulse escapes a deep GLB hole.
-   * Same pattern as the portals (spawnFromAlternateWorld).
-   */
+  // On eject the ball is teleported (setTranslation) to ejectPos, not
+  // impulsed — no impulse escapes a deep GLB hole.
   ejectPos: { x: number; z: number };
-  /** exit velocity (m/s) applied as-is (setLinvel) — TUNE at smoke test */
-  ejectVelocity: { x: number; y: number; z: number };
+  ejectVelocity: { x: number; y: number; z: number }; // TODO: tune at smoke test
 }
 
-// Defaults tunable at smoke test. Exit: position picked in 3D by the map
-// author (0.143, −0.172), projected LEFT (−x). (Observed y 1.041 =
-// ballCenterOnSurface(−0.172) → formula kept.)
 export const DEFAULT_SCOOP_CONFIG: ScoopConfig = {
   armDwellMs: 300,
   captureRadius: 0.03,
@@ -45,29 +26,17 @@ export const DEFAULT_SCOOP_CONFIG: ScoopConfig = {
   ejectVelocity: { x: -0.6, y: 0, z: 0 },
 };
 
-/**
- * Phase returned each tick:
- * - idle    : nothing to do
- * - armed   : contact happened, waiting for the ball to settle (or leave)
- * - capture : armed→hold transition (ONE frame) — the module grants rewards
- * - hold    : keep the ball in the hole
- * - eject   : exit kick (ONE frame)
- */
+// 'capture' and 'eject' are each returned for a single frame.
 export type ScoopPhase = 'idle' | 'armed' | 'capture' | 'hold' | 'eject';
 
 export interface ScoopBallState {
-  /** ball within the sensor capture radius */
   inZone: boolean;
-  /** speed ≤ settleSpeed */
   slow: boolean;
 }
 
 export interface ScoopCapture {
-  /** true during hold (the playfield freezes physics on this flag) */
   isHolding(): boolean;
-  /** sensor contact (SCOOP_ENTER) → arms the dwell (no-op if already armed/captured) */
   arm(): void;
-  /** advance one frame; see ScoopPhase */
   tick(dtMs: number, ball: ScoopBallState): ScoopPhase;
   reset(): void;
   readonly config: ScoopConfig;
@@ -91,20 +60,17 @@ export function createScoopCapture(config: ScoopConfig = DEFAULT_SCOOP_CONFIG): 
       if (state === 'idle') return 'idle';
 
       if (state === 'armed') {
-        // Ball left → flythrough: disarm with no effect.
         if (!ball.inZone) {
           state = 'idle';
           return 'idle';
         }
-        // Dwell only counts while the ball is settled (slow) in the zone.
         if (ball.slow) dwellRemaining -= dtMs;
         if (dwellRemaining > 0) return 'armed';
         state = 'hold';
         holdRemaining = config.holdMs;
-        return 'capture'; // one frame: the module grants rewards here
+        return 'capture';
       }
 
-      // hold
       holdRemaining -= dtMs;
       if (holdRemaining > 0) return 'hold';
       state = 'idle';

--- a/packages/maps/strangerthings/systems/BumperVisuals.ts
+++ b/packages/maps/strangerthings/systems/BumperVisuals.ts
@@ -26,16 +26,15 @@ const IDLE_PULSE_SPEED = 1.35;
 const IDLE_PULSE_AMP = 0.18;
 const HIT_FLASH_DURATION = 0.2;
 const HIT_FLASH_BOOST = 1.1;
-const PUNCH_DURATION = 0.15; // pop duration in seconds
-const PUNCH_PEAK = 0.20; // amplitude: 0.20 = grows to 1.20×
+const PUNCH_DURATION = 0.15;
+const PUNCH_PEAK = 0.20;
 
 const _emissiveA = new THREE.Color();
 const _emissiveB = new THREE.Color();
 
 type BumperKind = 'gltf' | 'base' | 'ring';
 
-// Order matters (first matching rule wins): legacy hide, then gltf,
-// then base, then ring.
+// First matching rule wins — order is load-bearing.
 const MATCH_RULES: readonly BumperMatchRule<BumperKind>[] = [
   { pattern: LEGACY_BUMPER, result: { action: 'hide' } },
   { pattern: GLTF_BUMPER, result: { action: 'part', kind: 'gltf' } },
@@ -50,7 +49,7 @@ type BumperPart = {
   material: THREE.MeshStandardMaterial;
   bumperIndex: number;
   kind: BumperKind;
-  glow: GlowSprite | null; // replaces the former PointLight (zero shader cost)
+  glow: GlowSprite | null;
   glowColor: number;
   baseIntensity: number;
   baseScale: THREE.Vector3;
@@ -148,9 +147,6 @@ export class BumperVisuals {
       };
     });
 
-    // Fail loudly: if no mesh matched (e.g. GLB naming convention changed),
-    // all bumper effects are silently dead. Report it rather than pretend
-    // the animation is wired.
     if (this.parts.length === 0) {
       console.warn(
         '[BumperVisuals] aucun mesh bumper reconnu (GLTF_BUMPER/LEGACY_*) — ' +
@@ -170,7 +166,6 @@ export class BumperVisuals {
 
     tickPunchTimers(this.hitTimers, dt);
 
-    // Scale punch (visual mesh only, colliders unchanged).
     tickPunchTimers(this.punchTimers, dt);
     applyPunchScale(this.parts, this.punchTimers, PUNCH_DURATION, PUNCH_PEAK);
 
@@ -210,7 +205,6 @@ export class BumperVisuals {
 
         if (part.glow) {
           part.glow.setColor(upsideDown && strobeFlash > 0.45 ? 0xff2244 : BUMPER_LIGHT_COLOR);
-          // opacity ∝ former light intensity (normalized), pulse via scale.
           const v = (BUMPER_LIGHT_INTENSITY * slowBreath + hitFactor * 0.35) * moodMul;
           part.glow.set(Math.min(1, v * 0.55), 0.9 + hitFactor * 0.5);
         }
@@ -236,8 +230,7 @@ export class BumperVisuals {
   }
 
   dispose(): void {
-    // Restore scales to their original value before clearing: otherwise a
-    // bumper disposed mid-punch stays enlarged.
+    // Restore scales before clearing, else a bumper disposed mid-punch stays enlarged.
     for (const part of this.parts) {
       part.mesh.scale.copy(part.baseScale);
       part.glow?.dispose();

--- a/packages/maps/strangerthings/systems/DemogorgonReveal.ts
+++ b/packages/maps/strangerthings/systems/DemogorgonReveal.ts
@@ -48,12 +48,8 @@ export type DemogorgonSetup = {
   bumperVisuals: BumperVisuals | null;
   onFightEnd?: () => void;
   onTargetReady?: () => void;
-  /**
-   * Game running? (gameState === 'playing'). Injected by the module — used
-   * to suspend the Eleven assist when the ball drains: without this gate the
-   * assist keeps scoring +100 every ~4 s while waiting at spawn.
-   * Absent (tests, legacy) → treated as always playing.
-   */
+  // Suspends the Eleven assist on drain; without it the assist scores +100
+  // every ~4 s while the ball waits at spawn. Absent → treated as playing.
   isPlaying?: () => boolean;
 };
 
@@ -126,9 +122,7 @@ export class DemogorgonReveal implements BossRevealController {
       this.billboard.ensureReady(),
       this.demogorgonVisual.ensureReady(),
     ]);
-    // GPU upload of the billboard texture + shader compilation for the
-    // demogorgon, targetGroup (ring/core/burst) and sprite — off the
-    // critical frame. Otherwise it all lands on the spawn frame → freeze.
+    // Warmup here (GPU upload + shader compile), else it lands on the spawn frame → freeze.
     this.billboard.warmup(renderer);
     await this.demogorgonVisual.warmup(renderer, scene, camera);
     if (this.targetGroup) await renderer.compileAsync(this.targetGroup, camera, scene);
@@ -136,10 +130,9 @@ export class DemogorgonReveal implements BossRevealController {
     if (sprite) await renderer.compileAsync(sprite, camera, scene);
   }
 
-  // PointLights added dynamically during the fight: strobe flash +
-  // Demogorgon glow + target light + Eleven assist flash. Any never-seen
-  // light count would recompile every lit shader on the reveal frame —
-  // preloadAll precompiles these variants (see orchestrator).
+  // Count of PointLights added dynamically during the fight (strobe flash,
+  // Demogorgon glow, target light, Eleven assist). preloadAll precompiles
+  // shader variants for this count, else the reveal frame recompiles every lit shader.
   dynamicPointLightCount(): number {
     return 4;
   }
@@ -184,7 +177,6 @@ export class DemogorgonReveal implements BossRevealController {
 
     const assistY = DEMOGORGON_TARGET.y + 0.021;
 
-    // Added to the scene ONLY during its flashes (see trigger/hide).
     this.elevenAssistLight = new THREE.PointLight(0xbb55ff, 0, 0.32, 0.3);
     this.elevenAssistLight.position.set(DEMOGORGON_TARGET.x, DEMOGORGON_TARGET.y + 0.045, DEMOGORGON_TARGET.z);
 
@@ -261,8 +253,6 @@ export class DemogorgonReveal implements BossRevealController {
       this.machine.isVictory(),
     );
 
-    // Assist frozen outside 'playing' (see DemogorgonSetup.isPlaying); other
-    // fight effects (strobe, flicker, phases) keep running.
     const d = this.machine.tick(dt, {
       suspendAssist: this.isPlaying ? !this.isPlaying() : false,
     });
@@ -389,7 +379,6 @@ export class DemogorgonReveal implements BossRevealController {
     });
   }
 
-  // IO side of an eleven assist trigger; the timer/state lives in the machine.
   private fireElevenAssist(): void {
     this.targetPulse?.flashHit();
     if (this.elevenShockOuter) this.elevenShockOuter.visible = true;
@@ -413,11 +402,10 @@ export class DemogorgonReveal implements BossRevealController {
     if (this.elevenShockInnerMat) this.elevenShockInnerMat.opacity = 0;
     if (this.elevenAssistLight) {
       this.elevenAssistLight.intensity = 0;
-      this.elevenAssistLight.removeFromParent(); // off-scene between flashes
+      this.elevenAssistLight.removeFromParent();
     }
   }
 
-  // Mesh animation for an active assist; envelope scalars come from the machine.
   private renderElevenAssist(frame: ElevenAssistFrame): void {
     const { t, elapsed, rise, alpha, burst } = frame;
 

--- a/packages/maps/strangerthings/systems/GarlandLights.ts
+++ b/packages/maps/strangerthings/systems/GarlandLights.ts
@@ -9,34 +9,19 @@ const TWINKLE_AMP = 0.28;
 const HIT_SURGE_DURATION = 0.3;
 const HIT_SURGE_BOOST = 0.55;
 
-// Width (in bulb count) of the rocket-liftoff light band.
 const ROCKET_BAND = 3;
 
-// Position of the rocket-liftoff light front, indexed on bulbs.
-// rocketT decays 1 → 0; the front rises from -ROCKET_BAND (before the first
-// bulb) to count (past the last) → full upward sweep. Pure.
 export function rocketFront(rocketT: number, count: number): number {
   const progress = 1 - Math.max(0, Math.min(1, rocketT));
   return -ROCKET_BAND + progress * (count + ROCKET_BAND);
 }
 
-// Intensity [0,1] of a given bulb for a rocket front: 1 at the front, falls
-// off linearly over ROCKET_BAND below it, 0 elsewhere. Pure.
 export function rocketGlow(index: number, front: number): number {
   const d = front - index;
   if (d < 0 || d > ROCKET_BAND) return 0;
   return 1 - d / ROCKET_BAND;
 }
 
-/**
- * Each garland in newStrangerthings.glb has:
- *  - baseColorTexture  : dark cable + colored bulbs
- *  - emissiveTexture   : bulb glow map
- *  - emissiveFactor    : [1,1,1] (white = neutral multiplier)
- *
- * We NO LONGER replace the material. The original GLB material is kept and
- * only emissiveIntensity is animated for twinkle and game-event reactions.
- */
 type GarlandBulb = {
   mesh: THREE.Mesh;
   material: THREE.MeshStandardMaterial;
@@ -59,19 +44,14 @@ export class GarlandLights {
   private celebrateT = 0;
   private rocketT = 0;
 
-  // Continuous chase during fever (permanent wave).
   setFever(on: boolean): void {
     this.feverActive = on;
   }
 
-  // 1s one-shot chase (milestone crossed).
   celebrate(): void {
     this.celebrateT = 1;
   }
 
-  // Rocket liftoff (score milestone): rising orange/gold sweep, matching the
-  // backglass/DMD rocket. Replaces the yellow "celebrate" chase on
-  // milestones for cross-screen rocket consistency.
   rocketBurst(): void {
     this.rocketT = 1;
   }
@@ -160,7 +140,6 @@ export class GarlandLights {
       }
     }
 
-    // Wave (chase) — continuous fever OR one-shot celebration.
     if (this.celebrateT > 0) this.celebrateT = Math.max(0, this.celebrateT - dt);
     if (this.feverActive || this.celebrateT > 0) {
       const speed = this.feverActive ? 6 : 9;
@@ -177,8 +156,6 @@ export class GarlandLights {
       }
     }
 
-    // Rocket liftoff (milestone): orange/gold light band climbs the garlands
-    // once, then fades. Matches the backglass/DMD rocket.
     if (this.rocketT > 0) {
       this.rocketT = Math.max(0, this.rocketT - dt);
       const front = rocketFront(this.rocketT, this.bulbs.length);
@@ -190,9 +167,6 @@ export class GarlandLights {
           bulb.material.emissiveIntensity,
           bulb.origIntensity * (0.6 + glow * 2.4),
         );
-        // Rocket flame (warm white → bright orange → red), NOT the yellow of
-        // the "celebrate" chase → distinct "liftoff" read, consistent with
-        // the DMD/backglass rocket.
         bulb.material.emissive.setHex(
           glow > 0.8 ? 0xffffff : glow > 0.5 ? 0xff7a1a : 0xff2200,
         );

--- a/packages/maps/strangerthings/systems/PlayfieldCinematicStrobe.ts
+++ b/packages/maps/strangerthings/systems/PlayfieldCinematicStrobe.ts
@@ -10,9 +10,6 @@ export {
   type PlayfieldCinematicStrobeConfig,
 };
 
-// ST uses the unified class and passes its lights/visuals (GarlandLights,
-// BumperVisuals) via the decor port. This function folds the two nullable
-// decors into a DecorLights array for `mount(root, config, decor)`.
 export function strangerthingsDecor(...lights: (DecorLights | null)[]): DecorLights[] {
   return lights.filter((d): d is DecorLights => d !== null);
 }

--- a/packages/maps/strangerthings/systems/PortalRevealCurve.ts
+++ b/packages/maps/strangerthings/systems/PortalRevealCurve.ts
@@ -4,20 +4,12 @@ import {
   UPSIDE_DOWN_PORTAL_REVEAL_DELAY,
 } from './UpsideDownConstants';
 
-// Share of the opening progress reached during the delay phase
-// (the remaining [DELAY_PROGRESS_FRACTION, 1] is covered by the opening phase).
 const DELAY_PROGRESS_FRACTION = 0.28;
 
 export function portalRevealTotalDuration(): number {
   return UPSIDE_DOWN_PORTAL_REVEAL_DELAY + UPSIDE_DOWN_PORTAL_OPEN_DURATION;
 }
 
-/**
- * Maps normalized reveal time `u` ∈ [0,1] (over delay + opening) to the
- * portal opening progress `p` ∈ [0,1]: the delay phase brings coverage up to
- * DELAY_PROGRESS_FRACTION (linear), the opening phase eases in-out the rest
- * up to 1.
- */
 export function mapPortalRevealProgress(u: number): number {
   const total = portalRevealTotalDuration();
   const delayFrac = UPSIDE_DOWN_PORTAL_REVEAL_DELAY / total;

--- a/packages/maps/strangerthings/systems/PortalTimeline.ts
+++ b/packages/maps/strangerthings/systems/PortalTimeline.ts
@@ -4,12 +4,6 @@ import {
   UPSIDE_DOWN_PORTAL_PULSE_SPEED,
 } from './UpsideDownConstants';
 
-/**
- * Impulse vector (world space) the portal magnet applies to a ball at
- * horizontal distance `horiz` from the anchor. `null` = out of radius or too
- * close (no impulse). Pure math — the caller reads `body.translation()` and
- * calls `body.applyImpulse()`.
- */
 export function portalMagnetImpulse(
   dx: number,
   dz: number,
@@ -27,16 +21,11 @@ export function portalMagnetImpulse(
   };
 }
 
-/**
- * Opening progress `p` ∈ [0,1] reached by the "polish" phase (`revealing`)
- * at normalized time `t` ∈ [0,1]: cubic ease-out over [0.35, 1].
- */
 export function portalRevealingProgress(t: number): number {
   const ease = 1 - Math.pow(1 - t, 3);
   return 0.35 + ease * 0.65;
 }
 
-/** Visual scalar levels derived from the opening progress `p`. */
 export type PortalOpenLevels = {
   portalOn: number;
   glbOff: number;
@@ -57,11 +46,6 @@ export type PortalOpenLevels = {
   particleScale: number;
 };
 
-/**
- * Maps the opening progress `p` ∈ [0,1] to all portal scalar levels
- * (opacities, intensities, scales). Consumed by the renderer to drive
- * materials/lights/sprites.
- */
 export function portalOpenLevels(p: number): PortalOpenLevels {
   const portalOn = easeInOut(p);
   const glbOff = easeInOut(Math.min(1, p / 0.42));
@@ -87,7 +71,6 @@ export function portalOpenLevels(p: number): PortalOpenLevels {
   };
 }
 
-/** Scalar levels of the open portal's "idle" (pulse) animation. */
 export type PortalPulseLevels = {
   pulse: number;
   fast: number;
@@ -102,11 +85,6 @@ export type PortalPulseLevels = {
   vineEmissiveIntensity: number;
 };
 
-/**
- * Open-portal animation levels at time `pulseT` with suction boost
- * `suckBoost`. Vine/particle positions stay in the renderer (they depend on
- * per-mesh state).
- */
 export function portalPulseLevels(pulseT: number, suckBoost: number): PortalPulseLevels {
   const pulse = 0.65 + Math.sin(pulseT * UPSIDE_DOWN_PORTAL_PULSE_SPEED) * 0.35;
   const accentPulse = 0.55 + Math.sin(pulseT * UPSIDE_DOWN_PORTAL_ACCENT_PULSE_SPEED) * 0.45;

--- a/packages/maps/strangerthings/systems/UpsideDownAtmosphere.ts
+++ b/packages/maps/strangerthings/systems/UpsideDownAtmosphere.ts
@@ -269,8 +269,6 @@ export class UpsideDownAtmosphere {
     this.sporesEnabled = enabled;
   }
 
-  // All spores in ONE THREE.Points (1 draw call) — the animation updates
-  // the position attribute.
   private buildSpores(root: THREE.Object3D): void {
     const n = UPSIDE_DOWN_ATMOSPHERE_SPORE_COUNT;
     this.sporePositions = new Float32Array(n * 3);
@@ -327,7 +325,6 @@ export class UpsideDownAtmosphere {
   }
 
   private applyMix(t: number): void {
-    // Early return: only touch materials/lights when mix changed.
     if (!this.blend.shouldApply(t)) return;
 
     const ease = AtmosphereBlend.ease(t);

--- a/packages/maps/strangerthings/systems/UpsideDownConstants.ts
+++ b/packages/maps/strangerthings/systems/UpsideDownConstants.ts
@@ -1,8 +1,6 @@
 import { mapAsset } from '../manifest';
 
-/** Upside Down entry cinematic (first portal pass). */
 export const PORTAL_ENTER_TEXTURE_URL = mapAsset('playfield/upsidedown.jpg');
-/** Return cinematic after Vecna victory (ball passes through the hole). */
 export const RETURN_PORTAL_TEXTURE_URL = mapAsset('playfield/fin_combat_vecna.png');
 
 export const UPSIDE_DOWN_TRANSITION_DURATION = 4;
@@ -18,11 +16,8 @@ export const UPSIDE_DOWN_TRANSITION_HOLD =
   - UPSIDE_DOWN_TRANSITION_RESTORE;
 
 export const UPSIDE_DOWN_PORTAL_REVEAL_DELAY = 3;
-/**
- * Delay (s) before the RETURN portal appears after the boss defeat: on the
- * fatal hit the ball is stuck to the boss (= to the portal) — opening
- * immediately would suck it in instantly instead of leaving it in play.
- */
+// On the fatal hit the ball is stuck to the boss (= the portal); this delay
+// prevents the reopening portal from instantly sucking it back in.
 export const RETURN_PORTAL_REVEAL_DELAY_S = 5;
 export const UPSIDE_DOWN_PORTAL_OPEN_DURATION = 2.5;
 export const UPSIDE_DOWN_PORTAL_OPEN_POLISH = 0.2;

--- a/packages/maps/strangerthings/systems/UpsideDownPortal.ts
+++ b/packages/maps/strangerthings/systems/UpsideDownPortal.ts
@@ -140,7 +140,6 @@ export class UpsideDownPortal {
 
   setUpsideDownActive(active: boolean): void {
     this.alternateWorldActive = active;
-    // Leaving the alternate world: a pending return reveal no longer makes sense.
     if (!active) this.returnRevealCountdown.cancel();
   }
 
@@ -164,8 +163,8 @@ export class UpsideDownPortal {
       return;
     }
     if (def.unlocksReturnPortal && this.alternateWorldActive) {
-      // Deferred reveal: on the fatal hit the ball sticks to the boss
-      // (= to the portal); opening immediately would suck it in without play.
+      // Deferred: the ball sticks to the boss (= the portal) on the fatal hit,
+      // so opening now would suck it straight back in.
       this.returnRevealCountdown.start(RETURN_PORTAL_REVEAL_DELAY_S);
     }
   }

--- a/packages/maps/strangerthings/systems/UpsideDownTransition.ts
+++ b/packages/maps/strangerthings/systems/UpsideDownTransition.ts
@@ -40,7 +40,6 @@ type SetupConfig = {
 type StartConfig = {
   ballMesh: THREE.Object3D;
   ballBody: RAPIER.RigidBody;
-  /** Fullscreen texture (default: upsidedown.jpg). */
   textureUrl?: string;
   onRevealStart?: () => void;
   onTremorStart?: () => void;

--- a/packages/maps/strangerthings/systems/VecnaReveal.ts
+++ b/packages/maps/strangerthings/systems/VecnaReveal.ts
@@ -62,9 +62,8 @@ export class VecnaReveal implements BossRevealController {
     await this.vecnaVisual.warmup(renderer, scene, camera);
   }
 
-  // PointLights added dynamically during the fight: strobe flash + Vecna
-  // glow + target light. Used to prewarm shader variants at preload
-  // (see BossRevealOrchestrator.preloadAll).
+  // Count of PointLights added dynamically during the fight (strobe flash,
+  // Vecna glow, target light); preloadAll prewarms shader variants for it.
   dynamicPointLightCount(): number {
     return 3;
   }
@@ -136,9 +135,8 @@ export class VecnaReveal implements BossRevealController {
       this.machine.getPhase() === 'victory',
     );
 
-    // The walk/settle exit timing lives in the visual (Three-side animation);
-    // sample it for the pure machine. updateSettle(dt) advances the settle anim
-    // and reports completion, so it must run every frame while settling.
+    // updateSettle advances the settle animation as a side effect, so it must
+    // run every frame while settling — not just when the phase result is read.
     const walkPathComplete =
       this.machine.getPhase() === 'walk' && this.vecnaVisual.isWalkPathComplete();
     const settleComplete =

--- a/packages/maps/strangerthings/systems/VecnaTargetVisual.ts
+++ b/packages/maps/strangerthings/systems/VecnaTargetVisual.ts
@@ -66,12 +66,6 @@ function resolveVecnaClips(
   return { walkAction, fightIdleAction, hitAction, finisherAction };
 }
 
-/**
- * Vecna 3D visual (GLB + animations). Delegates the whole
- * walk/fight/hit/victory lifecycle to the generic WalkBossTargetActor
- * (game-engine); only clip resolution (raw, walk reused as frozen pose) and
- * the Vecna constants are specific.
- */
 export class VecnaTargetVisual {
   private readonly actor = new WalkBossTargetActor({
     logTag: 'Vecna',

--- a/packages/maps/strangerthings/systems/index.ts
+++ b/packages/maps/strangerthings/systems/index.ts
@@ -1,5 +1,3 @@
-// Stranger Things visual/behavioral systems (the engine stays generic,
-// these classes live in the map).
 export * from './GarlandLights';
 export * from './BumperVisuals';
 export * from './UpsideDownAtmosphere';

--- a/packages/maps/strangerthings/systems/testDomStub.ts
+++ b/packages/maps/strangerthings/systems/testDomStub.ts
@@ -1,9 +1,6 @@
-// Shared, complete DOM stub for the map's tests. No happy-dom in this package,
-// yet several systems touch document/Image at import time (GlowSprite builds a
-// radial canvas; CameraBillboardSprite's TextureLoader creates an <img>). bun
-// test shares one module singleton across files, so a per-file partial stub
-// would poison the global for whichever file runs next (order-dependent, green
-// on macOS / red on CI). One idempotent, complete stub removes that race.
+// Must stay one shared, complete, idempotent stub: bun test shares a module
+// singleton across files, so a per-file partial stub poisons the global for
+// the next file to run (order-dependent, green on macOS / red on CI).
 
 type StubContext = {
   createRadialGradient: () => { addColorStop: () => void };
@@ -13,8 +10,6 @@ type StubContext = {
   fillStyle: unknown;
 };
 
-// One element that satisfies both the canvas path (getContext) and the <img>
-// path (addEventListener/src) so createElement and createElementNS can share it.
 function makeStubElement() {
   const listeners: Record<string, Array<() => void>> = {};
   return {
@@ -25,8 +20,7 @@ function makeStubElement() {
     removeAttribute: () => {},
     addEventListener: (type: string, cb: () => void) => {
       (listeners[type] ??= []).push(cb);
-      // ImageLoader waits for load/error; simulate a failed decode so its error
-      // path runs and resolves (loader catch → texture null).
+      // Fire error immediately so ImageLoader's load/error wait resolves (→ texture null).
       if (type === 'error') queueMicrotask(() => cb());
     },
     removeEventListener: () => {},

--- a/packages/maps/zelda/backglass/GanondorfTakeover.tsx
+++ b/packages/maps/zelda/backglass/GanondorfTakeover.tsx
@@ -1,10 +1,8 @@
 import { cx } from './artStyles'
 
-// Ganondorf-defeated boss takeover.
 export default function GanondorfTakeover() {
-  // Triforce coordinates (same as SideArt, scaled ×1.6 in a 400×600 viewBox)
   const S = 128
-  const H = S * Math.sqrt(3) / 2  // ≈ 110.9
+  const H = S * Math.sqrt(3) / 2
   const cx0 = 200, cy0 = 130
   const tri = {
     top: `${cx0},${cy0} ${cx0 - S / 2},${cy0 + H} ${cx0 + S / 2},${cy0 + H}`,
@@ -23,13 +21,11 @@ export default function GanondorfTakeover() {
               <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
             </filter>
           </defs>
-          {/* Fond halo */}
           <radialGradient id="ganoHalo" cx="50%" cy="50%" r="60%">
             <stop offset="0%" stopColor="#FFD700" stopOpacity="0.15" />
             <stop offset="100%" stopColor="#FFD700" stopOpacity="0" />
           </radialGradient>
           <ellipse cx="200" cy={cy0 + H} rx="160" ry="110" fill="url(#ganoHalo)" />
-          {/* Triforce */}
           <g filter="url(#ganoGlow)">
             <polygon points={tri.top} fill="#3a2a00" fillOpacity="0.6" stroke="#FFD700" strokeWidth="3" strokeOpacity="0.95" />
             <polygon points={tri.bl}  fill="#3a2a00" fillOpacity="0.6" stroke="#FFD700" strokeWidth="3" strokeOpacity="0.95" />

--- a/packages/maps/zelda/backglass/JoyceWall.tsx
+++ b/packages/maps/zelda/backglass/JoyceWall.tsx
@@ -8,11 +8,9 @@ interface JoyceWallProps {
   reactor?: Reactor
 }
 
-// Minimal Triforce SVG centered in the header.
 function TriforceIcon() {
   return (
     <svg viewBox="0 0 60 52" className={cx('logo-triforce')} aria-hidden>
-      {/* Triangle du bas-gauche */}
       <polygon points="0,52 30,0 60,52" fill="none" stroke="#FFD700" strokeWidth="2.5"
         style={{ filter: 'drop-shadow(0 0 6px #FFD700)' }} />
     </svg>
@@ -29,7 +27,6 @@ export default function JoyceWall({ message, messageId }: JoyceWallProps) {
     if (timerRef.current) window.clearTimeout(timerRef.current)
     setVisibleMsg(message.toUpperCase())
     setGlow(true)
-    // Clears the message after 4s
     timerRef.current = window.setTimeout(() => {
       setGlow(false)
       timerRef.current = window.setTimeout(() => setVisibleMsg(null), 600)

--- a/packages/maps/zelda/backglass/SideArt.tsx
+++ b/packages/maps/zelda/backglass/SideArt.tsx
@@ -24,16 +24,13 @@ export default function SideArt({ mood, agitation, reactor }: SideArtProps) {
     })
   }, [reactor])
 
-  // Glow color: emerald in the normal world, gold in the Sacred Realm
   const glow = sacred ? '#FFD700' : '#22cc44'
   const glowDim = sacred ? '#a87c00' : '#145c20'
   const pulseDur = 3 - agitation * 1.5
   const rayOpacity = 0.04 + agitation * 0.08
 
-  // Triforce coordinates (3 equilateral triangles, 80px side)
-  // Centered around (160, 280) in a 320×660 viewBox
   const S = 80
-  const H = S * Math.sqrt(3) / 2  // ≈ 69.3
+  const H = S * Math.sqrt(3) / 2
   const cx0 = 160, cy0 = 235
   const tri = {
     top: `${cx0},${cy0} ${cx0 - S / 2},${cy0 + H} ${cx0 + S / 2},${cy0 + H}`,
@@ -67,13 +64,10 @@ export default function SideArt({ mood, agitation, reactor }: SideArtProps) {
           </filter>
         </defs>
 
-        {/* Fond */}
         <rect x="0" y="0" width="320" height="660" fill="url(#zeldaBg)" />
 
-        {/* Halo diffus autour de la Triforce */}
         <ellipse cx="160" cy={cy0 + H} rx="120" ry="80" fill="url(#triGlow)" />
 
-        {/* Rayons lumineux (Sacred Realm) */}
         {Array.from({ length: 12 }).map((_, i) => {
           const angle = (i * Math.PI * 2) / 12
           const x2 = 160 + Math.cos(angle) * 240
@@ -90,14 +84,12 @@ export default function SideArt({ mood, agitation, reactor }: SideArtProps) {
           )
         })}
 
-        {/* Triforce — 3 triangles */}
         <g className={cx('triforce')} filter="url(#zGlow)">
           <polygon points={tri.top} fill={glowDim} fillOpacity="0.15" stroke={glow} strokeWidth="2" strokeOpacity="0.9" />
           <polygon points={tri.bl}  fill={glowDim} fillOpacity="0.15" stroke={glow} strokeWidth="2" strokeOpacity="0.9" />
           <polygon points={tri.br}  fill={glowDim} fillOpacity="0.15" stroke={glow} strokeWidth="2" strokeOpacity="0.9" />
         </g>
 
-        {/* Anneau animé */}
         <circle
           cx="160" cy={cy0 + H}
           r="105"
@@ -118,7 +110,6 @@ export default function SideArt({ mood, agitation, reactor }: SideArtProps) {
           style={{ animationDelay: '1s' }}
         />
 
-        {/* Piliers du temple (bas) */}
         {[50, 90, 130, 170, 210, 250, 290].map((x, i) => (
           <rect
             key={i}
@@ -129,7 +120,6 @@ export default function SideArt({ mood, agitation, reactor }: SideArtProps) {
           />
         ))}
 
-        {/* Ligne du sol du temple */}
         <line x1="20" y1="500" x2="300" y2="500" stroke={glow} strokeOpacity="0.12" strokeWidth="1" />
       </svg>
     </div>

--- a/packages/maps/zelda/backglass/artStyles.ts
+++ b/packages/maps/zelda/backglass/artStyles.ts
@@ -1,8 +1,6 @@
 import styles from './art.module.css'
 
-// Resolves a class name: scoped if defined in art.module.css (Zelda
-// content), otherwise returned as-is (global structural app class:
-// tk-center, glitch-text, vhs*, tk-confetti…). Importing this module also
-// loads the Zelda content CSS.
+// Scoped name if defined in art.module.css, else returned as-is (global
+// structural app class). Importing this module also loads the map's CSS.
 export const cx = (...names: string[]): string =>
   names.map((n) => styles[n] ?? n).join(' ')

--- a/packages/maps/zelda/backglass/css-modules.d.ts
+++ b/packages/maps/zelda/backglass/css-modules.d.ts
@@ -1,5 +1,3 @@
-// CSS Modules declaration for the map package tsc (the app has its own via
-// next-env.d.ts; the package must provide one itself).
 declare module '*.module.css' {
   const classes: Record<string, string>
   export default classes

--- a/packages/maps/zelda/backglass/index.ts
+++ b/packages/maps/zelda/backglass/index.ts
@@ -1,9 +1,8 @@
-// Zelda backglass components and data — Ocarina of Time.
 export { default as JoyceWall } from './JoyceWall'
 export { default as SideArt } from './SideArt'
 export { default as GanondorfTakeover } from './GanondorfTakeover'
-// Type-compat alias with BackglassContent (typeof strangerthings) which
-// exposes DemogorgonTakeover. TODO: extract a shared BackglassContent.
+// Alias required by BackglassContent (typeof strangerthings), which exposes
+// DemogorgonTakeover. TODO: extract a shared BackglassContent interface.
 export { default as DemogorgonTakeover } from './GanondorfTakeover'
 export type { Reactor, Reaction } from './reactor'
 export { renderMapTakeover, clipBehavior, eventTakeovers } from './takeover'
@@ -12,6 +11,5 @@ export { backglassTheme, backglassThemeAlternate } from './theme'
 export type { ThemeTokens } from './theme'
 import { manifest } from '../manifest'
 import type { ClipTimings } from '@pinball/shared-types'
-// Lightweight manifest data exposed to the backglass.
 export const counterLabels: Record<string, string> = manifest.counterLabels ?? {}
 export const clips: Record<string, ClipTimings> = manifest.clips ?? {}

--- a/packages/maps/zelda/backglass/reactor.ts
+++ b/packages/maps/zelda/backglass/reactor.ts
@@ -1,6 +1,5 @@
-// Structural type of the backglass in-game reactor (defined app-side in
-// useIngameReactor). Duplicated here so the map's Zelda components don't
-// depend on the app; structurally identical → assignable.
+// Must stay structurally identical to the app-side reactor type
+// (useIngameReactor); duplicated here to avoid depending on the app.
 export type Reaction =
   | { kind: 'gameStart'; player: string }
   | { kind: 'hit'; intensity: number }

--- a/packages/maps/zelda/backglass/takeover.tsx
+++ b/packages/maps/zelda/backglass/takeover.tsx
@@ -11,7 +11,6 @@ export interface MapTakeoverContext {
   Vhs: VhsComponent
 }
 
-// Zelda-specific takeover visual for a clip (or an event key).
 // Returns null → the core handles hall_of_fame + the generic fallback.
 export function renderMapTakeover(clip: string, ctx: MapTakeoverContext): ReactNode | null {
   const { payload, Vhs } = ctx

--- a/packages/maps/zelda/backglass/theme.ts
+++ b/packages/maps/zelda/backglass/theme.ts
@@ -1,10 +1,5 @@
-// Zelda map backglass theme tokens (CSS custom properties). The app sets
-// them as inline style on the root container. The app's structural CSS +
-// the map's Zelda modules consume these var(). A map without a theme → the
-// app keeps its neutral defaults.
 export type ThemeTokens = Record<`--${string}`, string>
 
-// Normal palette (Hyrule — black marble, emerald and gold).
 export const backglassTheme: ThemeTokens = {
   '--foreground': '#dff5c8',
   '--glow': '#22cc44',
@@ -17,8 +12,7 @@ export const backglassTheme: ThemeTokens = {
   '--fever-b': '#22cc44',
 }
 
-// Sacred Realm overrides — merged over the base when alternateWorld is
-// active.
+// Partial overrides merged over backglassTheme when alternateWorld is active.
 export const backglassThemeAlternate: ThemeTokens = {
   '--glow': '#FFD700',
   '--vignette': '#150f00',

--- a/packages/maps/zelda/bosses.ts
+++ b/packages/maps/zelda/bosses.ts
@@ -7,9 +7,6 @@ import {
   DARK_LINK_VICTORY_CAMERA_CINEMATIC,
 } from './cameraCinematics'
 
-// Zelda boss definitions.
-// Ganondorf: normal world, central target.
-// Dark Link: alternate world (Sacred Realm), higher target.
 export const bossDefinitions: BossDefinition[] = [
   {
     id: 'ganondorf',
@@ -41,8 +38,6 @@ export const bossDefinitions: BossDefinition[] = [
     unlocksReturnPortal: false,
     cameraCinematic: GANONDORF_CAMERA_CINEMATIC,
     victoryCameraCinematic: GANONDORF_VICTORY_CAMERA_CINEMATIC,
-    // No revealSoundUrl: Ganondorf's intro sound plays one-shot via
-    // manifest.sounds.ganondorf_appear → ambient resumes right after.
     targetMeshTheme: {
       ring: {
         color: 0xff6600,
@@ -104,18 +99,13 @@ export const bossDefinitions: BossDefinition[] = [
     unlocksReturnPortal: true,
     cameraCinematic: DARK_LINK_CAMERA_CINEMATIC,
     victoryCameraCinematic: DARK_LINK_VICTORY_CAMERA_CINEMATIC,
-    // ── Dark Link audio ──────────────────────────────────────────────────────
-    // Fight music started at reveal.
     revealSoundUrl: mapAsset('audio/second-boss.mp3'),
     revealSoundVolume: 100,
-    // Final phase (≥7 hits): more dynamic music.
     latePhaseSoundUrl: mapAsset('audio/last-pv-second-boss.mp3'),
     latePhaseSoundVolume: 100,
     latePhaseHitThreshold: 7,
-    // Victory: switch to the win music as soon as Dark Link is defeated.
     victoryMusicUrl: mapAsset('audio/win.mp3'),
     victoryMusicVolume: 100,
-    // Win music keeps playing during the Hyrule return cinematic.
     keepMusicUntilReturnPortal: true,
     targetMeshTheme: {
       ring: {

--- a/packages/maps/zelda/cameraCinematics.ts
+++ b/packages/maps/zelda/cameraCinematics.ts
@@ -1,9 +1,6 @@
 import { DEFAULT_BOSS_FACE_DIR, type BossCameraCinematicConfig } from '@pinball/game-engine'
 
-// Camera direction → boss face (same as ST for consistency).
 const BOSS_FACE_DIR = DEFAULT_BOSS_FACE_DIR
-
-// ── Ganondorf (normal world) ──────────────────────────────────────────────
 
 export const GANONDORF_CAMERA_CINEMATIC: BossCameraCinematicConfig = {
   lookAtLift: 0.06,
@@ -21,8 +18,6 @@ export const GANONDORF_VICTORY_CAMERA_CINEMATIC: BossCameraCinematicConfig = {
   zoomOutDuration: 0.4,
   distanceScale: 0.68,
 }
-
-// ── Dark Link (Sacred Realm) ──────────────────────────────────────────────
 
 export const DARK_LINK_CAMERA_CINEMATIC: BossCameraCinematicConfig = {
   lookAtLift: 0.07,

--- a/packages/maps/zelda/dmd/attract.ts
+++ b/packages/maps/zelda/dmd/attract.ts
@@ -3,8 +3,6 @@ import { GRID_W, GRID_H } from '@pinball/dmd-core'
 import { DOT } from '@pinball/dmd-core'
 import { applyGlitch } from '@pinball/dmd-core'
 
-// Zelda attract mode: pure state machine driven by clockMs.
-
 const MARQUEE_TEXT = 'DEFY GANONDORF * ENTER THE SACRED REALM'
 const MARQUEE_SPEED = 22 // dots/s
 const MARQUEE_SCALE = 3
@@ -85,7 +83,6 @@ export function attractFrame(grid: Uint8Array, display: { player: string }, cloc
   }
 }
 
-// Phase 'title' — typewriter 'PINBALL' / 'HETIC'.
 function phaseTitle(grid: Uint8Array, tLocal: number): void {
   const w1 = 'PINBALL'
   const w2 = 'HETIC'
@@ -116,13 +113,11 @@ function cursor2x2(grid: Uint8Array, x: number, y: number): void {
   for (let i = 0; i < 2; i++) for (let j = 0; j < 2; j++) plot(grid, x + i, y + j, DOT.marquee)
 }
 
-// Phase 'marquee' — text enters right, exits left.
 function phaseMarquee(grid: Uint8Array, tLocal: number): void {
   const x = GRID_W - (tLocal / 1000) * MARQUEE_SPEED
   drawText(grid, GRID_W, Math.round(x), 5, MARQUEE_TEXT, FONT_5X7, DOT.marquee, 1, MARQUEE_SCALE)
 }
 
-// Phase 'coin' — falling coin + 'INSERT COIN' blink.
 function phaseCoin(grid: Uint8Array, tLocal: number): void {
   for (let dx = 0; dx < 14; dx++) {
     plot(grid, 2 + dx, 15, DOT.event)
@@ -142,17 +137,14 @@ function phaseCoin(grid: Uint8Array, tLocal: number): void {
   }
 }
 
-// Dot-art rupee (elongated diamond) replacing the ST coin.
 function drawRupee(grid: Uint8Array, cx: number, cy: number, squashed: boolean): void {
   if (squashed) {
-    // Diamond squashed on impact
     for (let dx = -4; dx <= 4; dx++) {
       const h = Math.round(2 - Math.abs(dx) * 0.5)
       for (let dy = -h; dy <= h; dy++) plot(grid, cx + dx + 4, cy + dy + 3, DOT.event)
     }
     return
   }
-  // Normal vertical diamond (7 dots tall)
   for (let dy = 0; dy < 9; dy++) {
     const w = dy <= 4 ? dy : 8 - dy
     for (let dx = -w; dx <= w; dx++) {
@@ -161,7 +153,6 @@ function drawRupee(grid: Uint8Array, cx: number, cy: number, squashed: boolean):
   }
 }
 
-// Phase 'rules' — Zelda tutorial.
 function phaseRules(grid: Uint8Array, tLocal: number): void {
   if (tLocal < 2500) {
     drawCentered(grid, 'COMPLETE', 4, DOT.score, 2)
@@ -193,7 +184,6 @@ function phaseRules(grid: Uint8Array, tLocal: number): void {
   drawCentered(grid, 'ENTRE LES BUMPERS', 18, DOT.heticOn, fitScale('ENTRE LES BUMPERS', 2))
 }
 
-// Phase 'ready' — player name + 'START !' blink.
 function phaseReady(grid: Uint8Array, tLocal: number, player: string): void {
   const name = player && player !== '—' ? player : 'PLAYER'
   const ns = fitScale(name, 2)

--- a/packages/maps/zelda/dmd/handlers.ts
+++ b/packages/maps/zelda/dmd/handlers.ts
@@ -9,10 +9,8 @@ import {
   type ClipHandler,
 } from '@pinball/dmd-core'
 
-// Zelda cinematic handlers.
 // TODO: add Ganondorf hero frames (DEMOGORGON_HERO equivalent) once
 // dot-art assets are available.
-
 const HETIC_LETTERS = 'HETIC'.split('')
 
 function clipHeticLetter(grid: Uint8Array, n: number, ms: number): void {
@@ -70,7 +68,7 @@ function clipHeticComplete(grid: Uint8Array, ms: number): void {
   }
 }
 
-// Ganondorf hero placeholder: ASCII text until real dot-art exists.
+// TODO: placeholder text until real Ganondorf dot-art exists.
 function clipGanondorfRises(grid: Uint8Array, ms: number): void {
   const p = Math.min(1, ms / 2000)
   const y = Math.round(15 - p * 10)

--- a/packages/maps/zelda/dmd/index.ts
+++ b/packages/maps/zelda/dmd/index.ts
@@ -4,13 +4,9 @@ import { scoreOverlay, feverBanner } from './overlays'
 import { attractFrame } from './attract'
 import { PALETTE_ZELDA, PALETTE_SACRED_REALM } from './palette'
 
-// Zelda DMD content injected into the @pinball/dmd-core engine.
 export const dmdContent: DmdMapContent = {
-  // Normal palette: emerald green / gold / sapphire blue (Zelda identity).
   paletteNormal: PALETTE_ZELDA,
-  // Alternate world palette (Sacred Realm): bright green + vivid gold.
   paletteAlternateWorld: PALETTE_SACRED_REALM,
-  // Color of the top/bottom NeonBand strips of the DMD screen.
   neonColor: '#FFD700',
   cinematicHandlers,
   scoreOverlay,

--- a/packages/maps/zelda/dmd/overlays.ts
+++ b/packages/maps/zelda/dmd/overlays.ts
@@ -12,7 +12,6 @@ import {
 } from '@pinball/dmd-core'
 import { mapStateNumber } from '@pinball/shared-types'
 
-// HETIC overlay (right row) — identical to ST, theme-independent.
 export const scoreOverlay: ScoreOverlay = (grid, display) => {
   const hetic = mapStateNumber(display.mapState, 'hetic')
   const letters = 'HETIC'
@@ -24,7 +23,6 @@ export const scoreOverlay: ScoreOverlay = (grid, display) => {
   }
 }
 
-// Zelda FEVER banner: golden chase + big score + "FEVER X5".
 export const feverBanner: FeverBanner = (grid, score, clockMs) => {
   drawChenillard(grid, clockMs, 0)
   drawChenillard(grid, -clockMs, GRID_H - 1)

--- a/packages/maps/zelda/dmd/palette.ts
+++ b/packages/maps/zelda/dmd/palette.ts
@@ -1,27 +1,23 @@
 import type { DotColor } from '@pinball/dmd-core'
 
-// Zelda normal palette (Hyrule world) — emerald green + gold + blue.
-// Replaces the default ST orange/red palette.
 export const PALETTE_ZELDA: Record<DotColor, string> = {
-  score:    '#22cc44', // emerald green — score digits
-  lives:    '#FFD700', // gold — hearts / lives
-  heticOn:  '#FFD700', // gold — lit HETIC letter
-  heticOff: '#0a1a00', // very dark green — unlit HETIC letter
-  combo:    '#FFD700', // gold — combo flash
-  multi:    '#4a80ff', // sapphire blue — multiplier
-  event:    '#FFD700', // gold — event label
-  gameOver: '#ff453a', // ruby red — game over
-  marquee:  '#22cc44', // green — marquee / titles
-  rain:     '#1a7a30', // dark green — background rain
-  rainGo:   '#FFD700', // gold — exit burst
+  score:    '#22cc44',
+  lives:    '#FFD700',
+  heticOn:  '#FFD700',
+  heticOff: '#0a1a00',
+  combo:    '#FFD700',
+  multi:    '#4a80ff',
+  event:    '#FFD700',
+  gameOver: '#ff453a',
+  marquee:  '#22cc44',
+  rain:     '#1a7a30',
+  rainGo:   '#FFD700',
 }
 
-// Sacred Realm palette (luminous green / vivid gold) — applied when
-// display.alternateWorld is active.
 export const PALETTE_SACRED_REALM: Record<DotColor, string> = {
-  score:    '#B8F59A', // intense light green
-  lives:    '#FFD700', // gold
-  heticOn:  '#AAFF55', // bright yellow-green
+  score:    '#B8F59A',
+  lives:    '#FFD700',
+  heticOn:  '#AAFF55',
   heticOff: '#0F2200',
   combo:    '#44FF88',
   multi:    '#88FFAA',

--- a/packages/maps/zelda/index.ts
+++ b/packages/maps/zelda/index.ts
@@ -4,8 +4,6 @@ import { manifest } from './manifest'
 export { layout } from './layout'
 export { createModule } from './module'
 
-// Zelda map package. DMD content via '@pinball/map-zelda/dmd',
-// backglass content via '@pinball/map-zelda/backglass'.
 export const mapPackage: MapPackage = {
   manifest,
   hasModule: true,

--- a/packages/maps/zelda/layout.ts
+++ b/packages/maps/zelda/layout.ts
@@ -12,12 +12,8 @@ import {
   PLAYFIELD_SHADE_MAX_OPACITY,
 } from '@pinball/game-engine'
 
-// Zelda layout. Geometry identical to the ST physical board (same board).
-// Update bumpers/dropTargets/sensors/shooterLane after a Zelda GLB export
-// if mesh positions change.
 export const layout: MapLayout = {
   bumpers: [
-    // Exact positions extracted from the zelda.glb GLB node (via dump-glb-meshes)
     { x: -0.02561, y: 1.02870, z: -0.19060 }, // bumper_3 (bottom center)
     { x: -0.09967, y: 1.04850, z: -0.32417 }, // bumper_2 (top left)
     { x: 0.05183,  y: 1.04850, z: -0.32417 }, // bumper_1 (top right)
@@ -84,8 +80,6 @@ export const layout: MapLayout = {
       maxOpacity: PLAYFIELD_SHADE_MAX_OPACITY,
     },
   },
-  // Sacred Realm: golden/green atmosphere — refine with dedicated constants
-  // once the ZeldaAtmosphere module is implemented.
   atmosphere: {
     transition: {
       durationS: 2.0,

--- a/packages/maps/zelda/manifest.ts
+++ b/packages/maps/zelda/manifest.ts
@@ -1,8 +1,5 @@
 import { mapAssetUrl, type MapManifest } from '@pinball/shared-types'
 
-// Map id + asset resolution helper (public URL /maps/<id>/…).
-// ONLY source of the id literal in the package (assets synced from
-// packages/maps/zelda/assets/).
 export const MAP_ID = 'zelda'
 export const mapAsset = (rel: string) => mapAssetUrl(MAP_ID, rel)
 
@@ -11,7 +8,6 @@ export const manifest: MapManifest = {
   name: 'The Legend of Zelda',
   version: 1,
   attractTagline: 'Hyrule Kingdom',
-  // Cinematic families. Not listed → 'other'.
   clipFamilies: {
     ganondorf_rises: 'boss',
     ganondorf_slain: 'boss',
@@ -26,27 +22,16 @@ export const manifest: MapManifest = {
     milestone_30k: 'milestone',
     milestone_big: 'milestone',
   },
-  // Assets preloaded by the playfield page.
   preload: [mapAsset('playfield/ganondorf.glb'), mapAsset('playfield/darklink.glb')],
-  // Zelda ambient music — loops in attract + during play until the boss.
   ambientMusic: mapAsset('audio/ambient.mp3'),
-  // Zelda game over sound.
   gameOverSound: mapAsset('audio/game-over.mp3'),
-  // Alternate world (Sacred Realm) music — loops between the portal and
-  // Dark Link's appearance.
   alternateWorldMusicUrl: mapAsset('audio/sacred-realm.mp3'),
-  // Map event sounds.
   sounds: {
-    // One-shot fanfare on Ganondorf's appearance (then ambient resumes).
     ganondorf_appear: { url: mapAsset('audio/spawnGanondorf.mp3'), volume: 100 },
-    // SFX played when the ball passes the Sacred Realm portal.
     sacred_realm_appear: { url: mapAsset('audio/transition-portal.mp3'), volume: 280 },
   },
-  // Counter labels (backglass recap).
   counterLabels: { ganondorfs: 'GANONDORFS', darklinks: 'DARK LINKS', portals: 'PORTAILS', hetic: 'HETIC' },
-  // mapState keys editable by the debug tool.
   debugMapState: { numbers: ['hetic'], flags: ['fever'] },
-  // Clip timings.
   clips: {
     ganondorf_rises: { showMs: 10_000, freezeMs: 6_000 },
     ganondorf_slain: { showMs: 15_000, freezeMs: 8_000 },
@@ -63,10 +48,9 @@ export const manifest: MapManifest = {
     hetic_complete: { showMs: 40_000, freezeMs: 10_000, takeoverMs: 10_000 },
     skill_shot: { showMs: 5_000, freezeMs: 2_000 },
   },
-  // TODO: replace with the real Zelda GLB when available.
   ballRadius: 0.012,
+  // TODO: replace with the real Zelda GLB when available.
   glb: mapAsset('playfield/zelda.glb'),
-  // Points per role.
   scoring: {
     bumper: 100,
     bump: 30,
@@ -87,7 +71,6 @@ export const manifest: MapManifest = {
     milestoneRepeatEvery: 25_000,
     comboDecayMs: 2_000,
   },
-  // Per-mesh physics materials (same table as ST — adjust to the Zelda GLB).
   elements: {
     floor_main: { physics: 'analytic' },
     wall_main: { singleSided: 1, restitution: 0.35, friction: 0.12 },
@@ -99,7 +82,6 @@ export const manifest: MapManifest = {
     wall_middle_right: { restitution: 0.3, friction: 0.1 },
     wall_guide_lane: { restitution: 0.2, friction: 0.15, smooth: 0 },
   },
-  // Zelda terms tracked by the anti-leak grep guard.
   forbiddenInCore: [
     'ganondorf',
     'darklink',
@@ -110,32 +92,25 @@ export const manifest: MapManifest = {
     'ocarina',
     'sheikah',
   ],
-  // Game-over screen wording (claim QR code). Zelda-themed texts.
-  // qrLogo absent: no PNG available in the assets (add later).
+  // TODO: qrLogo absent — no PNG in the assets yet.
   outro: {
     title: 'LA LÉGENDE EST TERMINÉE',
     scanLabel: 'Scanne pour graver ton nom au Temple du Temps',
     replayLabel: 'START — Rejouer',
   },
-  // ─── Three.js rendering — Zelda-specific ──────────────────────────────────
-  // Hyrule aesthetic: deep black marble, vivid gold and gems.
-  // High envIntensityMetallic → metallic materials (triforce, bumper crowns,
-  // gems) strongly reflect the environment → Vectary-like look.
-  // Overhead dirLight (strong y) → lights horizontal surfaces (logo, crowns).
-  // Low ambient → very dark shadow zones = dramatic contrast.
   rendering: {
     useEnvironment: true,
     toneMappingExposure: 1.3,
     colorDarken: 0.9,
-    environmentBlur: 0.01,       // sharp reflections = crisp highlights on gold
-    envIntensityMetallic: 2.8,   // highly reflective gold/gems/chrome
+    environmentBlur: 0.01,
+    envIntensityMetallic: 2.8,
     envIntensitySemi: 1.8,
     envIntensityBase: 1.1,
     lights: {
-      ambient: { color: 0xffffff, intensity: 0.22 },   // dark zones stay dark
+      ambient: { color: 0xffffff, intensity: 0.22 },
       hemi:    { sky: 0xfff8e8, ground: 0x111108, intensity: 0.15 },
-      dir:     { color: 0xffffff, intensity: 2.8, x: 0, y: 1.0, z: 0.6 },  // overhead → Hyrule logo
-      fill:    { color: 0xfff0dd, intensity: 0.5,  x: 0, y: 0.3, z: 1.0 }, // camera fill
+      dir:     { color: 0xffffff, intensity: 2.8, x: 0, y: 1.0, z: 0.6 },
+      fill:    { color: 0xfff0dd, intensity: 0.5,  x: 0, y: 0.3, z: 1.0 },
     },
   },
 }

--- a/packages/maps/zelda/module/index.ts
+++ b/packages/maps/zelda/module/index.ts
@@ -19,24 +19,17 @@ import {
   BumperVisuals,
 } from '../systems'
 
-// Zelda behavior module. Handles counters, milestones, boss events and the
-// Ganondorf + Dark Link visual systems.
 export function createModule(): MapModule {
   let ctxRef: MapContext | null = null
 
-  // Zelda counters (feed mapState + GameStats.counters).
   let ganondorfs = 0
   let darklinks  = 0
   let portals    = 0
   let hetic      = 0
 
-  // Nest: armed-since timestamp (ms) + late hint already fired, per boss.
   const armedAt: Record<string, number> = {}
   const hintFired = new Set<string>()
 
-  // Timescale-restore timers after a boss defeat (~400 ms). Tracked per
-  // bossId to avoid leaks (cancelled on reset/dispose, never stacked).
-  // See createBossDefeatTimers (game-engine).
   const bossDefeatTimers = createBossDefeatTimers()
 
   let ganondorfReveal: GanondorfReveal | null = null
@@ -47,7 +40,6 @@ export function createModule(): MapModule {
   let transition:      ZeldaTransition | null = null
   let bumperVisuals:   BumperVisuals   | null = null
 
-  // ── onGameEvent handlers (closures over Zelda state/systems) ─────────────
   function onMilestone(ctx: MapContext, e: GameEvent): void {
     if (e.type !== 'MILESTONE') return
     ctx.playCinematic(selectMilestoneClip(e.threshold), { value: e.threshold })
@@ -56,30 +48,25 @@ export function createModule(): MapModule {
 
   function onPortalTransitionEnd(ctx: MapContext, e: GameEvent): void {
     if (e.type !== 'PORTAL_TRANSITION_END') return
-    // Sacred Realm entry confirmed (transition end). Same pattern as ST:
-    // reset() first, then enterAlternateWorld(). The RETURN sensor is only
-    // created once Dark Link is defeated.
+    // reset() must run before enterAlternateWorld(). The RETURN sensor is
+    // only created once Dark Link is defeated.
     portal?.reset()
     ctx.resetPortalTrigger()
     ctx.enterAlternateWorld()
   }
 
   function onGameOverDrain(ctx: MapContext, e: GameEvent): void {
-    // Game over: end all boss fights.
     if (isGameOverDrain(e, ctx.gameState())) bossReveals?.endAllFights()
   }
 
   function onBossArmed(ctx: MapContext, e: GameEvent): void {
     if (e.type !== 'BOSS_ARMED') return
-    // Nest wakes up: DMD banner + hint timestamp (shared) + shake.
     handleBossArmed(ctx, e, armedAt, performance.now())
     ctx.screenShake(0.3)
   }
 
   function onGanondorf(ctx: MapContext, e: GameEvent): void {
-    // Ganondorf boss cinematics.
     if (e.type === 'BOSS_REVEAL' && e.bossId === 'ganondorf') {
-      // One-shot fanfare (~5s) via manifest.sounds → ambient resumes after.
       ctx.playSound('ganondorf_appear')
       ctx.playCinematic('ganondorf_rises', { once: true })
     }
@@ -91,7 +78,6 @@ export function createModule(): MapModule {
         ctx.physics.setTimeScale(1 / 3)
         bossDefeatTimers.schedule('ganondorf', 400, () => {
           ctx.physics.setTimeScale(1)
-          // The blue Sacred Realm portal opens as soon as time resumes.
           portal?.open()
           ctx.playCinematic('ganondorf_slain', {
             onEnd: () =>
@@ -103,7 +89,6 @@ export function createModule(): MapModule {
   }
 
   function onDarkLink(ctx: MapContext, e: GameEvent): void {
-    // Dark Link boss cinematics.
     if (e.type === 'BOSS_REVEAL' && e.bossId === 'darklink') {
       ctx.playCinematic('darklink_rises', { once: true })
     }
@@ -133,18 +118,15 @@ export function createModule(): MapModule {
     if (e.type !== 'PORTAL_ENTER') return
     portals += 1
     ctx.setMapState({ portals })
-    // The portal disappears on entry — cannot be re-taken endlessly.
     portal?.hide()
     const ball = ctx.ball
     const mesh = ctx.ballMesh
     if (ball && mesh && transition && !transition.isActive()) {
-      // Sacred Realm sound (same pattern as ST "upside_down_appear").
       ctx.playSound('sacred_realm_appear')
-      // Teleport + freeze the ball before the flash.
       ball.holdAtAlternateWorldSpawn()
       ball.syncToMesh(mesh)
       transition.start({ ballMesh: mesh }, () => {
-        // Called from update() — outside Rapier's event drain, mutations are safe.
+        // Called from update(), outside Rapier's event drain — mutations are safe.
         ball.spawnFromAlternateWorld()
         ctx.resetPortalTrigger()
         ctx.resetStuck()
@@ -164,7 +146,7 @@ export function createModule(): MapModule {
       ball.holdAtNormalReturnSpawn()
       ball.syncToMesh(mesh)
       transition.start({ ballMesh: mesh }, () => {
-        // ST pattern: reset() BEFORE completeWorldCycle() (which resets portalTriggered).
+        // reset() must run BEFORE completeWorldCycle() (which resets portalTriggered).
         portal?.reset()
         bossReveals?.endAllFights()
         ball.spawnFromNormalReturn()
@@ -183,7 +165,6 @@ export function createModule(): MapModule {
     setup(ctx: MapContext): void {
       ctxRef = ctx
 
-      // ── Ganondorf ────────────────────────────────────────────────────────
       ganondorfReveal = new GanondorfReveal()
       ganondorfReveal.setup({
         root:   ctx.root,
@@ -194,7 +175,6 @@ export function createModule(): MapModule {
       })
       ganondorfReveal.setEmit(ctx.emitGameEvent)
 
-      // ── Dark Link ────────────────────────────────────────────────────────
       darkLinkReveal = new DarkLinkReveal()
       darkLinkReveal.setup({
         root:   ctx.root,
@@ -202,18 +182,15 @@ export function createModule(): MapModule {
         camera: ctx.camera,
         onFightEnd: () => {
           ctx.setBossFightActive('darklink', false)
-          // Defeating Dark Link opens the return portal.
           portal?.enableReturn()
         },
         onTargetReady: () => ctx.setBossTargetArmed('darklink', true),
       })
 
-      // ── Orchestrator ─────────────────────────────────────────────────────
       bossReveals = new BossRevealOrchestrator()
       bossReveals.register(ganondorfReveal)
       bossReveals.register(darkLinkReveal)
 
-      // ── Sacred Realm atmosphere ──────────────────────────────────────────
       sacredRealm = new SacredRealmAtmosphere()
       sacredRealm.setup({
         root: ctx.root,
@@ -227,7 +204,6 @@ export function createModule(): MapModule {
         },
       })
 
-      // ── Sacred Realm portal: blue visual + sensor (closed until Ganondorf) ─
       portal = new ZeldaPortal()
       portal.setup({
         root:        ctx.root,
@@ -237,11 +213,9 @@ export function createModule(): MapModule {
         onOpenChange: (open) => ctx.setPortalGateOpen(open),
       })
 
-      // ── Transition (purple flash → tremor → callback) ────────────────────
       transition = new ZeldaTransition()
       transition.setup({ root: ctx.root, camera: ctx.camera })
 
-      // ── VIS bumper punch animation ───────────────────────────────────────
       bumperVisuals = new BumperVisuals()
       bumperVisuals.setup(ctx.root)
     },
@@ -285,7 +259,6 @@ export function createModule(): MapModule {
       const ctx = ctxRef
       if (!ctx) return
 
-      // Nest late hint.
       const candidates = ctx.layout.bosses.map((boss) => boss.id)
       for (const id of dueLateHints(candidates, armedAt, hintFired, performance.now())) {
         hintFired.add(id)
@@ -302,13 +275,9 @@ export function createModule(): MapModule {
       return false
     },
 
-    applyBallMagnet(): void {
-      // No magnetism on the Zelda map.
-    },
+    applyBallMagnet(): void {},
 
-    setSporesEnabled(): void {
-      // No spores on the Zelda map (reserved for the ST Upside Down).
-    },
+    setSporesEnabled(): void {},
 
     releaseWorld(): void {
       sacredRealm?.reset()

--- a/packages/maps/zelda/systems/BumperVisuals.ts
+++ b/packages/maps/zelda/systems/BumperVisuals.ts
@@ -34,8 +34,6 @@ export class BumperVisuals {
       baseScale:   ctx.baseScale,
     }));
 
-    // Fail loudly: no matched mesh = bumper effects silently dead (GLB
-    // naming convention changed). Diagnostic parity with ST.
     if (this.parts.length === 0) {
       console.warn(
         '[BumperVisuals] aucun mesh bumper reconnu (VIS_BUMPER) — ' +
@@ -51,12 +49,10 @@ export class BumperVisuals {
 
   update(dt: number): void {
     tickPunchTimers(this.punchTimers, dt);
-    // Scale animation: 1 → 1+PEAK → 1 with easeOutBack.
     applyPunchScale(this.parts, this.punchTimers, PUNCH_DURATION, PUNCH_PEAK);
   }
 
   dispose(): void {
-    // Restore scales to their original value before clearing.
     for (const part of this.parts) {
       part.mesh.scale.copy(part.baseScale);
     }

--- a/packages/maps/zelda/systems/DarkLinkConstants.ts
+++ b/packages/maps/zelda/systems/DarkLinkConstants.ts
@@ -21,20 +21,16 @@ export const DARK_LINK_ANIM_IDLE_FRAMES = { start: 1,  end: 89 } as const
 export const DARK_LINK_ANIM_HIT_FRAMES  = { start: 40, end: 70 } as const
 export const DARK_LINK_ANIM_DEAD_FRAMES = { start: 20, end: 50 } as const
 
-// Walk: approximate duration of one cycle × number of cycles
 export const DARK_LINK_WALK_CLIP_DURATION = 1.0   // seconds
 export const DARK_LINK_WALK_CYCLES        = 2.2
 export const DARK_LINK_WALK_DURATION      = DARK_LINK_WALK_CLIP_DURATION * DARK_LINK_WALK_CYCLES
 export const DARK_LINK_WALK_SETTLE_FACING = 0.35
 export const DARK_LINK_WALK_FADE_OUT      = 0.2
 
-// Start point (off-screen, Sacred Realm)
 export const DARK_LINK_SPAWN = { x: 0, z: -0.32 } as const
 
-/**
- * Delay (s) before the RETURN portal activates after Dark Link's defeat: on
- * the fatal hit the ball is stuck to the boss — activating immediately would
- * suck it in instantly instead of leaving it in play (same fix as ST).
- */
+// Delay before the RETURN portal activates after Dark Link's defeat: on the
+// fatal hit the ball is stuck to the boss, so activating immediately would
+// suck it in instead of leaving it in play.
 export const RETURN_PORTAL_REVEAL_DELAY_S = 5
 

--- a/packages/maps/zelda/systems/DarkLinkReveal.ts
+++ b/packages/maps/zelda/systems/DarkLinkReveal.ts
@@ -9,7 +9,6 @@ import { DarkLinkTargetVisual } from './DarkLinkTargetVisual';
 import type { BossRevealController } from './BossRevealController';
 
 const VICTORY_DURATION = 0.65;
-// Dark Link red flash
 const FLASH_COLOR = 0xff2200;
 const FLASH_INTENSITY = 1.6;
 
@@ -21,14 +20,6 @@ export type DarkLinkSetup = {
   onTargetReady?: () => void;
 };
 
-/**
- * Dark Link reveal controller (Sacred Realm).
- * Same pattern as VecnaReveal:
- *  - walk phase   : Dark Link walks to his position (gameplay frozen)
- *  - settle phase : rotation to face the camera (gameplay frozen)
- *  - fight phase  : combat, idle animation + hit on each blow
- *  - victory phase: dead animation + return portal opened
- */
 export class DarkLinkReveal implements BossRevealController {
   readonly bossId = 'darklink' as const;
   private onFightEnd: (() => void) | null = null;
@@ -50,8 +41,6 @@ export class DarkLinkReveal implements BossRevealController {
     fightFlickerFlashMix: 0.10,
     targetHits: getBossDefinition('darklink').targetHits,
   });
-
-  // ── BossRevealController ─────────────────────────────────────────────────
 
   async preload(
     renderer: THREE.WebGLRenderer,
@@ -130,7 +119,6 @@ export class DarkLinkReveal implements BossRevealController {
       this.machine.getPhase() === 'victory',
     );
 
-    // walk/settle exit timing is Three-side; sample it for the pure machine.
     const walkPathComplete =
       this.machine.getPhase() === 'walk' && this.darkLinkVisual.isWalkPathComplete();
     const settleComplete =
@@ -178,8 +166,6 @@ export class DarkLinkReveal implements BossRevealController {
     this.targetLight  = null;
     this.targetPulse  = null;
   }
-
-  // ── Private ──────────────────────────────────────────────────────────────
 
   private startWalkPhase(): void {
     this.targetPulse?.reset();

--- a/packages/maps/zelda/systems/DarkLinkTargetVisual.ts
+++ b/packages/maps/zelda/systems/DarkLinkTargetVisual.ts
@@ -90,15 +90,6 @@ function resolveDarkLinkClips(
   return { walkAction, fightIdleAction, hitAction, finisherAction };
 }
 
-/**
- * Dark Link 3D visual (GLB + animations). Delegates the whole lifecycle to
- * the generic WalkBossTargetActor (game-engine):
- *  - walks from DARK_LINK_SPAWN to DARK_LINK_TARGET
- *  - looped idle in combat
- *  - hit animation on each blow
- *  - dead animation at victory
- * Only clip resolution (subclipped) and the constants are specific.
- */
 export class DarkLinkTargetVisual {
   private readonly actor = new WalkBossTargetActor({
     logTag: 'DarkLink',

--- a/packages/maps/zelda/systems/GanondorfReveal.ts
+++ b/packages/maps/zelda/systems/GanondorfReveal.ts
@@ -21,7 +21,6 @@ const FIGHT_FLICKER_HZ = 3;
 const FIGHT_FLASH_MIX = 0.45;
 const FLASH_INTENSITY = 1.5;
 
-// Ganondorf purple flash.
 const FLASH_COLOR = 0x9900ff;
 
 export type GanondorfSetup = {
@@ -52,9 +51,8 @@ export class GanondorfReveal implements BossRevealController {
   private ownedGeos: THREE.BufferGeometry[] = [];
   private ownedMats: THREE.Material[] = [];
 
-  // Ganondorf has no shade (flash-only) and no eleven assist; the flicker shade
-  // config is all-zero (renderer passes a literal 0 to applyFightFlicker, exactly
-  // as before) and the assist sub-machine is disabled (null).
+  // Flash-only: the flicker-shade config is all-zero and the assist
+  // sub-machine is disabled (null) — Ganondorf has no shade and no assist.
   private machine = new BlackoutFightPhaseMachine(
     {
       blackout: BLACKOUT,
@@ -160,7 +158,6 @@ export class GanondorfReveal implements BossRevealController {
     if (d.phase === 'idle') return;
 
     if (d.phase === 'blackout') {
-      // Purple flash without black veil.
       this.cinematicStrobe.applyFlashOnly(d.on, d.blackoutMix);
       return;
     }
@@ -175,7 +172,6 @@ export class GanondorfReveal implements BossRevealController {
     }
 
     if (d.phase === 'flicker') {
-      // No shade, only the purple flash at the flicker rhythm.
       this.cinematicStrobe.applyFightFlicker(0, d.flickerBlink ? FIGHT_FLASH_MIX : 0);
       return;
     }
@@ -194,7 +190,6 @@ export class GanondorfReveal implements BossRevealController {
         this.resetAtmosphere();
         return;
       }
-      // No shade during restore.
       this.cinematicStrobe.stop();
     }
   }

--- a/packages/maps/zelda/systems/PlayfieldCinematicStrobe.ts
+++ b/packages/maps/zelda/systems/PlayfieldCinematicStrobe.ts
@@ -1,5 +1,3 @@
-// Zelda version: no GarlandLights or BumperVisuals (not implemented).
-// Re-exports the unified game-engine class, mounted without a decor port.
 export {
   PlayfieldCinematicStrobe,
   type PlayfieldCinematicStrobeConfig,

--- a/packages/maps/zelda/systems/SacredRealmAtmosphere.ts
+++ b/packages/maps/zelda/systems/SacredRealmAtmosphere.ts
@@ -12,40 +12,30 @@ import {
 } from '@pinball/game-engine';
 import type { AtmosphereMaterialEntry, SceneLighting } from '@pinball/game-engine';
 
-// ── Sacred Realm constants ────────────────────────────────────────────────────
-// Inspired by UpsideDownAtmosphere (ST) — no spores, no GarlandLights/BumperVisuals.
-
-/** Transition duration (seconds, in + out). */
+// Transition duration in seconds (in + out).
 const BLEND_DURATION = 2.0;
 
-// Background & material tint
-const SACRED_BG              = 0x12002e;   // dark but visible violet
-const SACRED_MAT_TINT        = 0x200040;   // soft violet tint
-const SACRED_MAT_EMISSIVE    = 0x1a0033;   // emissive glow
+const SACRED_BG              = 0x12002e;
+const SACRED_MAT_TINT        = 0x200040;
+const SACRED_MAT_EMISSIVE    = 0x1a0033;
 
-// Sacred Realm light intensities — dark but readable
 const SACRED_AMBIENT_INTENSITY = 0.62;
 const SACRED_HEMI_INTENSITY    = 0.52;
 const SACRED_DIR_INTENSITY     = 0.82;
 const SACRED_FILL_INTENSITY    = 0.54;
 
-// Exposure target
 const SACRED_EXPOSURE = 1.18;
 
-// Shade overlay (light violet veil)
 const SACRED_SHADE_COLOR   = 0x08001a;
 const SACRED_SHADE_OPACITY = 0.18;
 
-// Fog — low density: FogExp2 @ 0.5 on a sub-1 m map = light haze
+// FogExp2 density: 0.5 is light haze on a sub-1 m map.
 const SACRED_FOG_COLOR   = 0x0c001a;
 const SACRED_FOG_DENSITY = 0.5;
 
-// Pulse (slow exposure sway when fully active)
 const SACRED_PULSE_SPEED   = 0.55;
 const SACRED_PULSE_EXP_MIN = 1.12;
 const SACRED_PULSE_EXP_MAX = 1.28;
-
-// ── Internal types ────────────────────────────────────────────────────────────
 
 type MaterialSnapshot = AtmosphereMaterialEntry;
 
@@ -54,16 +44,6 @@ export type SacredRealmSetupConfig = {
   lighting: SceneLighting;
 };
 
-// ── Main class ────────────────────────────────────────────────────────────────
-
-/**
- * Sacred Realm atmosphere (Zelda).
- *
- * - Triggered by `PORTAL_TRANSITION_END` → transition to dark violet atmosphere.
- * - Reset by `RETURN_PORTAL_TRANSITION_END` → back to normal lighting.
- *
- * Same pattern as `UpsideDownAtmosphere` (ST): setup/onGameEvent/update/reset/dispose.
- */
 export class SacredRealmAtmosphere {
   private materials: MaterialSnapshot[] = [];
   private lighting: SceneLighting | null = null;
@@ -71,7 +51,6 @@ export class SacredRealmAtmosphere {
 
   private blend = new AtmosphereBlend(BLEND_DURATION);
 
-  // Original values captured at setup
   private snapshot = new LightingSnapshot();
   private sacredFog: AtmosphereFog | null = null;
 
@@ -79,16 +58,13 @@ export class SacredRealmAtmosphere {
     this.dispose();
     this.lighting = config.lighting;
 
-    // Snapshot every MeshStandard material in the root tree.
     this.materials = collectAtmosphereMaterials(config.root);
 
-    // Dark violet veil.
     this.shade.mount(config.root, {
       color: SACRED_SHADE_COLOR,
       renderOrder: 551,
     });
 
-    // Save the original lighting state.
     this.snapshot.capture(config.lighting);
     this.sacredFog = new AtmosphereFog(SACRED_FOG_COLOR);
     this.sacredFog.save(config.lighting.scene);
@@ -97,18 +73,15 @@ export class SacredRealmAtmosphere {
   }
 
   onGameEvent(event: GameEvent): void {
-    // Sacred Realm entry.
     if (event.type === 'PORTAL_TRANSITION_END') {
       this.blend.visited = true;
       this.blend.targetMix = 1;
     }
-    // Return from the Sacred Realm.
     if (event.type === 'RETURN_PORTAL_TRANSITION_END') {
       this.blend.targetMix = 0;
     }
   }
 
-  /** Resets the atmosphere (back to normal) without dispose. */
   reset(): void {
     this.blend.targetMix = 0;
   }
@@ -132,15 +105,12 @@ export class SacredRealmAtmosphere {
     this.blend.reset();
   }
 
-  // ── Internals ───────────────────────────────────────────────────────────────
-
   private applyMix(t: number): void {
     if (!this.blend.shouldApply(t)) return;
 
     const ease = AtmosphereBlend.ease(t);
     const fullyActive = t >= 1 && this.blend.targetMix >= 1;
 
-    // ── Materials: dark violet tint + darkening ──────────────────────────────
     for (const entry of this.materials) {
       applyMaterialTint(entry, ease, {
         tint: SACRED_MAT_TINT,
@@ -153,10 +123,8 @@ export class SacredRealmAtmosphere {
       });
     }
 
-    // ── Violet veil ─────────────────────────────────────────────────────────
     this.shade.setOpacity(SACRED_SHADE_OPACITY * ease);
 
-    // ── Lighting ────────────────────────────────────────────────────────────
     if (!this.lighting) return;
     const { scene, renderer, ambient, hemi, dir, fill } = this.lighting;
 
@@ -164,7 +132,6 @@ export class SacredRealmAtmosphere {
       applyColorTint(scene.background, this.snapshot.bg, SACRED_BG, ease, 1);
     }
 
-    // Exposure: transition, then slow pulse when fully active.
     if (!fullyActive) {
       renderer.toneMappingExposure = THREE.MathUtils.lerp(this.snapshot.exposure, SACRED_EXPOSURE, ease);
     } else {
@@ -172,7 +139,6 @@ export class SacredRealmAtmosphere {
       renderer.toneMappingExposure = THREE.MathUtils.lerp(SACRED_PULSE_EXP_MIN, SACRED_PULSE_EXP_MAX, wave);
     }
 
-    // Ambient: violet-ish, heavily reduced.
     applyLightTint(
       ambient,
       { color: this.snapshot.ambientColor, intensity: this.snapshot.ambientIntensity },
@@ -180,7 +146,6 @@ export class SacredRealmAtmosphere {
       { color: 0xcc88ff, colorK: 0.5, intensity: SACRED_AMBIENT_INTENSITY },
     );
 
-    // Hemi: dark violet.
     applyLightTint(
       hemi,
       { color: this.snapshot.hemiSky, intensity: this.snapshot.hemiIntensity },
@@ -189,7 +154,6 @@ export class SacredRealmAtmosphere {
     );
     applyColorTint(hemi.groundColor, this.snapshot.hemiGround, 0x180022, ease, 0.70);
 
-    // Directional: pale lavender, weakened.
     applyLightTint(
       dir,
       { color: this.snapshot.dirColor, intensity: this.snapshot.dirIntensity },
@@ -197,7 +161,6 @@ export class SacredRealmAtmosphere {
       { color: 0xccaaff, colorK: 0.38, intensity: SACRED_DIR_INTENSITY },
     );
 
-    // Fill: warm violet, reduced.
     applyLightTint(
       fill,
       { color: this.snapshot.fillColor, intensity: this.snapshot.fillIntensity },

--- a/packages/maps/zelda/systems/ZeldaPortal.ts
+++ b/packages/maps/zelda/systems/ZeldaPortal.ts
@@ -4,7 +4,6 @@ import type { MapLayout } from '@pinball/game-engine';
 import { easeOut, RevealCountdown } from '@pinball/game-engine';
 import { RETURN_PORTAL_REVEAL_DELAY_S } from './DarkLinkConstants';
 
-// ── Dimensions ─────────────────────────────────────────────────────────────
 const PORTAL_SENSOR_RADIUS = 0.014;
 const PORTAL_OUTER_R       = 0.01867;
 const PORTAL_INNER_R       = 0.01333;
@@ -20,16 +19,7 @@ type SetupConfig = {
   onOpenChange: (open: boolean) => void;
 };
 
-/**
- * Sacred Realm portal (Zelda) — Three.js visual + Rapier sensor.
- *
- * Same pattern as UpsideDownPortal (ST):
- *  - The Rapier sensor is created ONLY when the portal opens (open / enableReturn).
- *  - The sensor is physically destroyed on hide() and reset().
- *  - The portal cannot be triggered while invisible.
- */
 export class ZeldaPortal {
-  // ── Rapier (created / destroyed dynamically) ─────────────────────────────
   private world:          RAPIER.World | null     = null;
   private sensorBody:     RAPIER.RigidBody | null = null;
   private sensorCollider: RAPIER.Collider | null  = null;
@@ -37,7 +27,6 @@ export class ZeldaPortal {
   private sensorPos = new THREE.Vector3();
   private onOpenChangeCb: ((open: boolean) => void) | null = null;
 
-  // ── Three.js ──────────────────────────────────────────────────────────────
   private portalGroup:   THREE.Group | null = null;
   private outerRing:     THREE.Mesh  | null = null;
   private innerRing:     THREE.Mesh  | null = null;
@@ -52,14 +41,11 @@ export class ZeldaPortal {
   private ownedGeos: THREE.BufferGeometry[] = [];
   private ownedMats: THREE.Material[]       = [];
 
-  // ── State ─────────────────────────────────────────────────────────────────
   private openState = false;
   private isOpening = false;
   private openT     = 0;
   private animT     = 0;
   private returnCountdown = new RevealCountdown();
-
-  // ── API ──────────────────────────────────────────────────────────────────
 
   setup(config: SetupConfig): void {
     this.dispose();
@@ -70,7 +56,6 @@ export class ZeldaPortal {
     const pos = config.layout.sensors.portal;
     this.sensorPos.set(pos.x, pos.y, pos.z);
 
-    // Three.js visual — hidden initially. Sensor NOT created yet.
     this.portalGroup = this.buildVisual();
     this.portalGroup.position.set(pos.x, pos.y + 0.020, pos.z);
     this.portalGroup.rotation.x = 96 * Math.PI / 180;  // flat on the playfield
@@ -80,7 +65,6 @@ export class ZeldaPortal {
     config.onOpenChange(false);
   }
 
-  /** Opens the portal after Ganondorf's defeat. */
   open(): void {
     if (this.openState) return;
     this.openState = true;
@@ -94,10 +78,6 @@ export class ZeldaPortal {
     this.onOpenChangeCb?.(true);
   }
 
-  /**
-   * Hides the visual and **destroys the Rapier sensor**.
-   * Called as soon as the ball enters the portal — cannot be re-taken.
-   */
   hide(): void {
     this.returnCountdown.cancel();
     if (this.portalGroup) this.portalGroup.visible = false;
@@ -105,16 +85,12 @@ export class ZeldaPortal {
     this.onOpenChangeCb?.(false);
   }
 
-  /**
-   * Schedules the sensor for the RETURN portal (Sacred Realm → normal world).
-   * Deferred: on the fatal hit the ball sticks to Dark Link — activating
-   * immediately would suck it in without play. The sensor is created by update(dt).
-   */
+  // Deferred: on the fatal hit the ball sticks to Dark Link, so activating
+  // the sensor immediately would suck it in without play. Created by update().
   enableReturn(): void {
     this.returnCountdown.start(RETURN_PORTAL_REVEAL_DELAY_S);
   }
 
-  /** Fully resets the portal (game reset). */
   reset(): void {
     this.returnCountdown.cancel();
     this.openState = false;
@@ -206,8 +182,6 @@ export class ZeldaPortal {
     this.animT     = 0;
   }
 
-  // ── Rapier sensor (created / destroyed dynamically) ──────────────────────
-
   private createSensor(): void {
     if (!this.world || !this.colliderMap || this.sensorCollider) return;
     this.sensorBody = this.world.createRigidBody(
@@ -237,8 +211,6 @@ export class ZeldaPortal {
     this.sensorCollider = null;
     this.sensorBody     = null;
   }
-
-  // ── Three.js visual ───────────────────────────────────────────────────────
 
   private buildVisual(): THREE.Group {
     const group = new THREE.Group();

--- a/packages/maps/zelda/systems/ZeldaTransition.ts
+++ b/packages/maps/zelda/systems/ZeldaTransition.ts
@@ -3,38 +3,20 @@ import { ShakeBasis, TransitionTimeline, tremorOffset } from '@pinball/game-engi
 import { PlayfieldCinematicStrobe } from './PlayfieldCinematicStrobe';
 import { layout } from '../layout';
 
-// ── Timings ────────────────────────────────────────────────────────────────
-/** Duration of the rising purple flash (Sacred Realm entry). */
 const BLACKOUT_DURATION = 0.45; // s
-/** Fade-out duration before the tremor phase. */
 const RESTORE_DURATION  = 0.55; // s
-/** Tremor duration (camera + playfield shakes). */
 const TREMOR_DURATION   = 0.55; // s
-/** Strobe frequency during the flash. */
 const STROBE_HZ = 6;
 
 type SetupConfig = {
-  /** Scene root (playfield root) — shaken during the tremor. */
   root: THREE.Object3D;
-  /** Camera — shaken during the tremor. */
   camera: THREE.Camera;
 };
 
 type StartConfig = {
-  /** Ball mesh — hidden during the transition. */
   ballMesh: THREE.Object3D;
 };
 
-/**
- * Sacred Realm transition (Zelda) — both entry AND return.
- *
- * Sequence: purple flash (blackout) → fade (restore) → tremor → callback.
- * The module calls `onComplete` to teleport the ball and emit
- * `PORTAL_TRANSITION_END` or `RETURN_PORTAL_TRANSITION_END`.
- *
- * The tremor (camera + playfield shakes) follows the screen restore, before
- * the ball becomes visible — same pattern as ST's UpsideDownTransition.
- */
 export class ZeldaTransition {
   private cinematicStrobe = new PlayfieldCinematicStrobe();
 
@@ -51,7 +33,6 @@ export class ZeldaTransition {
   private ballMesh: THREE.Object3D | null = null;
   private onComplete: (() => void) | null = null;
 
-  // Tremor references.
   private camera:        THREE.Camera | null       = null;
   private playfieldRoot: THREE.Object3D | null     = null;
   private shakeBasis     = new ShakeBasis();
@@ -77,11 +58,7 @@ export class ZeldaTransition {
     return this.active;
   }
 
-  /**
-   * Starts the transition.
-   * Called from `onGameEvent(PORTAL_ENTER | RETURN_PORTAL_ENTER)`.
-   * The ball must already be held before the call.
-   */
+  // The ball must already be held before this call.
   start(config: StartConfig, onComplete: () => void): void {
     this.active     = true;
     this.timeline.reset();

--- a/packages/shared-types/src/cabinet-buttons.ts
+++ b/packages/shared-types/src/cabinet-buttons.ts
@@ -3,10 +3,10 @@ import type { ButtonId } from './socket-events'
 export type GameAction = 'FLIP_LEFT' | 'FLIP_RIGHT' | 'PLUNGE' | 'START'
 
 export interface CabinetButton {
-  id: ButtonId // physical id, UPPER_SNAKE
-  gpio: number // ESP32 pin
+  id: ButtonId
+  gpio: number
   activeLow: boolean // true = internal pull-up, button wired to GND
-  action?: GameAction // game mapping; optionnal
+  action?: GameAction
 }
 
 export const CABINET_BUTTONS: readonly CabinetButton[] = [

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -1,6 +1,5 @@
-// Full re-export (types + values: clip*Ms helpers, mapAssetUrl, ...).
-// `export *` is required for Turbopack to see the value exports (a split into
-// `export type {…}` + `export {…}` made it treat the module as export-less).
+// `export *` is required for Turbopack to see the value exports (splitting into
+// `export type {…}` + `export {…}` makes it treat the module as export-less).
 export * from './socket-events'
 export * from './map-contract'
 export * from './cabinet-buttons'

--- a/packages/shared-types/src/map-contract.ts
+++ b/packages/shared-types/src/map-contract.ts
@@ -1,31 +1,15 @@
 import type { ClipId, ClipTimings } from './socket-events'
 
-// SERIALIZABLE data contract for a map. No Three/React/game-engine dependency:
-// shared-types stays neutral. Runtime interfaces (MapModule, MapContext,
-// DMD/backglass content) live in game-engine and the apps.
 export type CinematicFamily = 'boss' | 'collect' | 'milestone' | 'other'
 
-// Default map id (no map selector: NEXT_PUBLIC_MAP_ID undefined → this map).
-// ONLY place where the literal lives on the apps/server side; consumers import
-// it instead of hardcoding.
 export const DEFAULT_MAP_ID = 'strangerthings'
 
-// Public URL of a map asset. Assets live in the map package
-// (packages/maps/<id>/assets/) and are synced to apps/<app>/public/maps/<id>/
-// at build time (scripts/sync-map-assets.sh). The prefix is derived from the
-// map id — no literal path on the consumer side.
 export function mapAssetUrl(mapId: string, relPath: string): string {
   return `/maps/${mapId}/${relPath.replace(/^\/+/, '')}`
 }
 
-// ─── Per-map rendering ───────────────────────────────────────────────────────
-// All visual parameters that vary between maps. The engine (game-engine +
-// PinballPlayfield) reads these instead of global constants. No Three.js
-// dependency here: colors = hex numbers.
-
 export interface MapLightConfig {
-  /** Light color as hex (e.g. 0xffffff). */
-  color: number;
+  color: number; // hex
   intensity: number;
 }
 
@@ -43,40 +27,22 @@ export interface MapHemiLightConfig {
 }
 
 export interface MapRenderingConfig {
-  /** Enables the environment map (RoomEnvironment + PMREMGenerator).
-   *  Required for vivid metallic materials (gold, gems).
-   *  false = no scene.environment → materials without ambient reflections (original ST look). */
   useEnvironment: boolean;
-  /** renderer.toneMappingExposure — global brightness after tone mapping. */
   toneMappingExposure: number;
-  /** Darken factor applied to surface materials (table, walls, plastic).
-   *  1.0 = no change, 0.9 = slight darkening. */
   colorDarken: number;
-  /** RoomEnvironment blur.
-   *  0 = razor-sharp reflections, 0.04 = soft reflections (Three.js default). */
   environmentBlur: number;
-  /** envMapIntensity for highly metallic materials (metalness ≥ 0.5).
-   *  1.0 = standard, 2–3 = vivid reflections, e.g. Zelda gold/gems. */
+  /** envMapIntensity for highly metallic materials (metalness ≥ 0.5). */
   envIntensityMetallic: number;
   /** envMapIntensity for semi-metallic materials (metalness 0.2–0.5). */
   envIntensitySemi: number;
-  /** Base envMapIntensity for non-metallic materials (metalness < 0.2). */
+  /** envMapIntensity for non-metallic materials (metalness < 0.2). */
   envIntensityBase: number;
   lights: {
-    /** Omnidirectional ambient light — minimal dose for shadowed areas. */
     ambient: MapLightConfig;
-    /** Sky/ground HemisphereLight — warm/cool tint from the volume. */
     hemi: MapHemiLightConfig;
-    /** Main directional — source of contrast and cast shadows. */
     dir: MapDirLightConfig;
-    /** Optional second directional, opposite side of the main one → dual
-     *  lighting that lifts the `dir` shadow without the fill (reserved for
-     *  UpsideDownAtmosphere). Absent → single sun. */
     dir2?: MapDirLightConfig;
-    /** Optional backlight (table rear, toward the camera) → highlight edge on
-     *  metal rims. Absent → no rim. */
     rim?: MapDirLightConfig;
-    /** Light fill — lifts shadowed areas without flattening contrast. */
     fill: MapDirLightConfig;
   };
 }
@@ -85,45 +51,27 @@ export interface MapManifest {
   id: string
   name: string
   version: number
-  /** Attract-screen subtitle (map branding, e.g. fictional lab). */
   attractTagline?: string
-  /** Mapping clipId → generic cinematic family (boss/collect/milestone/other). */
   clipFamilies?: Record<string, CinematicFamily>
-  /** Theme CSS variables (e.g. flair colors) applied on the stage. */
   theme?: Record<string, string>
-  /** Wording + assets for the game-over outro screen (neutral FR defaults if absent). */
   outro?: {
     title?: string // default "FIN DE PARTIE"
     scanLabel?: string // default "Scanne pour t'inscrire au classement"
     replayLabel?: string // default "START — Rejouer"
-    qrLogo?: string // asset URL for the QR center logo (absent → no logo)
+    qrLogo?: string // absent → no logo
   }
-  /** Assets to preload (paths relative to public/) — consumed by the page. */
-  preload?: string[]
-  /** Cinematic overlay videos/images by clipId (otherwise CSS fallback). */
+  preload?: string[] // paths relative to public/
   overlayFiles?: Record<string, string>
-  /** Map event sounds by id (played via ctx.playSound(id)). */
   sounds?: Record<string, { url: string; volume?: number }>
-  /** Looping ambient music (attract + in-game). Fallback: /audio/early-sound.mp3 */
-  ambientMusic?: string
-  /** Game-over sound. Fallback: /audio/sound-lost.mp3 */
-  gameOverSound?: string
-  /**
-   * Looping music played in the alternate world (between PORTAL_TRANSITION_END
-   * and the alternate boss's BOSS_REVEAL). Stops as soon as the combat music
-   * takes over, or at WORLD_CYCLE_COMPLETE if no boss was revealed.
-   */
+  ambientMusic?: string // fallback: /audio/early-sound.mp3
+  gameOverSound?: string // fallback: /audio/sound-lost.mp3
   alternateWorldMusicUrl?: string
   alternateWorldMusicVolume?: number
-  /** Counter labels (GameStats.counters) by id, for the backglass recap. */
   counterLabels?: Record<string, string>
-  /** mapState keys drivable by the debug tool (dev). Lets debug edit a map's
-   *  mapState without hardcoded keys. */
   debugMapState?: { numbers?: string[]; flags?: string[] }
-  /** Ball radius (m). Absent = DEFAULT_BALL_RADIUS (ST: 0.01374). */
-  ballRadius?: number
+  ballRadius?: number // m; absent = DEFAULT_BALL_RADIUS
   glb: string // relative to the package's assets/ folder
-  scoring: Record<string, number> // points per role (bumper, slingshot, target…)
+  scoring: Record<string, number>
   rules: {
     lives: number
     multiplierThresholds: number[]
@@ -131,20 +79,16 @@ export interface MapManifest {
     milestoneRepeatEvery: number
     comboDecayMs: number
   }
-  elements?: Record<string, Record<string, number | string>> // per-element-id tuning
+  elements?: Record<string, Record<string, number | string>>
   meshAliases?: Record<string, string> // legacy GLB name → conventional name
-  clips?: Record<ClipId, ClipTimings> // clip timings for the map
-  forbiddenInCore?: string[] // terms for the anti-leak grep guard
-  /** Map-specific Three.js rendering configuration.
-   *  Absent → the engine uses its own defaults. */
+  clips?: Record<ClipId, ClipTimings>
+  forbiddenInCore?: string[]
   rendering?: MapRenderingConfig
 }
 
-// Map package resolved by the composition root (packages/maps/index.ts).
-// Runtime modules are loaded later; only capability flags are exposed here.
 export interface MapPackage {
   manifest: MapManifest
-  hasModule: boolean // custom playfield behavior
-  hasDmd: boolean // DMD content provided — otherwise NO SIGNAL
-  hasBackglass: boolean // same for backglass
+  hasModule: boolean
+  hasDmd: boolean
+  hasBackglass: boolean
 }

--- a/packages/shared-types/src/socket-client.ts
+++ b/packages/shared-types/src/socket-client.ts
@@ -1,46 +1,19 @@
-// ───────────────────────────────────────────────────────────────────────────
-// CLIENT-side Socket.io factory (playfield / dmd / backglass kiosks).
-// Single place for the "how a kiosk connects to the server" rule — it was
-// previously duplicated across ~8 hooks/pages.
-//
-// IMPORTANT — deliberately NOT re-exported from index.ts. The `server` imports
-// `@pinball/shared-types` (for TYPES) but does not depend on
-// `socket.io-client` (it uses `socket.io` server-side). Going through
-// `export *` would pull client code into the server bundle. Frontends
-// therefore import it by direct path:
+// Deliberately NOT re-exported from index.ts: `server` imports this package for
+// TYPES only and must not pull `socket.io-client` into its bundle via `export *`.
+// Frontends import it by direct path:
 //     import { createPinballSocket } from '@pinball/shared-types/src/socket-client'
-// ───────────────────────────────────────────────────────────────────────────
 
 import { io, type Socket } from 'socket.io-client';
 import type { ServerToClientEvents, ClientToServerEvents } from './socket-events';
 
-/**
- * Project-typed Socket.io: incoming (Server→Client) and outgoing
- * (Client→Server) events are constrained by the shared contracts.
- */
 export type PinballSocket = Socket<ServerToClientEvents, ClientToServerEvents>;
 
 /**
- * Creates and OPENS a Socket.io connection to the game server.
- *
- * Transport choice depends on the deployment environment:
- *
- * - `NEXT_PUBLIC_SOCKET_URL` SET (local dev: the server port is exposed,
- *   e.g. http://localhost:3334) → DIRECT WebSocket connection, faster.
- *
- * - `NEXT_PUBLIC_SOCKET_URL` UNSET (Fliphetic prod: the server has no host
- *   port, we go through a same-origin Next.js rewrite) → pure POLLING.
- *   Reason: Next.js rewrites cannot relay the HTTP "upgrade" that promotes a
- *   polling connection to WebSocket → a WebSocket would fail silently.
- *   Polling (~50-100 ms latency) is acceptable for buttons and score.
- *
- * NB: `process.env.NEXT_PUBLIC_SOCKET_URL` is replaced with its value at BUILD
- * time by Next.js ("public" variable inlined in the bundle). This only works
- * because `@pinball/shared-types` is listed in `transpilePackages` of all 3
- * apps — otherwise Next would not do the replacement in this file.
- *
- * @returns a socket already connecting. The caller owns its lifecycle
- *          (`socket.disconnect()` on component unmount).
+ * NEXT_PUBLIC_SOCKET_URL SET → direct WebSocket. UNSET (Fliphetic prod: server
+ * has no host port, same-origin Next.js rewrite) → pure polling: rewrites cannot
+ * relay the HTTP upgrade, so a WebSocket would fail silently.
+ * NB: the env var is inlined at build time only because `@pinball/shared-types`
+ * is in every app's `transpilePackages`.
  */
 export function createPinballSocket(): PinballSocket {
   const url = process.env.NEXT_PUBLIC_SOCKET_URL || undefined;

--- a/packages/shared-types/src/socket-events.ts
+++ b/packages/shared-types/src/socket-events.ts
@@ -6,17 +6,13 @@ export interface ServerToClientEvents {
   'input:button': (data: ButtonInput) => void
   'input:tilt': (data: TiltInput) => void
   'input:sensor': (data: SensorInput) => void
-  // Routed by the server only to the `input-bridge` room (`simulate-esp32`
-  // mode). Not broadcast to frontends.
+  // Routed only to the `input-bridge` room (simulate-esp32 mode), NOT broadcast.
   'dev:simulate-button': (data: ButtonInput) => void
   'dmd:display': (data: DmdDisplay) => void
-  // /debug page → injects a GameEvent into the playfield (full chain).
   'dev:trigger-game-event': (data: DevGameEventTrigger) => void
-  // Emitted only to the socket that sent game:over (not a broadcast).
+  // Sent only to the socket that emitted game:over, not a broadcast.
   'game:registered': (data: GameRegistered) => void
-  // Broadcast to all clients when the active map changes (map selector →
-  // DMD + backglass switch dynamically). Also sent as unicast to each new
-  // connection to communicate the current map.
+  // Broadcast on map change; also unicast to each new connection.
   'map:selected': (data: { mapId: string }) => void
 }
 
@@ -27,18 +23,14 @@ export interface ClientToServerEvents {
   'input:button': (data: ButtonInput) => void
   'input:tilt': (data: TiltInput) => void
   'input:sensor': (data: SensorInput) => void
-  // Emitted only by frontends in `simulate-esp32` mode (keyboard → network to
-  // validate the chain without hardware). The server turns it back into an
-  // `input:button` broadcast to ALL clients (sender included).
+  // Server turns this back into an `input:button` broadcast to ALL clients.
   'dev:simulate-button': (data: ButtonInput) => void
   'dmd:display': (data: DmdDisplay) => void
   'dev:trigger-game-event': (data: DevGameEventTrigger) => void
-  // Emitted by the playfield when the user confirms a map in the selector.
-  // The server updates its state and broadcasts `map:selected` to everyone.
+  // Server updates its state and broadcasts `map:selected` to everyone.
   'map:select': (data: { mapId: string }) => void
 }
 
-// Injectable subset of GameEvent (plain serialized) — emitted by /debug.
 export interface DevGameEventTrigger {
   type:
     | 'BUMPER_HIT'
@@ -52,18 +44,14 @@ export interface DevGameEventTrigger {
     | 'BOTTOM_OUT'
     | 'BALL_LAUNCHED'
     | 'ASSIST'
-    | 'DEBUG_ADD_SCORE' // injects raw score (to cross thresholds)
-  bossId?: string // for BOSS_REVEAL / BOSS_TARGET_HIT (map boss id)
+    | 'DEBUG_ADD_SCORE'
+  bossId?: string // for BOSS_REVEAL / BOSS_TARGET_HIT
   hitCount?: number // for BOSS_TARGET_HIT
   amount?: number // for DEBUG_ADD_SCORE
 }
 
-// Map-specific state bag (ST: hetic, fever — another map will have other keys,
-// e.g. wanted). The core knows no keys: it only transports them; theming and
-// display are provided by the map content.
 export type MapState = Record<string, number | boolean>
 
-// Safe reads: an absent key never breaks the display.
 export const mapStateNumber = (s: MapState, k: string): number => {
   const v = s[k]
   return typeof v === 'number' ? v : 0
@@ -79,15 +67,11 @@ export interface ScoreUpdate {
   mapState: MapState
 }
 
-// Cinematic clip identifier. Open type (string): a map defines its own clips
-// without editing shared-types.
 export type ClipId = string
 
-// Transitional alias (limits churn on existing imports). Remove once all
-// consumers have migrated to ClipId.
+// TODO: remove once all consumers have migrated to ClipId.
 export type CinematicClip = ClipId
 
-// Fields shared by the "snapshot" variants (SCORE/EVENT/COMBO/MULTI).
 interface SnapshotFields {
   player: string
   score: number
@@ -115,10 +99,8 @@ export interface GameStart {
 export interface GameStats {
   maxCombo: number
   maxMultiplier: number
-  // Map-specific counters (ST: demogorgons, portals, hetic). Another map will
-  // have other keys. Display labels come from the map content.
   counters: Record<string, number>
-  durationS: number // game duration in seconds
+  durationS: number
 }
 
 export interface GameOver {
@@ -126,17 +108,15 @@ export interface GameOver {
   finalScore: number
   mapId: string
   stats: GameStats
-  // Emitted from /debug → relay only, NO persistence (keeps the leaderboard clean).
+  // When set, the server relays but does NOT persist (keeps the leaderboard clean).
   debug?: boolean
 }
 
 export interface GameRegistered {
-  code: string // claim token
-  claimUrl: string // URL encoded in the QR (rendered client-side)
+  code: string
+  claimUrl: string
 }
 
-// Pseudo display limit (truncated by the screens). The actual input max is
-// defined by the global API.
 export const PSEUDO_MAX_DISPLAY = 12
 
 export interface LeaderboardEntry {
@@ -148,8 +128,6 @@ export interface LeaderboardEntry {
 
 export interface GlobalStats {
   totalGames: number
-  // Generic per-counter totals (key = counter key, label provided by the map,
-  // value = sum).
   totals: { key: string; label: string; value: number }[]
   bestCombo: { value: number; player: string } | null
   bestToday: { score: number; player: string } | null
@@ -181,26 +159,14 @@ export interface SensorInput {
   value: number
 }
 
-// Cinematic clip timings, provided by the map (manifest.clips):
-//   showMs   — SHOW duration: how long DMD/backglass play the clip
-//              (may exceed the freeze → celebration while gameplay has resumed).
-//   freezeMs — playfield physics FREEZE duration (0 = no gameplay pause).
-//   takeoverMs — full-screen takeover duration of the DMD stack (default showMs;
-//              overridden when the visual is shorter, e.g. hetic_complete:
-//              10s of cinematic then fever in SCORE mode).
 export interface ClipTimings {
   showMs: number
-  freezeMs: number
-  takeoverMs?: number
+  freezeMs: number // playfield physics freeze; 0 = no gameplay pause
+  takeoverMs?: number // DMD full-screen takeover; default showMs
 }
 
-// Default SHOW duration for a clip missing from manifest.clips (unknown clip
-// or map without explicit timing). The game never crashes: generic visual for
-// this duration.
 export const DEFAULT_CLIP_SHOW_MS = 4_000
 
-// Generic lookups on a map's clip table (manifest.clips). A missing clip falls
-// back to safe values (never undefined → never NaN).
 export function clipShowMs(clips: Record<string, ClipTimings> | undefined, id: ClipId): number {
   return clips?.[id]?.showMs ?? DEFAULT_CLIP_SHOW_MS
 }

--- a/packages/ui/src/NoSignal.tsx
+++ b/packages/ui/src/NoSignal.tsx
@@ -1,13 +1,9 @@
 import type { CSSProperties } from 'react'
 
 interface NoSignalProps {
-  /** Reason shown below the title (e.g. "MAP INTROUVABLE"). */
   reason?: string
 }
 
-// Full-screen NO SIGNAL screen: black, CRT scanlines, animated grain, drifting
-// phosphor text, flicker. Pure CSS, zero assets — fallback when a map is not
-// found or its content is missing. Shared by playfield + backglass.
 export default function NoSignal({ reason }: NoSignalProps) {
   return (
     <div style={WRAP} aria-label="no signal">


### PR DESCRIPTION
Keep only comments that prevent a real silent bug (reorder/ordering gotchas), irrecoverable facts (units, measured geometry, GLB conventions), actionable TODOs, and functional directives (eslint-disable, @ts-expect-error, @deprecated). Drop all why/rationale/responsibility/JSDoc that merely restated names or types. ~2900 comment lines removed (84%), 253 files. Enable eslint no-empty allowEmptyCatch so intentional empty catches need no filler comment.

Behaviour unchanged: lint, build, full test suite and validate-map all green.