### PR TITLE
test(e2e): fix stale playfield spec + add real cross-screen flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,7 @@ firmware/.pio/
 lcov.info
 **/.cov/
 **/.cov-audio/
+
+# Playwright
+test-results/
+playwright-report/

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,13 +1,12 @@
 import { defineConfig, devices } from '@playwright/test'
 
-// E2E Playwright — sommet de la pyramide de tests. Smoke only.
-// Ces specs tournent contre une stack live (`docker compose up`).
-// Sans la stack, ils sont attendus en échec/skip — c'est normal.
-//
-// baseURL : chaque écran (playfield/dmd/backglass) a son propre port hôte
-// dynamique en prod Fliphetic, et un port distinct en dev local. Surcharger
-// via PLAYWRIGHT_BASE_URL pour cibler l'écran voulu avant de lancer la suite.
-const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:3000'
+// Live-stack E2E. Start the app first:
+//   docker compose -f docker-compose.dev.yml up
+// then: bun run test:e2e
+// Each screen has its own dev host port; override if yours differ.
+export const PLAYFIELD_URL = process.env.PLAYFIELD_URL ?? 'http://localhost:3333'
+export const DMD_URL = process.env.DMD_URL ?? 'http://localhost:3335'
+export const BACKGLASS_URL = process.env.BACKGLASS_URL ?? 'http://localhost:3336'
 
 export default defineConfig({
   testDir: './tests/e2e',
@@ -15,13 +14,27 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   reporter: 'list',
-  use: {
-    baseURL,
-    trace: 'on-first-retry',
-  },
+  use: { trace: 'on-first-retry' },
   projects: [
     {
-      name: 'chromium',
+      name: 'playfield',
+      testMatch: /playfield\.spec\.ts$/,
+      use: { ...devices['Desktop Chrome'], baseURL: PLAYFIELD_URL },
+    },
+    {
+      name: 'dmd',
+      testMatch: /dmd\.spec\.ts$/,
+      use: { ...devices['Desktop Chrome'], baseURL: DMD_URL },
+    },
+    {
+      name: 'backglass',
+      testMatch: /backglass\.spec\.ts$/,
+      use: { ...devices['Desktop Chrome'], baseURL: BACKGLASS_URL },
+    },
+    {
+      // Cross-screen flow: opens several screens at once, uses absolute URLs.
+      name: 'flow',
+      testMatch: /flow\.spec\.ts$/,
       use: { ...devices['Desktop Chrome'] },
     },
   ],

--- a/tests/e2e/flow.spec.ts
+++ b/tests/e2e/flow.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from '@playwright/test'
+import { DMD_URL, PLAYFIELD_URL } from '../../playwright.config'
+
+// Real cross-screen flow: an event emitted from the playfield /debug page must
+// travel through the server (Socket.io) and update the DMD screen. This
+// exercises the whole chain playfield -> server -> dmd, deterministically
+// (no physics), which is the point of the socket architecture.
+test.describe('cross-screen socket propagation', () => {
+  test('SCORE emitted from playfield /debug shows on the DMD', async ({ browser }) => {
+    // ?flat = the DMD's DOM renderer (the default page draws a <canvas>, so the
+    // score would not be a queryable DOM node).
+    const dmdCtx = await browser.newContext({ baseURL: DMD_URL })
+    const dmd = await dmdCtx.newPage()
+    await dmd.goto('/?flat')
+    // Wait until the DMD's socket is up, else the broadcast arrives before it
+    // subscribed and is lost.
+    await expect(dmd.getByText('Disconnected')).toBeHidden({ timeout: 15000 })
+
+    const debugCtx = await browser.newContext({ baseURL: PLAYFIELD_URL })
+    const debug = await debugCtx.newPage()
+    await debug.goto('/debug')
+    await expect(debug.getByText('socket connecté')).toBeVisible({ timeout: 15000 })
+
+    // Emit a dmd:display SCORE frame from the debug console.
+    await debug.getByRole('button', { name: 'SCORE', exact: true }).click()
+
+    // The DMD switches to SCORE mode and renders the formatted number.
+    await expect(dmd.locator('.tabular-nums')).toBeVisible({ timeout: 10000 })
+
+    await debugCtx.close()
+    await dmdCtx.close()
+  })
+})

--- a/tests/e2e/playfield.spec.ts
+++ b/tests/e2e/playfield.spec.ts
@@ -1,12 +1,10 @@
 import { expect, test } from '@playwright/test'
 
-// Playfield smoke: the monorepo home screen loads and offers the link to the
-// 3D scene. Target with PLAYWRIGHT_BASE_URL=<host:port_playfield>.
+// Playfield smoke: the game entry is /pinball (there is no '/' home). It boots
+// into the map selector, which renders interactive nav buttons.
 test.describe('playfield kiosk', () => {
-  test('home page loads with title and playfield link', async ({ page }) => {
-    await page.goto('/')
-
-    await expect(page.getByRole('heading', { name: 'Pinball Monorepo' })).toBeVisible()
-    await expect(page.getByRole('link', { name: 'Ouvrir le playfield' })).toBeVisible()
+  test('/pinball boots into the map selector', async ({ page }) => {
+    await page.goto('/pinball')
+    await expect(page.locator('button').first()).toBeVisible()
   })
 })


### PR DESCRIPTION
playwright.config: one project per screen with the correct dev host ports (playfield 3333 / dmd 3335 / backglass 3336), overridable via *_URL env. playfield.spec: target /pinball (there is no '/' home) and assert the map selector, replacing the removed 'Pinball Monorepo' home assertions. flow.spec (new): real cross-screen e2e — a SCORE frame emitted from the playfield /debug page propagates through the server to the DMD (/?flat DOM renderer), waiting for both sockets to connect first. Exercises the full playfield -> server -> dmd chain deterministically.

Ignore Playwright test-results/.